### PR TITLE
Email settings view cleanup

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -93,7 +93,7 @@ def email(request, **kwargs):
                             "email": add_email_form.cleaned_data["email"]
                         }
                     )
-                return HttpResponseRedirect(reverse(email))
+                return HttpResponseRedirect(reverse('account_email'))
         else:
             add_email_form = form_class()
             if request.POST.get("email"):
@@ -110,7 +110,7 @@ def email(request, **kwargs):
                             }
                         )
                         EmailConfirmation.objects.send_confirmation(email_address)
-                        return HttpResponseRedirect(reverse(email))
+                        return HttpResponseRedirect(reverse('account_email'))
                     except EmailAddress.DoesNotExist:
                         pass
                 elif request.POST.has_key("action_remove"):
@@ -133,7 +133,7 @@ def email(request, **kwargs):
                                     "email": email,
                                 }
                             )
-                            return HttpResponseRedirect(reverse(email))
+                            return HttpResponseRedirect(reverse('account_email'))
                     except EmailAddress.DoesNotExist:
                         pass
                 elif request.POST.has_key("action_primary"):
@@ -146,7 +146,7 @@ def email(request, **kwargs):
                         email_address.set_as_primary()
                         messages.add_message(request, messages.SUCCESS,
                                              ugettext("Primary e-mail address set"))
-                        return HttpResponseRedirect(reverse(email))
+                        return HttpResponseRedirect(reverse('account_email'))
                     except EmailAddress.DoesNotExist:
                         pass
     else:


### PR DESCRIPTION
Sorry that my editor is set to delete extra whitespace. To view the diff without that: https://github.com/sssbox/django-allauth/compare/email_settings_update?w=1

Changes: 

1 Don't allow users to delete primary email.
2 On success, redirect back to account_email so a page refresh doesn't resubmit the form
3 Add the same error checking to the set primary email address action as is in the other two email specific actions.
