### PR TITLE
fix-trivial-example-errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ account.
 
 This approach separates the worlds of local and social
 authentication. However, there are common scenarios to be dealt with
-in boh worlds. For example, an e-mail address passed along by an
+in both worlds. For example, an e-mail address passed along by an
 OpenID provider is not guaranteed to be verified. So, before hooking
 an OpenID account up to a local account the e-mail address must be
 verified. So, e-mail verification needs to be present in both worlds.

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,4 @@
+django>=1.4
+django-allauth==0.8.0
 django-bootstrap-form==2.0.3
 django-uni-form==0.7.0


### PR DESCRIPTION
Fixed trivial docs typo & requirements.txt in example.
