### PR TITLE
Add a setting to specify the email field length.

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -132,6 +132,13 @@ class AppSettings(object):
         return self._setting("PASSWORD_MIN_LENGTH", 6)
 
     @property
+    def EMAIL_FIELD_LENGTH(self):
+        """
+        Length of the EmailAddress email field
+        """
+        return self._setting("EMAIL_FIELD_LENGTH", 75)
+
+    @property
     def EMAIL_SUBJECT_PREFIX(self):
         """
         Subject-line prefix to use for email messages sent

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -23,6 +23,7 @@ class EmailAddress(models.Model):
     user = models.ForeignKey(allauth_app_settings.USER_MODEL,
                              verbose_name=_('user'))
     email = models.EmailField(unique=app_settings.UNIQUE_EMAIL,
+                              max_length=app_settings.EMAIL_FIELD_LENGTH,
                               verbose_name=_('e-mail address'))
     verified = models.BooleanField(verbose_name=_('verified'), default=False)
     primary = models.BooleanField(verbose_name=_('primary'), default=False)


### PR DESCRIPTION
Provide a setting to override the max_length for the email field.

The default is kept to be the same for the django EmailField, which is 75.

This now allows the user to override the default to a more standards compliant 254 (see standards comment here: https://docs.djangoproject.com/en/dev/ref/models/fields/#emailfield)

Interestingly when running the tests (on ubuntu with python 2.7.5), I had import errors from
unittest.mock, and I'm not sure why.
