### PR TITLE
Fix login link on socialaccount login cancelled page

### DIFF
--- a/allauth/templates/socialaccount/login_cancelled.html
+++ b/allauth/templates/socialaccount/login_cancelled.html
@@ -9,7 +9,7 @@
     
 <h1>{% trans "Login Cancelled" %}</h1>
 
-{% url 'socialaccount_login' as login_url %}
+{% url 'account_login' as login_url %}
 
 <p>{% blocktrans %}You decided to cancel logging in to our site using one of your existing accounts. If this was a mistake, please proceed to <a href="{{login_url}}">sign in</a>.{% endblocktrans %}</p>
 


### PR DESCRIPTION
The login link in the default login cancelled template is pointing to non-existent url.
Fix it to point to account_login instead.
