### PR TITLE
signup email initial = account_verified_email

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -127,6 +127,8 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin, FormView)
                                self.get_success_url())
 
     def get_context_data(self, **kwargs):
+        form = kwargs['form']
+        form.fields["email"].initial = self.request.session.get('account_verified_email', None)
         ret = super(SignupView, self).get_context_data(**kwargs)
         login_url = passthrough_next_redirect_url(self.request,
                                                   reverse("account_login"),


### PR DESCRIPTION
Since we are going through the trouble of collecting the verified email
lets pre-populate the signup form.

Another thought would be to validate that the email provided matched
account_verified_email.  If it does not match, this would indicate that the user wants allauth
to disreguard the account_verified_email and just send a validation
email for the new provided email address and make that the primary.
