### PR TITLE
OAuth2 Systems like Google do not resend refresh_token on every login

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -200,7 +200,10 @@ class SocialLogin(object):
                     t = SocialToken.objects.get(account=self.account,
                                                 app=self.token.app)
                     t.token = self.token.token
-                    t.token_secret = self.token.token_secret
+                    if self.token.token_secret:
+                        # only update the refresh token if we got one
+                        # many oauth2 providers do not resend the refresh token
+                        t.token_secret = self.token.token_secret
                     t.expires_at = self.token.expires_at
                     t.save()
                     self.token = t


### PR DESCRIPTION
Google asks that you do not delete the refresh token you received the first time around ... and they have [workarounds if you happen to lose your refresh token](https://developers.google.com/accounts/docs/OAuth2WebServer):

> Important: When your application receives a refresh token, it is important to store that refresh token for future use. If your application loses the refresh token, it will have to re-prompt the user for consent before obtaining another refresh token. If you need to re-prompt the user for consent, include the `approval_prompt` parameter in the authorization code request, and set the value to force.

This patch also adds two tests to the oauth2 base tests, one testing that access tokens and refresh tokens are saved (was not being tested) and the second tests that if a refresh token is not passed the old one is not deleted.
