### PR TITLE
Fixes https://github.com/pennersr/django-allauth/issues/216

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -273,7 +273,8 @@ class SignupForm(BaseSignupForm):
         new_user = self.create_user()
         super(SignupForm, self).save(new_user)
         email_address = setup_user_email(request, new_user)
-        email_address.for_new_user = True
+        if email_address:
+            email_address.for_new_user = True
         send_email_confirmation(request, new_user, email_address=email_address)
         self.after_signup(new_user)
         return new_user


### PR DESCRIPTION
Sorry, didn't notice that setup_user_email could return None.
