### PR TITLE
Fix #37: Change validation msg if email present.

### DIFF
--- a/allauth/socialaccount/forms.py
+++ b/allauth/socialaccount/forms.py
@@ -1,11 +1,15 @@
 from __future__ import absolute_import
 
 from django import forms
+from django.utils.translation import ugettext_lazy as _
 
 from allauth.account.forms import BaseSignupForm
 from allauth.account.utils import (user_username, user_email,
                                    user_field)
+from allauth.account.adapter import get_adapter as get_account_adapter
+from allauth.account import app_settings as account_app_settings
 
+from ..utils import email_address_exists
 from .models import SocialAccount
 from .adapter import get_adapter
 from . import app_settings
@@ -26,6 +30,17 @@ class SignupForm(BaseSignupForm):
         kwargs['initial'] = initial
         kwargs['email_required'] = app_settings.EMAIL_REQUIRED
         super(SignupForm, self).__init__(*args, **kwargs)
+
+    def clean_email(self):
+        value = self.cleaned_data["email"]
+        value = get_account_adapter().clean_email(value)
+        if account_app_settings.UNIQUE_EMAIL:
+            if value and email_address_exists(value):
+                raise forms.ValidationError \
+                (_("This email address is already in use. If you already "
+                   "have an account on this site, please sign in and "
+                   "connect it with this social account first."))
+        return value
 
     def save(self, request):
         adapter = get_adapter()


### PR DESCRIPTION
In case the user's email adress is already present with another account during social account sign up, notify the user that a manual connection of both accounts is needed in order to use it for signing in to the existing local account.

---

Because GitHub doesn't want to let me change commits in my [previous pull request](/pennersr/django-allauth/pull/337), I opened this new one as a follow-up to this comment: 

> The new text you put in there refers to a social account, whereas that same message is used in case someone signs up for a local account. So, we need to change the message only for allauth.socialaccount.forms.SignupForm.
