### PR TITLE
Remove unnecessary and mostly documentation links

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,18 +4,3 @@
    contain the root `toctree` directive.
 
 .. include:: ../README.rst
-
-Contents:
-
-.. toctree::
-   :maxdepth: 2
-
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-


### PR DESCRIPTION
Why each part was removed:

``` RestructuredText

Contents:  # No contents so this isn't needed.

.. toctree::  # No included files so this isn't needed.
   :maxdepth: 2  # No included files so this isn't needed.



Indices and tables
==================

* :ref:`genindex`  # No indexes specified so this isn't needed
* :ref:`modindex`  # No module indexes specified so this isn't needed
* :ref:`search`  # Search is better done in left RTD full-text side-bar
```
