### PR TITLE
Fix account tests

### DIFF
--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -35,9 +35,10 @@ class AccountTests(TestCase):
         if 'allauth.socialaccount' in settings.INSTALLED_APPS:
             # Otherwise ImproperlyConfigured exceptions may occur
             from ..socialaccount.models import SocialApp
-            SocialApp.objects.create(name='testfb',
-                                     provider='facebook',
-                                     site=Site.objects.get_current())
+            sa = SocialApp.objects.create(name='testfb',
+                                     provider='facebook')
+            sa.sites = [Site.objects.get_current()]
+            sa.save()
 
 
     def test_signup_email_verified_externally(self):
@@ -104,10 +105,8 @@ class AccountTests(TestCase):
 
 
     def test_email_escaping(self):
-        """
-        Test is only valid if emailconfirmation is listed after
-        allauth in INSTALLED_APPS
-        """
+        #Force email prefix to none so site.name will be put into email subject
+        app_settings.EMAIL_SUBJECT_PREFIX = None
         site = Site.objects.get_current()
         site.name = '<enc&"test>'
         site.save()


### PR DESCRIPTION
Fixes account test cases.  Fixes improper model creation for M2M fields in setUp, ensures EMAIL_SUBJECT_PREFIX=None in test_email_escaping. (2012-12-16 18:01:27 -0500)
