### PR TITLE
allow default facebook postForm js function to be overridden

### DIFF
--- a/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
+++ b/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
@@ -43,7 +43,8 @@
                                  [['next', nextUrl || ''],
                                   ['process', process],
                                   ['access_token', response.authResponse.accessToken],
-                                  ['expires_in', response.authResponse.expiresIn]]);
+                                  ['expires_in', response.authResponse.expiresIn]],
+                                  response);
                     } else {
                         var next;
                         if (response && response.status && ["not_authorized", "unknown"].indexOf(response.status) > -1) {

--- a/allauth/socialaccount/providers/facebook/templates/facebook/fbconnect.html
+++ b/allauth/socialaccount/providers/facebook/templates/facebook/fbconnect.html
@@ -15,7 +15,7 @@ allauth.facebook.init({
   csrfToken: '{{csrf_token}}'
   /*
   // override the default postForm function with your logic (e.g. ajax)
-  , postForm: function(action, data) {}
+  , postForm: function(action, data, fbResponse) {}
   */
 });
 </script>


### PR DESCRIPTION
The default js implementation creates a form and submits it.

Sometimes, it's handy to be able to control the post facebook login action by overriding the default behaviour (e.g. if you want to use an ajax post and stay on the page).

To do that, you would just override the `fbconnect.html` and specify your own `postForm`:

```
{% load url from future %}
{% load staticfiles %}
<div id="fb-root"></div>
<script type="text/javascript" src="{% static "facebook/js/fbconnect.js" %}"></script>
<script type="text/javascript">
allauth.facebook.init({
  appId: '{{facebook_app.client_id}}',
  locale: '{{facebook_jssdk_locale}}',
  loginOptions: {{fb_login_options}},
  loginByTokenUrl: '{% url 'facebook_login_by_token' %}',
  channelUrl : '{{facebook_channel_url}}',
  cancelUrl: '{% url 'socialaccount_login_cancelled' %}',
  logoutUrl: '{% url 'account_logout' %}',
  errorUrl: '{% url 'socialaccount_login_error' %}',
  csrfToken: '{{csrf_token}}', 
  postForm: function(action, data) {
    data.push(['csrfmiddlewaretoken', '{{csrf_token}}']);

    var postData = {};
    $.each(data, function(i, el) { postData[el[0]] = el[1] });

    $.post(action, postData, function(resData, textStatus) {
      if (textStatus == 'success') {
        // do somethind
      } else {
        // do something else
      }
    }, 'html');
  }
});
</script>
```
