### PR TITLE
Fix a bug in custom signup form classes, which rejected classes that only implemented the new 'signup' method.

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -183,9 +183,14 @@ def _base_signup_form_class():
         raise exceptions.ImproperlyConfigured('Module "%s" does not define a'
                                               ' "%s" class' % (fc_module,
                                                                fc_classname))
-    if not hasattr(fc_class, 'save'):
-        raise exceptions.ImproperlyConfigured('The custom signup form must'
-                                              ' implement a "save" method')
+    if not hasattr(fc_class, 'signup'):
+        if hasattr(fc_class, 'save'):
+            warnings.warn("The custom signup form must offer"
+                          " a `def signup(self, request, user)` method",
+                          DeprecationWarning)
+        else:
+            raise exceptions.ImproperlyConfigured(
+                'The custom signup form must implement a "signup" method')
     return fc_class
 
 


### PR DESCRIPTION
django-allauth was updated to use the 'signup' method instead of the 'save' method for custom signup form classes. However, there is one place that didn't get updated and thus it won't work.

Original commit here: https://github.com/pennersr/django-allauth/commit/afc467a539173922b4f11e8f8bc084827ec10ad8#diff-3b9310d6e2c9a729f9c65c16647b3e1aR192
