### PR TITLE
support for use_tz in django 1.4. 

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.db import models
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
@@ -9,8 +7,8 @@ from django.contrib.auth.models import User
 class SocialAccount(models.Model):
     user = models.ForeignKey(User)
     # No social_id here because I want it to be unique
-    last_login = models.DateTimeField(default=datetime.now)
-    date_joined = models.DateTimeField(default=datetime.now)
+    last_login = models.DateTimeField(auto_now=True)
+    date_joined = models.DateTimeField(auto_now_add=True)
 
     def authenticate(self):
         return authenticate(account=self)


### PR DESCRIPTION
if you set use_tz=True in settings saving a datetime requires a timezone. datetime.now passes a naive datetime. if you use the auto_now=True and auto_now_add=True options you can avoid this issue. 
