### PR TITLE
Invitation mode, for use in conjunction with django-invitation

### DIFF
--- a/allauth/socialaccount/providers/facebook/views.py
+++ b/allauth/socialaccount/providers/facebook/views.py
@@ -21,7 +21,7 @@ User = get_user_model()
 def fb_complete_login(app, token):
     resp = requests.get('https://graph.facebook.com/me',
                         params={ 'access_token': token.token })
-    extra_data = resp.json()
+    extra_data = resp.json
     email = valid_email_or_none(extra_data.get('email'))
     uid = extra_data['id']
     user = User(email=email)


### PR DESCRIPTION
Hello, 

I made some changes to add an INVITE_MODE setting to be used in conjunction with django-invitation, so that users are only activated if they have received an invitation code.  

The case where a user creates an account without an invitation code, and then subsequently receives an invite code and logs in again, does also rely on a change I just submitted to django-invitation.

Let me know what you think,
Liz 
