### PR TITLE
added custom client for linkedin_oauth2 to deal with accessToken bug

### DIFF
--- a/allauth/socialaccount/providers/linkedin_oauth2/client.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/client.py
@@ -1,0 +1,33 @@
+from allauth.socialaccount.providers.oauth2.client import (OAuth2Client,
+                                                           OAuth2Error)
+try:
+    from urllib.parse import parse_qsl, urlencode
+except ImportError:
+    from urllib import urlencode
+    from urlparse import parse_qsl
+import requests
+
+class LinkedInOAuth2Client(OAuth2Client):
+    def get_access_token(self, code):
+        params = {'client_id': self.consumer_key,
+                  'redirect_uri': self.callback_url,
+                  'grant_type': 'authorization_code',
+                  'client_secret': self.consumer_secret,
+                  'scope': self.scope,
+                  'code': code}
+        url = self.access_token_url
+        #NOTE: need to use GET instead of POST for linkedin
+        #See: http://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token?page=1
+        resp = requests.get(url, params=params)
+        access_token = None
+        if resp.status_code == 200:
+            # Weibo sends json via 'text/plain;charset=UTF-8'
+            if (resp.headers['content-type'].split(';')[0] == 'application/json'
+                or resp.text[:2] == '{"'):
+                access_token = resp.json()
+            else:
+                access_token = dict(parse_qsl(resp.text))
+        if not access_token or 'access_token' not in access_token:
+            raise OAuth2Error('Error retrieving access token: %s' 
+                              % resp.content)
+        return access_token

--- a/allauth/socialaccount/providers/linkedin_oauth2/views.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/views.py
@@ -1,17 +1,32 @@
 import requests
 from allauth.socialaccount import providers
+from django.core.urlresolvers import reverse
+from allauth.utils import build_absolute_uri
 from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
                                                           OAuth2LoginView,
                                                           OAuth2CallbackView)
-
+from .client import LinkedInOAuth2Client
 from .provider import LinkedInOAuth2Provider
+
+class LinkedInOAuth2CallbackView(OAuth2CallbackView):
+    def get_client(self, request, app):
+        callback_url = reverse(self.adapter.provider_id + "_callback")
+        callback_url = build_absolute_uri(
+            request, callback_url,
+            protocol=self.adapter.redirect_uri_protocol)
+        provider = self.adapter.get_provider()
+        client = LinkedInOAuth2Client(self.request, app.client_id, app.secret,
+                              self.adapter.access_token_url,
+                              callback_url,
+                              provider.get_scope())
+        return client
 
 class LinkedInOAuth2Adapter(OAuth2Adapter):
     provider_id = LinkedInOAuth2Provider.id
     access_token_url = 'https://api.linkedin.com/uas/oauth2/accessToken'
     authorize_url = 'https://www.linkedin.com/uas/oauth2/authorization'
     profile_url = 'https://api.linkedin.com/v1/people/~'
-    supports_state = False
+    supports_state = True
 
     def complete_login(self, request, app, token, **kwargs):
         extra_data = self.get_user_info(token)
@@ -26,4 +41,4 @@ class LinkedInOAuth2Adapter(OAuth2Adapter):
         return resp.json()
 
 oauth2_login = OAuth2LoginView.adapter_view(LinkedInOAuth2Adapter)
-oauth2_callback = OAuth2CallbackView.adapter_view(LinkedInOAuth2Adapter)
+oauth2_callback = LinkedInOAuth2CallbackView.adapter_view(LinkedInOAuth2Adapter)


### PR DESCRIPTION
I've had to extend the oauth2 client for linkedin_oauth2 to deal with an intermittent linkedin server bug.
http://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token?page=1
Instead of sending a post with the parameters to get the accessToken the linkedin dev said to send a get request instead which should solve the issue. The code seems to work, but its hard to test since it only happens to specific users. 
