### PR TITLE
Always save the sociallogin on the request

### DIFF
--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -141,6 +141,11 @@ def _add_social_account(request, sociallogin):
 def complete_social_login(request, sociallogin):
     assert not sociallogin.is_existing
     sociallogin.lookup()
+
+    # Save the sociallogin on the request, so third-party implementations can
+    # always access it, whether via signals or adapters
+    request.sociallogin = sociallogin
+
     try:
         get_adapter().pre_social_login(request, sociallogin)
         signals.pre_social_login.send(sender=SocialLogin,


### PR DESCRIPTION
This pull request ensures the `sociallogin` instance is saved on the request, making it available to all third-party allauth implementations, either via signals or adapters. Addresses issue #323.

One particular use case for this, is when an interim login page should load for users who have logged in before (detected via a cookie) but who now appear to be logging in via a different social account. In our implementation, we'd like to give these users the option of adding the new social account to their existing login before proceeding, to avoid scenarios where single users have multiple connected accounts associated with different Django users.
