### PR TITLE
Set JS var fbApiInit after Facebook JS SDK has been initialized

### DIFF
--- a/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
+++ b/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
@@ -43,6 +43,10 @@
                     oauth      : true,
                     xfbml      : true
                 });
+
+                FB.getLoginStatus(function(response) {
+                    window.fbApiInit = true;
+                });
             };
 
             (function(d){


### PR DESCRIPTION
Setting a pretty standard JS var after the Facebook JS SDJ has been initialized, so that we know when we can start calling the FB api.
