### PR TITLE
Added the ability to have minimum length for username

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -61,6 +61,9 @@ SIGNUP_FORM_CLASS = getattr(settings, "ACCOUNT_SIGNUP_FORM_CLASS", None)
 # The user is required to enter a username when signing up
 USERNAME_REQUIRED = getattr(settings, "ACCOUNT_USERNAME_REQUIRED", True)
 
+# Minimum Username Length
+USERNAME_MIN_LENGTH = getattr(settings, "ACCOUNT_USERNAME_MIN_LENGTH", 1)
+
 # render_value parameter as passed to PasswordInput fields
 PASSWORD_INPUT_RENDER_VALUE = getattr(settings, 
                                       "ACCOUNT_PASSWORD_INPUT_RENDER_VALUE", 

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -29,6 +29,7 @@ from app_settings import AuthenticationMethod
 import app_settings
 
 USERNAME_REGEX = UserCreationForm().fields['username'].regex
+username_min_length = app_settings.USERNAME_MIN_LENGTH
 
 class PasswordField(forms.CharField):
 
@@ -172,6 +173,7 @@ class BaseSignupForm(_base_signup_form_class()):
     username = forms.CharField(
         label = _("Username"),
         max_length = 30,
+        min_length = username_min_length,
         widget = forms.TextInput()
     )
     email = forms.EmailField(widget=forms.TextInput())


### PR DESCRIPTION
I added the ability to have minimum length for usename through ACCOUNT_USERNAME_MIN_LENGTH settings. Not sure that this is the correct approach, but it does the job.

And it doesn't have test (yet).
