### PR TITLE
Fix deprecation warning in the Django example

### DIFF
--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -165,9 +165,15 @@ INSTALLED_APPS = (
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
     'handlers': {
         'mail_admins': {
             'level': 'ERROR',
+            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
         }
     },
@@ -179,6 +185,7 @@ LOGGING = {
         },
     }
 }
+
 
 try:
     from local_settings import *


### PR DESCRIPTION
When I run the example I got the following warning. Making the prooposed change according to the django documentation will fix the issue

https://docs.djangoproject.com/en/dev/releases/1.4/#request-exceptions-are-now-always-logged

The warning 

``` python
/virtualenvs/allauth/lib/python2.7/site-packages/django/conf/__init__.py:221: DeprecationWarning: You have no filters defined on the 'mail_admins' logging handler: adding implicit debug-false-only filter. See http://docs.djangoproject.com/en/dev/releases/1.4/#request-exceptions-are-now-always-logged
  DeprecationWarning)
```
