### PR TITLE
add url to action

### DIFF
--- a/allauth/templates/account/password_reset.html
+++ b/allauth/templates/account/password_reset.html
@@ -14,7 +14,7 @@
     
     <p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
     
-    <form method="POST" action="" class="password_reset">
+    <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
         {% csrf_token %}
         {{ form.as_p }}
         <input type="submit" value="{% trans "Reset My Password" %}" />


### PR DESCRIPTION
With a javascript library that intrudes on forms, having a blank action may change behavior. Adding the URL to action matches the approach of other forms (i.e. the sign in form).
