### PR TITLE
Correct typo in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=1.4
 oauth2
 python-openid
-requests>==1.0.3
+requests>=1.0.3


### PR DESCRIPTION
issue #168: changed `requests>==1.0.3` to `requests>=1.0.3`
