### PR TITLE
README clarification re admin interface for ACCOUNT_AUTHENTICATION_METHOD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,7 +175,9 @@ Available settings:
 
 ACCOUNT_AUTHENTICATION_METHOD (="username" | "email" | "username_email")
   Specifies the login method to use -- whether the user logs in by
-  entering his username, e-mail address, or either one of both.
+  entering his username, e-mail address, or either one of both. Note that
+  if you set this to "email" and you enable the Django admin interface,
+  you will need to log in using an email address there too.
 
 ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL (=settings.LOGIN_URL)
   The URL to redirect to after a successful e-mail confirmation, in case no


### PR DESCRIPTION
I have `ACCOUNT_AUTHENTICATION_METHOD` set to `email` and just enabled the admin interface but was unable to log in because it asks for a username (and I was entering the username). If you have `ACCOUNT_AUTHENTICATION_METHOD` set to `email` you need to enter an email address.

I guess this is probably obvious to long-time Django users, but it wasn't to me :-(
