### PR TITLE
Custom LogoutView templates

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -419,6 +419,9 @@ class LogoutView(TemplateResponseMixin, View):
     template_name = "account/logout.html"
     redirect_field_name = "next"
 
+    def get_template_names(self):
+        return [self.kwargs.pop("template_name", self.template_name)]
+
     def get(self, *args, **kwargs):
         if app_settings.LOGOUT_ON_GET:
             return self.post(*args, **kwargs)


### PR DESCRIPTION
I couldn't work out how to pass a custom `template_name` to the `LogoutView`, like you can with other views (such as `password_reset`). There may be a way to do this without editing the view itself (other creating another template named `account/logout.html`), if there is I would be happy to know.

This branch lets you supply a `template_name` just like any of the other `django-allauth` views.
Tested on Python 2.7.4 and Django 1.5.1.

``` python
from allauth.account import views as allauth_views

urlpatterns += patterns('',
    ....
    url(r"^logout/$", allauth_views.logout, {
        "template_name": "allauth/logout.html",
        }, name="account_logout"),
    ....
)
```
