### PR TITLE
Fixed a bug where the wrong user object was sent in the signal

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -414,8 +414,8 @@ def password_reset_from_key(request, uidb36, key, **kwargs):
                 messages.add_message(request, messages.SUCCESS,
                     ugettext(u"Password successfully changed.")
                 )
-                signals.password_reset.send(sender=request.user.__class__,
-                        request=request, user=request.user)
+                signals.password_reset.send(sender=user.__class__,
+                        request=request, user=user)
                 password_reset_key_form = None
         else:
             password_reset_key_form = form_class()


### PR DESCRIPTION
The user on the request object is an anonymous user most of the time which is not that useful to the listener of the signal (imagine you want to send the user an email confirming the change of the password). So it might be better to send the user we fetched from the url params.
