### PR TITLE
Raise exception if import of provider urls module fails because of external dependency

### DIFF
--- a/allauth/urls.py
+++ b/allauth/urls.py
@@ -14,7 +14,9 @@ if app_settings.SOCIALACCOUNT_ENABLED:
 for provider in providers.registry.get_list():
     try:
         prov_mod = importlib.import_module(provider.package + '.urls')
-    except ImportError:
+    except ImportError as e:
+        if not "urls" in e:
+            raise
         continue
     prov_urlpatterns = getattr(prov_mod, 'urlpatterns', None)
     if prov_urlpatterns:


### PR DESCRIPTION
In my case, httplib2 was missing, causing the import of the facebook provider urls module to fail. The error I got was a "no reverse match" error, which was rather hard to trace down.

There might be (probably are ;-) ) smarter ways to handle this situation, but this works for me.
