### PR TITLE
password_change_done - using correct template

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -433,7 +433,7 @@ password_reset = PasswordResetView.as_view()
 
 
 class PasswordResetDoneView(TemplateView):
-    template_name = "account/password_reset.html"
+    template_name = "account/password_reset_done.html"
 
 password_reset_done = PasswordResetDoneView.as_view()
 


### PR DESCRIPTION
During the transition to all class based views an error slipped using the wrong template in `allauth.accounts.views` `PasswordResetDoneView` (currently set to use `account/password_reset.html`).
In old function based view `password_reset_done` you are using `account/password_reset_done.html` template. 

In this pull request I set it to use the correct template and that's about it :)
