### PR TITLE
Don't call self.load() from registry.register() to avoid recursion.

### DIFF
--- a/allauth/socialaccount/providers/__init__.py
+++ b/allauth/socialaccount/providers/__init__.py
@@ -11,7 +11,6 @@ class ProviderRegistry(object):
         return self.provider_map.values()
 
     def register(self, cls):
-        self.load()
         self.provider_map[cls.id] = cls()
 
     def by_id(self, id):


### PR DESCRIPTION
Presently registry.load() imports provider modules, and each module calls
registry.register(), which itself calls self.load().  The result is that
self.load() attempts to import the entire list of modules once for each
provider module that calls registry.register().

The recursion doesn't hurt because already-imported modules don't run again,
but it would be better to avoid it, and there's no reason for 
registry.register() to call self.load()
