### PR TITLE
BUGFIX: default created time bug

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -70,7 +70,7 @@ class EmailAddress(models.Model):
 class EmailConfirmation(models.Model):
     
     email_address = models.ForeignKey(EmailAddress)
-    created = models.DateTimeField(default=timezone.now())
+    created = models.DateTimeField(default=timezone.now)
     sent = models.DateTimeField(null=True)
     key = models.CharField(max_length=64, unique=True)
     


### PR DESCRIPTION
If default is set to "now()", the timestamp is fixed when the model is defined. The right way would be to use the callable "now", or use "auto_now_add=True".

Reference:
http://stackoverflow.com/questions/2771676/django-default-datetime-now-problem

Thanks.
