### PR TITLE
Fixes facebook response.status values and adds callback support for cancelUrl and errorUrl

### DIFF
--- a/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
+++ b/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
@@ -33,9 +33,9 @@
                 xfbml      : true
             });
             allauth.facebook.login = function(nextUrl, action, process) {
-		if (action == 'reauthenticate') {
-		    opts.loginOptions.auth_type = action;
-		}
+        if (action == 'reauthenticate') {
+            opts.loginOptions.auth_type = action;
+        }
                 FB.login(function(response) {
                     if (response.authResponse) {
                         postForm(opts.loginByTokenUrl,
@@ -45,12 +45,17 @@
                                   ['expires_in', response.authResponse.expiresIn]]);
                     } else {
                         var next;
-                        if (response && response.status && response.status == "notConnected") {
+                        if (response && response.status && ["not_authorized", "unknown"].indexOf(response.status) > -1) {
                             next = opts.cancelUrl;
                         } else {
                             next = opts.errorUrl;
                         }
-                        window.location.href = next;
+
+                        if (typeof(next) == "function") {
+                            next();
+                        } else {
+                            window.location.href = next;
+                        }
                     }
                 }, opts.loginOptions);
             };


### PR DESCRIPTION
## response.status bugfix

It seems that the `notConnected` status disappeared and now Facebook uses `connected`, `not_authorized` and `unknown` as possible values https://developers.facebook.com/docs/reference/javascript/FB.getLoginStatus/

In case of `not_authorized` and `unknown`, the `cancelUrl` should be used.
## Callbacks support

This pull request adds a new feature, that is the possibility to use a callback function for `cancelUrl` and `errorUrl`.

In other words, you can create `templates/facebook/fbconnect.html` and use custom logic in case of facebook cancel or error:

```
{% load url from future %}
{% load staticfiles %}
<div id="fb-root"></div>
<script type="text/javascript" src="{% static "facebook/js/fbconnect.js" %}"></script>
<script type="text/javascript">
allauth.facebook.init({ appId: '{{facebook_app.client_id}}',
  locale: '{{facebook_jssdk_locale}}',
  loginOptions: {{fb_login_options}},
  loginByTokenUrl: '{% url 'facebook_login_by_token' %}',
  channelUrl : '{{facebook_channel_url}}',
  cancelUrl: function() {   # <== new
    // don't do anything
  },
  logoutUrl: '{% url 'account_logout' %}',
  errorUrl: function() {   # <== new
    alert('An error occurred while attempting to login via Facebook');
  },
  csrfToken: '{{csrf_token}}' });
</script>
```
