### PR TITLE
Since social api tokens are often long, make the admin boxes long enough...

### DIFF
--- a/allauth/socialaccount/admin.py
+++ b/allauth/socialaccount/admin.py
@@ -1,11 +1,14 @@
 from django.contrib import admin
+from django.db      import models
+from django.forms   import TextInput, Textarea
 
-from .models import SocialApp, SocialAccount, SocialToken
-
+from  .models  import SocialApp, SocialAccount, SocialToken
 from ..account import app_settings
 
-
 class SocialAppAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        models.CharField: {'widget': TextInput(attrs={'size':'100'})}
+    }
     list_display = ('name', 'provider',)
     filter_horizontal = ('sites',)
 


### PR DESCRIPTION
Adjust admin so the entire token is seen without scrolling.
