### PR TITLE
Set the domain and name of the current site in the example

### DIFF
--- a/example/urls.py
+++ b/example/urls.py
@@ -1,6 +1,16 @@
 from django.conf.urls.defaults import patterns, include, url
 from django.contrib import admin
 
+
+# Set the domain and name of the example site to be local so that the
+# links we generate in confirmation emails can be clicked.
+from django.contrib.sites.models import Site
+current_site = Site.objects.get_current()
+current_site.domain = '127.0.0.1:8000'
+current_site.name = 'localhost'
+current_site.save()
+
+
 admin.autodiscover()
 
 urlpatterns = patterns('',


### PR DESCRIPTION
Hack to set the domain and name of the current site (once, on start-up) in the example application so that confirmation emails contain a locally clickable link.

It's a hack to do this in urls.py, but it works. See http://stackoverflow.com/questions/6791911/execute-code-when-django-starts-once-only

Fixes #103
