### PR TITLE
Email verification required for primary address if the user has verified an email address.

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -225,11 +225,11 @@ def email(request, **kwargs):
                                         # Slightly different variation, don't
                                         # require verified unless moving from a
                                         # verified address. Ignore constraint
-                                        # if previous, primary email address is
+                                        # if previous primary email address is
                                         # not verified.
                                     ).exists():
                             messages.add_message(request, messages.ERROR,
-                                    ugettext("Your primary email address must "
+                                    ugettext("Your primary e-mail address must "
                                         "be verified"))
                         else:
                             email_address.set_as_primary()


### PR DESCRIPTION
Only allow switching the primary e-mail address to a non-verified e-mail address if no verified e-mail addresses exist for the user.

This may not belong in the main branch, but thought it may be of interest to those who would prefer to have primary email addresses verified if possible, but don't actually want to require that every single address entered be verified.

Effectively, once the user has at least one verified email address, they will never be allowed to switch to an unverified account. However, it is still possible that if they have 3 unverified email addresses and verify one of the non-primary ones without making it primary, they will be in the non-ideal state until they try to change the primary email address to either of the others, where it will only let them change it to the primary one (though still, they could theoretically refuse to change it after the change attempt fails, leaving it in the non-ideal state).
