### PR TITLE
Add username blacklist in BaseSignupForm.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,9 @@ ACCOUNT_USER_DISPLAY (=a callable returning `user.username`)
 ACCOUNT_USERNAME_MIN_LENGTH (=1)
   An integer specifying the minimum allowed length of a username.
 
+ACCOUNT_USERNAME_BLACKLIST (=[])
+  A list of usernames that can't be used by user.
+
 ACCOUNT_USERNAME_REQUIRED (=True)
   The user is required to enter a username when signing up. Note that
   the user will be asked to do so even if

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -148,6 +148,13 @@ class AppSettings(object):
         return self._setting("USERNAME_MIN_LENGTH", 1)
 
     @property
+    def USERNAME_BLACKLIST(self):
+        """
+        List of usernames that are not allowed
+        """
+        return self._setting("USERNAME_BLACKLIST", [])
+
+    @property
     def PASSWORD_INPUT_RENDER_VALUE(self):
         """
         render_value parameter as passed to PasswordInput fields

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -192,6 +192,11 @@ class BaseSignupForm(_base_signup_form_class()):
         if not USERNAME_REGEX.match(value):
             raise forms.ValidationError(_("Usernames can only contain "
                                           "letters, digits and @/./+/-/_."))
+
+        if value in app_settings.USERNAME_BLACKLIST:
+            raise forms.ValidationError(_("Username can not be used. "
+                                          "Please use other username."))
+
         try:
             User.objects.get(username__iexact=value)
         except User.DoesNotExist:

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -11,6 +11,7 @@ from django.contrib.sites.models import Site
 from django.test.client import RequestFactory
 from django.contrib.auth.models import AnonymousUser
 
+from allauth.account.forms import BaseSignupForm
 from allauth.account.models import EmailAddress, EmailConfirmation
 from allauth.utils import get_user_model
 
@@ -115,3 +116,28 @@ class AccountTests(TestCase):
         request = RequestFactory().get('/')
         EmailAddress.objects.add_email(request, u, u.email, confirm=True)
         self.assertTrue(mail.outbox[0].subject[1:].startswith(site.name))
+
+
+class BaseSignupFormTests(TestCase):
+
+    @override_settings(
+        ACCOUNT_USERNAME_REQUIRED=True,
+        ACCOUNT_USERNAME_BLACKLIST=['username'])
+    def test_username_in_blacklist(self):
+        data = {
+            'username': 'username',
+            'email': 'user@example.com',
+        }
+        form = BaseSignupForm(data)
+        self.assertFalse(form.is_valid())
+
+    @override_settings(
+        ACCOUNT_USERNAME_REQUIRED=True,
+        ACCOUNT_USERNAME_BLACKLIST=['username'])
+    def test_username_not_in_blacklist(self):
+        data = {
+            'username': 'theusername',
+            'email': 'user@example.com',
+        }
+        form = BaseSignupForm(data)
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
Hi,

I added feature to have list of usernames that can't be used by user. I updated the clean_username method in BaseSignupForm, and created tests for that case.

thanks.
