### PR TITLE
fix bug when SOCIALACCOUNT_EMAIL_VERIFICATION='none'

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -235,7 +235,7 @@ def setup_user_email(request, user, addresses):
         user.save()
     return primary
 
-def send_email_confirmation(request, user, email_address=None):
+def send_email_confirmation(request, user, email_address=None, email_verification=app_settings.EMAIL_VERIFICATION):
     """
     E-mail verification mails are sent:
     a) Explicitly: when a user signs up
@@ -251,7 +251,7 @@ def send_email_confirmation(request, user, email_address=None):
     COOLDOWN_PERIOD = timedelta(minutes=3)
     email = user_email(user)
     if (email 
-        and app_settings.EMAIL_VERIFICATION != EmailVerificationMethod.NONE):
+        and email_verification != EmailVerificationMethod.NONE):
         try:
             if email_address is None:
                 email_address = EmailAddress.objects.get(user=user,

--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -72,7 +72,7 @@ def _process_signup(request, sociallogin):
         user_email(u, email or '')
         u.set_unusable_password()
         sociallogin.save(request)
-        send_email_confirmation(request, u)
+        send_email_confirmation(request, u, email_verification=app_settings.EMAIL_VERIFICATION)
         ret = complete_social_signup(request, sociallogin)
     return ret
 


### PR DESCRIPTION
If SOCIALACCOUNT_EMAIL_VERIFICATION='none' and ACCOUNT_EMAIL_VERIFICATION='mandatory', when first time se socail account to login, system still send a verification email. It's a bug. I fixed it.
