### PR TITLE
Use Transifex for translation.

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[django-allauth.django]
+file_filter = allauth/locale/<lang>/LC_MESSAGES/django.po
+source_file = allauth/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type = PO

--- a/allauth/locale/en/LC_MESSAGES/django.po
+++ b/allauth/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,603 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-07-20 17:53+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: account/adapter.py:168
+msgid "Usernames can only contain letters, digits and @/./+/-/_."
+msgstr ""
+
+#: account/adapter.py:173
+msgid "Username can not be used. Please use other username."
+msgstr ""
+
+#: account/forms.py:33 account/forms.py:51 account/forms.py:237
+#: account/forms.py:343
+msgid "Password"
+msgstr ""
+
+#: account/forms.py:43
+msgid "Password must be a minimum of {0} characters."
+msgstr ""
+
+#: account/forms.py:53
+msgid "Remember Me"
+msgstr ""
+
+#: account/forms.py:64 account/forms.py:178
+msgid "E-mail address"
+msgstr ""
+
+#: account/forms.py:65 account/forms.py:189 account/forms.py:292
+#: account/forms.py:360
+msgid "E-mail"
+msgstr ""
+
+#: account/forms.py:70 account/forms.py:71 account/forms.py:171
+#: account/forms.py:175
+msgid "Username"
+msgstr ""
+
+#: account/forms.py:78
+msgid "Username or e-mail"
+msgstr ""
+
+#: account/forms.py:79
+msgctxt "field label"
+msgid "Login"
+msgstr ""
+
+#: account/forms.py:111
+msgid "This account is currently inactive."
+msgstr ""
+
+#: account/forms.py:115
+msgid "The e-mail address and/or password you specified are not correct."
+msgstr ""
+
+#: account/forms.py:119
+msgid "The username and/or password you specified are not correct."
+msgstr ""
+
+#: account/forms.py:122
+msgid "The login and/or password you specified are not correct."
+msgstr ""
+
+#: account/forms.py:192
+msgid "E-mail (optional)"
+msgstr ""
+
+#: account/forms.py:207
+msgid "This username is already taken. Please choose another."
+msgstr ""
+
+#: account/forms.py:216
+msgid "A user is already registered with this e-mail address."
+msgstr ""
+
+#: account/forms.py:238 account/forms.py:344
+msgid "Password (again)"
+msgstr ""
+
+#: account/forms.py:256 account/forms.py:333 account/forms.py:349
+#: account/forms.py:418
+msgid "You must type the same password each time."
+msgstr ""
+
+#: account/forms.py:301
+msgid "This e-mail address is already associated with this account."
+msgstr ""
+
+#: account/forms.py:302
+msgid "This e-mail address is already associated with another account."
+msgstr ""
+
+#: account/forms.py:321
+msgid "Current Password"
+msgstr ""
+
+#: account/forms.py:322 account/forms.py:406
+msgid "New Password"
+msgstr ""
+
+#: account/forms.py:323 account/forms.py:407
+msgid "New Password (again)"
+msgstr ""
+
+#: account/forms.py:327
+msgid "Please type your current password."
+msgstr ""
+
+#: account/forms.py:371
+msgid "The e-mail address is not assigned to any user account"
+msgstr ""
+
+#: account/models.py:31
+msgid "email address"
+msgstr ""
+
+#: account/models.py:32
+msgid "email addresses"
+msgstr ""
+
+#: account/models.py:82
+msgid "email confirmation"
+msgstr ""
+
+#: account/models.py:83
+msgid "email confirmations"
+msgstr ""
+
+#: account/utils.py:290
+#, python-format
+msgid "Confirmation e-mail sent to %(email)s"
+msgstr ""
+
+#: socialaccount/adapter.py:73
+msgid "Your account has no password set up."
+msgstr ""
+
+#: socialaccount/adapter.py:78
+msgid "Your account has no verified e-mail address."
+msgstr ""
+
+#: socialaccount/providers/oauth/client.py:78
+#, python-format
+msgid "Invalid response while obtaining request token from \"%s\"."
+msgstr ""
+
+#: socialaccount/providers/oauth/client.py:102
+#, python-format
+msgid "Invalid response while obtaining access token from \"%s\"."
+msgstr ""
+
+#: socialaccount/providers/oauth/client.py:115
+#, python-format
+msgid "No request token saved for \"%s\"."
+msgstr ""
+
+#: socialaccount/providers/oauth/client.py:159
+#, python-format
+msgid "No access token saved for \"%s\"."
+msgstr ""
+
+#: socialaccount/providers/oauth/client.py:177
+#, python-format
+msgid "No access to private resources at \"%s\"."
+msgstr ""
+
+#: templates/account/email.html:6
+msgid "Account"
+msgstr ""
+
+#: templates/account/email.html:9
+msgid "E-mail Addresses"
+msgstr ""
+
+#: templates/account/email.html:11
+msgid "The following e-mail addresses are associated with your account:"
+msgstr ""
+
+#: templates/account/email.html:25
+msgid "Verified"
+msgstr ""
+
+#: templates/account/email.html:27
+msgid "Unverified"
+msgstr ""
+
+#: templates/account/email.html:29
+msgid "Primary"
+msgstr ""
+
+#: templates/account/email.html:35
+msgid "Make Primary"
+msgstr ""
+
+#: templates/account/email.html:36
+msgid "Re-send Verification"
+msgstr ""
+
+#: templates/account/email.html:37 templates/socialaccount/connections.html:35
+msgid "Remove"
+msgstr ""
+
+#: templates/account/email.html:44
+msgid "Warning:"
+msgstr ""
+
+#: templates/account/email.html:44
+msgid ""
+"You currently do not have any e-mail address set up. You should really add "
+"an e-mail address so you can receive notifications, reset your password, etc."
+msgstr ""
+
+#: templates/account/email.html:49
+msgid "Add E-mail Address"
+msgstr ""
+
+#: templates/account/email.html:54
+msgid "Add E-mail"
+msgstr ""
+
+#: templates/account/email.html:63
+msgid "Do you really want to remove the selected e-mail address?"
+msgstr ""
+
+#: templates/account/email_confirm.html:7
+#: templates/account/email_confirm.html:11
+#: templates/account/email_confirmed.html:6
+#: templates/account/email_confirmed.html:11
+#: templates/account/email/email_confirmation_subject.txt:3
+msgid "Confirm E-mail Address"
+msgstr ""
+
+#: templates/account/email_confirm.html:17
+#, python-format
+msgid ""
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-mail "
+"address for user %(user_display)s."
+msgstr ""
+
+#: templates/account/email_confirm.html:21
+msgid "Confirm"
+msgstr ""
+
+#: templates/account/email_confirm.html:28
+#, python-format
+msgid ""
+"This e-mail confirmation link expired or is invalid. Please <a href="
+"\"%(email_url)s\">issue a new e-mail confirmation request</a>."
+msgstr ""
+
+#: templates/account/email_confirmed.html:15
+#, python-format
+msgid ""
+"You have confirmed that <a href=\"mailto:%(email)s\">%(email)s</a> is an e-"
+"mail address for user %(user_display)s."
+msgstr ""
+
+#: templates/account/login.html:7 templates/account/login.html.py:11
+#: templates/account/login.html:39
+msgid "Sign In"
+msgstr ""
+
+#: templates/account/login.html:14
+#, python-format
+msgid ""
+"Please sign in with one\n"
+"of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign "
+"up</a> \n"
+"for a %(site_name)s account and sign in below:"
+msgstr ""
+
+#: templates/account/login.html:24
+msgid "or"
+msgstr ""
+
+#: templates/account/login.html:38
+msgid "Forgot Password?"
+msgstr ""
+
+#: templates/account/logout.html:6 templates/account/logout.html.py:9
+#: templates/account/logout.html:18
+msgid "Sign Out"
+msgstr ""
+
+#: templates/account/logout.html:11
+msgid "Are you sure you want to sign out?"
+msgstr ""
+
+#: templates/account/password_change.html:4
+#: templates/account/password_change.html:7
+#: templates/account/password_change.html:12
+#: templates/account/password_reset_from_key.html:5
+#: templates/account/password_reset_from_key.html:8
+msgid "Change Password"
+msgstr ""
+
+#: templates/account/password_delete.html:5
+#: templates/account/password_delete.html:8
+msgid "Delete Password"
+msgstr ""
+
+#: templates/account/password_delete.html:9
+msgid ""
+"You may delete your password since you are currently logged in using OpenID."
+msgstr ""
+
+#: templates/account/password_delete.html:12
+msgid "delete my password"
+msgstr ""
+
+#: templates/account/password_delete_done.html:5
+#: templates/account/password_delete_done.html:8
+msgid "Password Deleted"
+msgstr ""
+
+#: templates/account/password_delete_done.html:9
+msgid "Your password has been deleted."
+msgstr ""
+
+#: templates/account/password_reset.html:6
+#: templates/account/password_reset.html:10
+#: templates/account/password_reset_done.html:6
+#: templates/account/password_reset_done.html:9
+msgid "Password Reset"
+msgstr ""
+
+#: templates/account/password_reset.html:15
+msgid ""
+"Forgotten your password? Enter your e-mail address below, and we'll send you "
+"an e-mail allowing you to reset it."
+msgstr ""
+
+#: templates/account/password_reset.html:20
+msgid "Reset My Password"
+msgstr ""
+
+#: templates/account/password_reset.html:23
+msgid "Please contact us if you have any trouble resetting your password."
+msgstr ""
+
+#: templates/account/password_reset_done.html:15
+msgid ""
+"We have sent you an e-mail. Please contact us if you do not receive it "
+"within a few minutes."
+msgstr ""
+
+#: templates/account/password_reset_from_key.html:8
+msgid "Bad Token"
+msgstr ""
+
+#: templates/account/password_reset_from_key.html:12
+#, python-format
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a <a href=\"%(passwd_reset_url)s\">new password reset</"
+"a>."
+msgstr ""
+
+#: templates/account/password_reset_from_key.html:18
+msgid "change password"
+msgstr ""
+
+#: templates/account/password_reset_from_key.html:21
+msgid "Your password is now changed."
+msgstr ""
+
+#: templates/account/password_set.html:5 templates/account/password_set.html:8
+#: templates/account/password_set.html:13
+msgid "Set Password"
+msgstr ""
+
+#: templates/account/signup.html:6 templates/socialaccount/signup.html:5
+msgid "Signup"
+msgstr ""
+
+#: templates/account/signup.html:9 templates/account/signup.html.py:19
+#: templates/socialaccount/signup.html:8
+#: templates/socialaccount/signup.html:19
+msgid "Sign Up"
+msgstr ""
+
+#: templates/account/signup.html:11
+#, python-format
+msgid ""
+"Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
+msgstr ""
+
+#: templates/account/signup_closed.html:6
+#: templates/account/signup_closed.html:9
+msgid "Sign Up Closed"
+msgstr ""
+
+#: templates/account/signup_closed.html:11
+msgid "We are sorry, but the sign up is currently closed."
+msgstr ""
+
+#: templates/account/verification_sent.html:5
+#: templates/account/verification_sent.html:8
+#: templates/account/verified_email_required.html:6
+#: templates/account/verified_email_required.html:9
+msgid "Verify Your E-mail Address"
+msgstr ""
+
+#: templates/account/verification_sent.html:10
+#, python-format
+msgid ""
+"We have sent an e-mail to <a href=\"mailto:%(email)s\">%(email)s</a> for "
+"verification. Follow the link provided to finalize the signup process. "
+"Please contact us if you do not receive it within a few minutes."
+msgstr ""
+
+#: templates/account/verified_email_required.html:13
+msgid ""
+"This part of the site requires us to verify that\n"
+"you are who you claim to be. For this purpose, we require that you\n"
+"verify ownership of your e-mail address. "
+msgstr ""
+
+#: templates/account/verified_email_required.html:17
+msgid ""
+"We have sent an e-mail to you for\n"
+"verification. Please click on the link inside this e-mail. Please\n"
+"contact us if you do not receive it within a few minutes."
+msgstr ""
+
+#: templates/account/verified_email_required.html:21
+#, python-format
+msgid ""
+"<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your e-"
+"mail address</a>."
+msgstr ""
+
+#: templates/account/email/email_confirmation_message.txt:1
+#, python-format
+msgid ""
+"User %(user_display)s at %(site_name)s has given this as an email address.\n"
+"\n"
+"To confirm this is correct, go to %(activate_url)s\n"
+msgstr ""
+
+#: templates/account/email/password_reset_key_message.txt:1
+#, python-format
+msgid ""
+"You're receiving this e-mail because you or someone else has requested a "
+"password for your user account at %(site_domain)s.\n"
+"It can be safely ignored if you did not request a password reset. Click the "
+"link below to reset your password.\n"
+"\n"
+"%(password_reset_url)s\n"
+"\n"
+"In case you forgot, your username is %(username)s.\n"
+"\n"
+"Thanks for using our site!\n"
+msgstr ""
+
+#: templates/account/email/password_reset_key_subject.txt:3
+msgid "Password Reset E-mail"
+msgstr ""
+
+#: templates/account/messages/cannot_delete_primary_email.txt:2
+#, python-format
+msgid "You cannot remove your primary e-mail address (%(email)s)."
+msgstr ""
+
+#: templates/account/messages/email_confirmation_sent.txt:2
+#, python-format
+msgid "Confirmation e-mail sent to %(email)s."
+msgstr ""
+
+#: templates/account/messages/email_confirmed.txt:2
+#, python-format
+msgid "You have confirmed %(email)s."
+msgstr ""
+
+#: templates/account/messages/email_deleted.txt:2
+#, python-format
+msgid "Removed e-mail address %(email)s."
+msgstr ""
+
+#: templates/account/messages/logged_in.txt:4
+#, python-format
+msgid "Successfully signed in as %(name)s."
+msgstr ""
+
+#: templates/account/messages/logged_out.txt:2
+msgid "You have signed out."
+msgstr ""
+
+#: templates/account/messages/password_changed.txt:2
+msgid "Password successfully changed."
+msgstr ""
+
+#: templates/account/messages/password_set.txt:2
+msgid "Password successfully set."
+msgstr ""
+
+#: templates/account/messages/primary_email_set.txt:2
+msgid "Primary e-mail address set."
+msgstr ""
+
+#: templates/account/messages/unverified_primary_email.txt:2
+msgid "Your primary e-mail address must be verified."
+msgstr ""
+
+#: templates/account/snippets/already_logged_in.html:5
+msgid "Note"
+msgstr ""
+
+#: templates/account/snippets/already_logged_in.html:5
+#, python-format
+msgid "you are already logged in as %(user_display)s."
+msgstr ""
+
+#: templates/openid/login.html:10
+msgid "OpenID Sign In"
+msgstr ""
+
+#: templates/socialaccount/account_inactive.html:5
+#: templates/socialaccount/account_inactive.html:8
+msgid "Account Inactive"
+msgstr ""
+
+#: templates/socialaccount/account_inactive.html:10
+msgid "This account is inactive."
+msgstr ""
+
+#: templates/socialaccount/authentication_error.html:5
+#: templates/socialaccount/authentication_error.html:8
+msgid "Social Network Login Failure"
+msgstr ""
+
+#: templates/socialaccount/authentication_error.html:10
+msgid ""
+"An error occurred while attempting to login via your social network account."
+msgstr ""
+
+#: templates/socialaccount/connections.html:5
+#: templates/socialaccount/connections.html:8
+msgid "Account Connections"
+msgstr ""
+
+#: templates/socialaccount/connections.html:11
+msgid ""
+"You can sign in to your account using any of the following third party "
+"accounts:"
+msgstr ""
+
+#: templates/socialaccount/connections.html:43
+msgid ""
+"You currently have no social network accounts connected to this account."
+msgstr ""
+
+#: templates/socialaccount/connections.html:46
+msgid "Add a 3rd Party Account"
+msgstr ""
+
+#: templates/socialaccount/login_cancelled.html:6
+#: templates/socialaccount/login_cancelled.html:10
+msgid "Login Cancelled"
+msgstr ""
+
+#: templates/socialaccount/login_cancelled.html:14
+#, python-format
+msgid ""
+"You decided to cancel logging in to our site using one of your existing "
+"accounts. If this was a mistake, please proceed to <a href=\"%(login_url)s"
+"\">sign in</a>."
+msgstr ""
+
+#: templates/socialaccount/signup.html:10
+#, python-format
+msgid ""
+"You are about to use your %(provider_name)s account to login to \n"
+"%(site_name)s. As a final step, please complete the following form:"
+msgstr ""
+
+#: templates/socialaccount/messages/account_connected.txt:2
+msgid "The social account has been connected."
+msgstr ""
+
+#: templates/socialaccount/messages/account_connected_other.txt:2
+msgid "The social account is already connected to a different account."
+msgstr ""
+
+#: templates/socialaccount/messages/account_disconnected.txt:2
+msgid "The social account has been disconnected."
+msgstr ""


### PR DESCRIPTION
More and more django packages make use of [Transifex](http://transifex.com), a collaborative translation platform that's free for open-source usage. Wanting to improve the German translation of `django-allauth` I tried to kill to birds with one stone and set up a [project page over at Transifex](https://www.transifex.com/projects/p/django-allauth) and imported the current resource files. Feel free to visit the site, add new languages and improve existing ones.
