### PR TITLE
Added HTML5 'placeholder' tag to Password field

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -34,7 +34,8 @@ class PasswordField(forms.CharField):
     def __init__(self, *args, **kwargs):
         render_value = kwargs.pop('render_value', 
                                   app_settings.PASSWORD_INPUT_RENDER_VALUE)
-        kwargs['widget'] = forms.PasswordInput(render_value=render_value)
+        kwargs['widget'] = forms.PasswordInput(render_value=render_value, 
+                                               attrs={'placeholder': _('Password')})
         super(PasswordField, self).__init__(*args, **kwargs)
 
 class SetPasswordField(PasswordField):


### PR DESCRIPTION
Currently Password field is missing 'placeholder' tag, even though other input fields do contain it. This patch will dd a 'placeholder' tag to PasswordField with a value 'Password'
