### PR TITLE
Get rid of requirement for a verified email when disconnecting an account

### DIFF
--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -73,10 +73,11 @@ class DefaultSocialAccountAdapter(object):
                 raise ValidationError(_("Your account has no password set"
                                         " up."))
             # No email address, no password reset
-            if EmailAddress.objects.filter(user=account.user,
-                                           verified=True).count() == 0:
-                raise ValidationError(_("Your account has no verified e-mail"
-                                        " address."))
+            if app_settings.EMAIL_VERIFICATION == 'mandatory':
+                if EmailAddress.objects.filter(user=account.user,
+                                               verified=True).count() == 0:
+                    raise ValidationError(_("Your account has no verified e-mail"
+                                            " address."))
 
 
 def get_adapter():


### PR DESCRIPTION
Allauth would always require a verified email when disconnecting a social account, regardless of settings.

Instead, instead check the email verification setting before requiring a verified email to disconnect a social account.
