### PR TITLE
Regex support for checking usernames against the USERNAME_BLACKLIST.

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -1,5 +1,6 @@
 import warnings
 import json
+import re
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -203,10 +204,12 @@ class DefaultAccountAdapter(object):
             raise forms.ValidationError(_("Usernames can only contain "
                                           "letters, digits and @/./+/-/_."))
 
-        # TODO: Add regexp support to USERNAME_BLACKLIST
-        if username in app_settings.USERNAME_BLACKLIST:
-            raise forms.ValidationError(_("Username can not be used. "
-                                          "Please use other username."))
+        # regex prevents usernames from using blacklisted words/names 
+        for illegal_word in app_settings.USERNAME_BLACKLIST:
+            if re.search(illegal_word, username, re.I):
+                raise forms.ValidationError(_(
+                    "That Username is not allowed. "
+                    "Please try a different username."))
         username_field = app_settings.USER_MODEL_USERNAME_FIELD
         assert username_field
         user_model = get_user_model()

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -204,12 +204,14 @@ class DefaultAccountAdapter(object):
             raise forms.ValidationError(_("Usernames can only contain "
                                           "letters, digits and @/./+/-/_."))
 
-        # regex prevents usernames from using blacklisted words/names 
+        # prevent usernames from using blacklisted words; partial matches
+        # are made; 'bad' will prevent "badname" and "iamabadman"
         for illegal_word in app_settings.USERNAME_BLACKLIST:
             if re.search(illegal_word, username, re.I):
                 raise forms.ValidationError(_(
                     "That Username is not allowed. "
                     "Please try a different username."))
+
         username_field = app_settings.USER_MODEL_USERNAME_FIELD
         assert username_field
         user_model = get_user_model()

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -350,7 +350,7 @@ class BaseSignupFormTests(TestCase):
 
     @override_settings(
         ACCOUNT_USERNAME_REQUIRED=True,
-        ACCOUNT_USERNAME_BLACKLIST=['username'])
+        ACCOUNT_USERNAME_BLACKLIST=['foobar'])
     def test_username_not_in_blacklist(self):
         data = {
             'username': 'theusername',
@@ -358,3 +358,15 @@ class BaseSignupFormTests(TestCase):
         }
         form = BaseSignupForm(data, email_required=True)
         self.assertTrue(form.is_valid())
+
+    @override_settings(
+        ACCOUNT_USERNAME_REQUIRED=True,
+        ACCOUNT_USERNAME_BLACKLIST=['username', 'foobar', 'bad',])
+    def test_part_of_username_in_blacklist(self):
+        data = {
+            'username': 'badname',
+            'email': 'user@example.com',
+        }
+        form = BaseSignupForm(data, email_required=True)
+        self.assertFalse(form.is_valid())
+


### PR DESCRIPTION
A case-insensitive regex check to prevents users from creating Usernames that use *words* in the ACCOUNT_USERNAME_BLACKLIST.

if ACCOUNT_USERNAME_BLACKLIST = ['shit', 'ass',] 

then ......usernames like 'AssHat' and 'ShitMonkey' will be disallowed. This was a TODO item.

NOTE: While 'AssHat' would not be allowed; 'BassFisherman' and 'Lassie' would also get stopped! it might make sense to add a BLACKLIST_EXACT_MATCH option and then update the docs so that people can choose between an exact case-insensitve match (using re.match) or the more aggressive match on partial word approach that I have used. 