### PR TITLE
Add SITE_ID information missing in settings.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,9 @@ settings.py::
         'allauth.socialaccount.providers.weibo',
         ...
     )
-
+    
+    SITE_ID = 1
+    
 urls.py::
 
     urlpatterns = patterns('',


### PR DESCRIPTION
On an existing project, the SITE_ID information in settings.py is missing from the doc. If we follow step by step the documentation, there is an error when we try to reach the admin pages
