### PR TITLE
Add a setting to configure showing a Django message on logout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,11 @@ ACCOUNT_LOGOUT_REDIRECT_URL (="/")
   The URL (or URL name) to return to after the user logs out. This is 
   the counterpart to Django's `LOGIN_REDIRECT_URL`.
 
+ACCOUNT_MESSAGE_ON_LOGOUT (=True)
+  Use the Django messaging framework to display a message when a user logs out.
+  If you are caching the page that the user is redirected to after logging out
+  (ACCOUNT_LOGOUT_REDIRECT_URL) then you may want to set this to False.
+
 ACCOUNT_SIGNUP_FORM_CLASS (=None)
   A string pointing to a custom form class
   (e.g. 'myapp.forms.SignupForm') that is used during signup to ask

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -186,6 +186,14 @@ class AppSettings(object):
     def USER_MODEL_EMAIL_FIELD(self):
         return self._setting('USER_MODEL_EMAIL_FIELD', 'email')
 
+    @property
+    def MESSAGE_ON_LOGOUT(self):
+        """
+        Use the messaging framework to tell the user they have successfully signed out.  You might
+        want to set this to False if you're caching the page that a logged-out user gets redirected to.
+        """
+        return self._setting('MESSAGE_ON_LOGOUT', True)
+
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -446,8 +446,9 @@ class LogoutView(TemplateResponseMixin, View):
         return redirect(url)
     
     def logout(self):
-        messages.add_message(self.request, messages.SUCCESS,
-                             ugettext("You have signed out."))
+        if app_settings.MESSAGE_ON_LOGOUT:
+            messages.add_message(self.request, messages.SUCCESS,
+                                 ugettext("You have signed out."))
         auth_logout(self.request)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Simple change to add a setting so that showing the "You have signed out" message is optional.  (We found the Django messaging framework didn't play nicely when we started caching the page we redirect to on logout).  
