### PR TITLE
Update example/local_settings.example

### DIFF
--- a/example/local_settings.example
+++ b/example/local_settings.example
@@ -2,7 +2,9 @@
 #
 # DO NOT CHANGE THIS FILE. Instead, copy it to local_settings.py
 # and make your changes there.
-
+# 
+# If you add this file include it in main settings.py
+# copy "from local_settings import *" to settings.py
 
 # Specifies the login method to use -- whether the user logs in by entering
 # his username, e-mail address, or either one of both. Possible values
@@ -25,9 +27,9 @@
 
 # Determines the e-mail verification method during signup. When set to
 # "mandatory" the user is blocked from logging in until the email
-# address is verified. Choose "optional" or "none" to allow logins
+# address is verified. Choose "optional" or False to allow logins
 # with an unverified e-mail address. In case of "optional", the e-mail
-# verification mail is still sent, whereas in case of "none" no e-mail
+# verification mail is still sent, whereas in case of False no e-mail
 # verification mails are sent.
 # ACCOUNT_EMAIL_VERIFICATION = "optional"
 


### PR DESCRIPTION
Some information wrong/ not given:
1. These settings should be included in settings.py
2. Setting ACCOUNT_EMAIL_VERIFICATION = "none" will still send mail as its boolean equivalent is True. We need to set ACCOUNT_EMAIL_VERIFICATION = False to avoid sending mail (Can cause confusion while working on local system with no mail server)
