### PR TITLE
Fixed so that the migrations work with custom user models

### DIFF
--- a/allauth/socialaccount/migrations/0001_initial.py
+++ b/allauth/socialaccount/migrations/0001_initial.py
@@ -3,6 +3,14 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 
+try:
+    from django.contrib.auth import get_user_model
+except ImportError: # django < 1.5
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
+
+
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
@@ -10,7 +18,7 @@ class Migration(SchemaMigration):
         # Adding model 'SocialAccount'
         db.create_table('socialaccount_socialaccount', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'])),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=User)),
             ('last_login', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
             ('date_joined', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
         ))


### PR DESCRIPTION
I had the same problem as #205 but updating to the latest version of allauth did not solve it so I implemented the fix suggested in the issue and tested it and it worked.

Under MySQL it worked without any other changes but under PostgreSQL I also had to add the following to the initial migration for the app that contains my custom user model:

```
needed_by = (
    ('socialaccount', '0001_initial'),
)
```

I suppose it might be possible to detect the app that contains the (custom) user model and have a `depends_on` in the socialaccount initial migration so that people don't have to make any changes to their migrations, but that seems error-prone so probably not worth doing it.
