### PR TITLE
Using 'add_message' from the adapter to add messages in 'send_email_conf...

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -293,7 +293,7 @@ def send_email_confirmation(request, user, signup=False):
         if send_email:
             get_adapter().add_message(request,
                               messages.INFO,
-                              "account/messages/logged_in.txt" % {"email": email},
+                              "account/messages/email_confirmation_sent.txt" % {"email": email},
                               {'user': user})
 
 


### PR DESCRIPTION
This is the only place where `add_message` is not used to add a message.
