### PR TITLE
Default rendering of template threw a traceback. Added missing template tag for url rendering.

### DIFF
--- a/allauth/templates/account/password_reset.html
+++ b/allauth/templates/account/password_reset.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load account %}
+{% load url from future %}
 
 {% block head_title %}{% trans "Password Reset" %}{% endblock %}
 


### PR DESCRIPTION
In the 0.15.0 release, rendering the password reset view threw a traceback. This commit fixes the issue.
