### PR TITLE
Descriptive error message if you forget to add the socialaccount context processor

### DIFF
--- a/allauth/app_settings.py
+++ b/allauth/app_settings.py
@@ -4,10 +4,8 @@ from django.core.exceptions import ImproperlyConfigured
 SOCIALACCOUNT_ENABLED = 'allauth.socialaccount' in settings.INSTALLED_APPS
 
 if SOCIALACCOUNT_ENABLED:
-    print 'Social account enabled'
     if 'allauth.socialaccount.context_processors.socialaccount' \
             not in settings.TEMPLATE_CONTEXT_PROCESSORS:
-        print 'should raise'
         raise ImproperlyConfigured("socialaccount context processor "
                     "not found in settings.TEMPLATE_CONTEXT_PROCESSORS."
                     "See settings.py instructions here: "


### PR DESCRIPTION
This should reclose https://github.com/pennersr/django-allauth/issues/116 unless you think the error message is too wordy.
