### PR TITLE
Allows welcome emails

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -279,8 +279,9 @@ class SignupForm(BaseSignupForm):
     def save(self, request):
         new_user = self.create_user()
         super(SignupForm, self).save(new_user)
-        setup_user_email(request, new_user)
-        send_email_confirmation(request, new_user)
+        email_address = setup_user_email(request, new_user)
+        email_address.for_new_user = True
+        send_email_confirmation(request, new_user, email_address=email_address)
         self.after_signup(new_user)
         return new_user
     

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -110,7 +110,12 @@ class EmailConfirmation(models.Model):
             "current_site": current_site,
             "key": self.key,
         }
-        get_adapter().send_mail('account/email/email_confirmation',
+        if (hasattr(self.email_address, 'for_new_user')
+                and self.email_address.for_new_user):
+            email_template = 'account/email/email_confirmation_welcome'
+        else:
+            email_template = 'account/email/email_confirmation'
+        get_adapter().send_mail(email_template,
                                 self.email_address.email,
                                 ctx)
         self.sent = timezone.now()

--- a/allauth/templates/account/email/email_confirmation_welcome_message.txt
+++ b/allauth/templates/account/email/email_confirmation_welcome_message.txt
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_message.txt" %}

--- a/allauth/templates/account/email/email_confirmation_welcome_subject.txt
+++ b/allauth/templates/account/email/email_confirmation_welcome_subject.txt
@@ -1,0 +1,1 @@
+{% include "account/email/email_confirmation_subject.txt" %}


### PR DESCRIPTION
100% reverse compatible change.

Allows users to optionally specify welcome variations on the email confirmation email so that they can explain why they need you to click on the link (if someone manually requested the email or they hit a wall where it says they need to verify their email address, the messaging in the verification email doesn't need to explain why it's needed as much).

Also changed some confusing naming. Before, `email_confirmation_sent` was accurate for about 2 lines and then it was used to mean the opposite of what it says.

I think `send_email` also makes sense for those initial 2 lines but also makes sense all the way until the last if statement (plus I added the comment explaining why it can be used in that way).
