### PR TITLE
Added settings to configure the auth backend used to login users

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -198,6 +198,10 @@ class AppSettings(object):
     def USER_MODEL_EMAIL_FIELD(self):
         return self._setting('USER_MODEL_EMAIL_FIELD', 'email')
 
+    @property
+    def AUTH_BACKEND(self):
+        return self._setting('AUTH_BACKEND', 'allauth.account.auth_backends.AuthenticationBackend')
+
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -130,7 +130,7 @@ def perform_login(request, user, email_verification,
     # whereas I do see the downsides (having to bother the integrator
     # to set up authentication backends in settings.py
     if not hasattr(user, 'backend'):
-        user.backend = "allauth.account.auth_backends.AuthenticationBackend"
+        user.backend = app_settings.AUTH_BACKEND
     signals.user_logged_in.send(sender=user.__class__,
                                 request=request,
                                 user=user,


### PR DESCRIPTION
Hi, first of all thanks for this really useful project.
While using it, I came across this issue: 

1) I have a custom Auth backend configured (which inherits from your allauth.account.auth_backends.AuthenticationBackend class, but needs to perform some additional logic).

2) After a user signs up, it should automatically logged in too. Instead, to be logged in after signing up required a new login. 

3) Basically, after signing up, the user was redirected back to the login form, because the session data was not valid for the current settings.

It turned out the issue in my case was caused by the hardcoded auth backend here: https://github.com/pennersr/django-allauth/blob/master/allauth/account/utils.py#L128

The auth backend used to log in the user is stored by Django in the session data. But my Django AUTHENTICATION_BACKENDS settings specifies instead another backend (actually a subclass of yours). As a result, the login cookie set right after the signup process is not considered "valid" for the next request, because the auth backend is different.

In my proposed solution (which is working for me) I simply added a configuration option to specify a custom auth class to be used (instead of hardcoding it). This settings default to your allauth.account.auth_backends.AuthenticationBackend class.

So in my Django settings now I have another setting:
ACCOUNT_AUTH_BACKEND = 'timeline.auth_backends.AuthBackend'

Hope this can help.
Fabio.
