### PR TITLE
Django package requirement should start with capital letter in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ METADATA = dict(
     long_description=open('README.rst').read(),
     url='http://github.com/pennersr/django-allauth',
     keywords='django auth account social openid twitter facebook oauth registration',
-    install_requires=['django >= 1.4.3',
+    install_requires=['Django >= 1.4.3',
                       openid_package,
                       'requests-oauthlib >= 0.3.0',
                       'requests >= 1.0.3'],


### PR DESCRIPTION
Django package starts with a capital letter in the PyPI index. For some reason, when it's specified in the setup.py in all lowercase, it causes problems when installing allauth using local packages in combination with the requirements.txt file as seen in the log below (Django-1.4.5 is already specified in the requirements file):

```
Downloading/unpacking django>=1.4.3 (from django-allauth==0.12.0->-r /Users/bezidejni/Documents/projekti/GitHub/appsembler/mediathread/requirements/apps.txt (line 25))
Exception:
Traceback (most recent call last):
  File "/Users/bezidejni/Documents/projekti/GitHub/appsembler/mediathread/ve/lib/python2.7/site-packages/pip-1.0-py2.7.egg/pip/basecommand.py", line 126, in main
    self.run(options, args)
  File "/Users/bezidejni/Documents/projekti/GitHub/appsembler/mediathread/ve/lib/python2.7/site-packages/pip-1.0-py2.7.egg/pip/commands/install.py", line 223, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/Users/bezidejni/Documents/projekti/GitHub/appsembler/mediathread/ve/lib/python2.7/site-packages/pip-1.0-py2.7.egg/pip/req.py", line 948, in prepare_files
    url = finder.find_requirement(req_to_install, upgrade=self.upgrade)
  File "/Users/bezidejni/Documents/projekti/GitHub/appsembler/mediathread/ve/lib/python2.7/site-packages/pip-1.0-py2.7.egg/pip/index.py", line 97, in find_requirement
    page = self._get_page(main_index_url, req)
  File "/Users/bezidejni/Documents/projekti/GitHub/appsembler/mediathread/ve/lib/python2.7/site-packages/pip-1.0-py2.7.egg/pip/index.py", line 324, in _get_page
    return HTMLPage.get_page(link, req, cache=self.cache)
  File "/Users/bezidejni/Documents/projekti/GitHub/appsembler/mediathread/ve/lib/python2.7/site-packages/pip-1.0-py2.7.egg/pip/index.py", line 441, in get_page
    resp = urlopen(url)
  File "/Users/bezidejni/Documents/projekti/GitHub/appsembler/mediathread/ve/lib/python2.7/site-packages/pip-1.0-py2.7.egg/pip/download.py", line 83, in __call__
    response = urllib2.urlopen(self.get_request(url))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 126, in urlopen
    return _opener.open(url, data, timeout)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 386, in open
    protocol = req.get_type()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 248, in get_type
    raise ValueError, "unknown url type: %s" % self.__original
ValueError: unknown url type: ''/django
```

It's a small change and it might help some people so I hope you'll accept it.
