### PR TITLE
Force https for amazon login even from non-http page.

### DIFF
--- a/allauth/socialaccount/providers/amazon/provider.py
+++ b/allauth/socialaccount/providers/amazon/provider.py
@@ -15,6 +15,11 @@ class AmazonProvider(OAuth2Provider):
     package = 'allauth.socialaccount.providers.amazon'
     account_class = AmazonAccount
 
+    # Return a https URL even if the request originated from a http site
+    def get_login_url(self, request, **kwargs):
+        url = super(AmazonProvider, self).get_login_url(request, **kwargs)
+        return 'https://' + request.get_host() + url
+
     def get_default_scope(self):
         return ['profile']
 


### PR DESCRIPTION
Amazon oauth2 requires https, at least in the simple case.
This patch forces an https url for the amazon {% provider_login_url %} link, even if the site itself is basic http.

The https code has the choice of leaving the user in a secure session or redirecting back to the http site.
