### PR TITLE
Fix for the Twitter oauth/authorize vs oauth/authenticate problem.

### DIFF
--- a/allauth/socialaccount/providers/twitter/urls.py
+++ b/allauth/socialaccount/providers/twitter/urls.py
@@ -2,3 +2,7 @@ from allauth.socialaccount.providers.oauth.urls import default_urlpatterns
 from provider import TwitterProvider
 
 urlpatterns = default_urlpatterns(TwitterProvider)
+urlpatterns += patterns('',
+    url('^' + TwitterProvider.id + '/authorize/$', oauth_authorize,
+        name=TwitterProvider.id + '_authorize'),
+)

--- a/allauth/socialaccount/providers/twitter/views.py
+++ b/allauth/socialaccount/providers/twitter/views.py
@@ -43,6 +43,10 @@ class TwitterOAuthAdapter(OAuthAdapter):
         return SocialLogin(account)
 
 
+class TwitterFullAuthorizationAdapter(TwitterOAuthAdapter):
+    authorize_url = 'https://api.twitter.com/oauth/authorize'
+
+
+oauth_authorize = OAuthLoginView.adapter_view(TwitterFullAuthorizationAdapter)
 oauth_login = OAuthLoginView.adapter_view(TwitterOAuthAdapter)
 oauth_callback = OAuthCallbackView.adapter_view(TwitterOAuthAdapter)
-


### PR DESCRIPTION
In `allauth/socialaccount/providers/twitter/views.py`:
- Added a `TwitterFullAuthorizationAdapter` to use `oauth/authorize`;
- Added a corresponding `oauth_authorize` view.

In `allauth/socialaccount/providers/twitter/urls.py`:
- Added a new url pattern to use the new `oauth_authorize` view when needed.

My solution to [issue #42](https://github.com/pennersr/django-allauth/issues/42)
