### PR TITLE
Actual default base template

### DIFF
--- a/allauth/templates/base.html
+++ b/allauth/templates/base.html
@@ -1,0 +1,26 @@
+{% load url from future %}
+<!DOCTYPE html>
+<html>
+<head>
+<title>{% block head_title %}{% endblock %}</title>
+{% block extra_head %}
+{% endblock %}
+</head>
+<body>
+{% block body %}
+<ul>
+{% if user.is_authenticated %}
+<li><a href="{% url 'account_email' %}">Change E-mail</a></li>
+<li><a href="{% url 'account_logout' %}">Sign Out</a></li>
+{% else %}
+<li><a href="{% url 'account_login' %}">Sign In</a></li>
+<li><a href="{% url 'account_signup' %}">Sign Up</a></li>
+{% endif %}
+</ul>
+{% block content %}
+{% endblock %}
+{% endblock %}
+{% block extra_body %}
+{% endblock %}
+</body>
+</html>


### PR DESCRIPTION
Make it easier to get started by copying the example base.html to be the default base.html of the project.

This could close https://github.com/pennersr/django-allauth/issues/110
