### PR TITLE
Add CI settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build
 dist
 django_allauth.egg-info
 example/local_settings.py
+coverage.xml
+pep8.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+langurage: python
+python:
+ - "2.7"
+ - "2.6"
+branches:
+ only:
+  - add_ci_settings
+script: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,9 @@ METADATA = dict(
         'Framework :: Django',
     ],
     packages=find_packages(exclude=['example']),
-    package_data=package_data
+    package_data=package_data,
+    tests_require=['django-setuptest', 'argparse'],
+    test_suite='setuptest.setuptest.SetupTestSuite'
 )
 
 if __name__ == '__main__':

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': '',
+        'PORT': '',
+    }
+}
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    "django.contrib.auth.context_processors.auth",
+    "django.core.context_processors.debug",
+    "django.core.context_processors.i18n",
+    "django.core.context_processors.media",
+    "django.core.context_processors.static",
+    "django.core.context_processors.request",
+    "django.contrib.messages.context_processors.messages",
+
+    "allauth.account.context_processors.account",
+    "allauth.socialaccount.context_processors.socialaccount",
+)
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.sites',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'django.contrib.admin',
+
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.twitter',
+    'allauth.socialaccount.providers.openid',
+    'allauth.socialaccount.providers.facebook',
+)


### PR DESCRIPTION
If there are some mistakes in English, I'd like to apologize...

I added configuration for running unit tests by setup.py, and configuration for [travis-ci.org](http://travis-ci.org)(.travis.yml).
It runs that type `python setup.py test` at command line.

see this example results.
- https://travis-ci.org/hirokinko/django-allauth
