### PR TITLE
Make EMAIL_VERIFICATION default to 'mandatory'.

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -77,7 +77,7 @@ class AppSettings(object):
         See e-mail verification method
         """
         ret = self._setting("EMAIL_VERIFICATION", 
-                            self.EmailVerificationMethod.OPTIONAL)
+                            self.EmailVerificationMethod.MANDATORY)
         # Deal with legacy (boolean based) setting
         if ret == True:
             ret = self.EmailVerificationMethod.MANDATORY


### PR DESCRIPTION
According to the documentation, email verification should default to `mandatory`, although the current implementation returns `optional` by default. The wording in the documentation suggests that one has to actively choose to disable verification or to make it optional, therefore I changed the implementation according to the docs and not the other way round.

> When set to "mandatory" the user is blocked from logging in until the email address is verified. **Choose "optional" or "none"** to allow logins with an unverified e-mail address. In case of "optional", the e-mail verification mail is still sent, whereas in case of "none" no e-mail verification mails are sent.
