### PR TITLE
Username case inconsistencies

### DIFF
--- a/allauth/account/auth_backends.py
+++ b/allauth/account/auth_backends.py
@@ -24,10 +24,13 @@ class AuthenticationBackend(ModelBackend):
         return ret
 
     def _authenticate_by_username(self, **credentials):
-        # Django ModelBackend <1.5 does not support additional params
-        return super(AuthenticationBackend, self) \
-            .authenticate(username=credentials.get('username'),
-                          password=credentials.get('password'))
+        try:
+            # Username query is case insensitive
+            user = User.objects.get(username__iexact=credentials["username"])
+            if user.check_password(credentials["password"]):
+                return user
+        except User.DoesNotExist:
+            return None
 
     def _authenticate_by_email(self, **credentials):
         # Even though allauth will pass along `email`, other apps may


### PR DESCRIPTION
This patch lets users log in with "username" even if they signed up with "uSeRName".

The `clean_username` function in `BaseSignupForm` won't let users sign up with a username if it matches another regardless of case, so it makes sense that the user should also be able to log in with any combination of case.
See: https://github.com/pennersr/django-allauth/blob/master/allauth/account/forms.py#L204

A settings variable `ACCOUNT_USERNAME_CASE_SENSITITIVE` defaulting to `False` might be useful to people who want to have usernames case sensitive. I'm happy to submit a pull request for it if there's interest.

Thanks!
-Gus
