### PR TITLE
Allow account username to be overridden by an adapter.

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -4,7 +4,8 @@ from django.template import TemplateDoesNotExist
 from django.contrib.sites.models import Site
 from django.core.mail import EmailMultiAlternatives, EmailMessage
 
-from allauth.utils import import_attribute
+from allauth.utils import (import_attribute, get_user_model,
+                           generate_unique_username)
 
 import app_settings
 
@@ -97,6 +98,22 @@ class DefaultAccountAdapter(object):
         regular flow by raising an ImmediateHttpResponse
         """
         return True
+
+    def populate_new_user(self,
+                          username=None,
+                          first_name=None, 
+                          last_name=None,
+                          email=None):
+        """
+        Spawns a new User instance, populating several common fields.
+        """
+        user = get_user_model()()
+        user.username = username or generate_unique_username(first_name or
+                                                     last_name or email)
+        user.email = email
+        user.first_name = first_name
+        user.last_name = last_name
+        return user
 
 def get_adapter():
     return import_attribute(app_settings.ADAPTER)()

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -15,8 +15,7 @@ from models import EmailAddress
 
 # from models import PasswordReset
 from utils import perform_login, send_email_confirmation, setup_user_email
-from allauth.utils import (email_address_exists, generate_unique_username, 
-                           get_user_model)
+from allauth.utils import (email_address_exists, get_user_model)
 
 from app_settings import AuthenticationMethod, EmailVerificationMethod
         
@@ -210,21 +209,15 @@ class BaseSignupForm(_base_signup_form_class()):
         return value
     
     def create_user(self, commit=True):
-        user = User()
-        # data collected by providers, if any, is passed as `initial`
-        # signup form data. This may contain fields such as
-        # `first_name`, whereas these may not have field counterparts
-        # in the form itself. So let's pick these up here...
-        data = self.initial
-        user.last_name = data.get('last_name', '')
-        user.first_name = data.get('first_name', '')
-        user.email = self.cleaned_data["email"].strip().lower()
         if app_settings.USERNAME_REQUIRED:
-            user.username = self.cleaned_data["username"]
+            username = self.cleaned_data["username"]
         else:
-            user.username = generate_unique_username(user.first_name or
-                                                     user.last_name or
-                                                     user.email)
+            username = None
+        data = self.initial
+        user = get_adapter().populate_new_user(username,
+            data.get('first_name', ''),
+            data.get('last_name', ''),
+            self.cleaned_data["email"].strip().lower())
         user.set_unusable_password()
         if commit:
             user.save()


### PR DESCRIPTION
I mirrored the populate_user adapter method from social to make it a bit more flexible.
