### PR TITLE
small fix in provider example url for local dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -486,7 +486,7 @@ Use a callback URL of the form::
 
 For local development, use the following::
 
-    http://127.0.0.1:8000/accounts/twitter/callback/
+    http://127.0.0.1:8000/accounts/twitter/login/callback/
 
 
 Facebook


### PR DESCRIPTION
The given example URL for local development in README / Providers  doesn't work

replaced
http://127.0.0.1:8000/accounts/twitter/callback/

with
http://127.0.0.1:8000/accounts/twitter/login/callback/
