### PR TITLE
Fix typo in README in user_display section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -565,7 +565,7 @@ Or, if you need to use in a `{% blocktrans %}`::
 
     {% load account %}
 
-    {% user_display user as user_display}
+    {% user_display user as user_display %}
     {% blocktrans %}{{ user_display }} has logged in...{% endblocktrans %}
 
 Then, override the `ACCOUNT_USER_DISPLAY` setting with your project


### PR DESCRIPTION
Just a tiny typo correction in the README file.
