### PR TITLE
[vk.com provider] avatar url fix, name fix

### DIFF
--- a/allauth/socialaccount/providers/vk/provider.py
+++ b/allauth/socialaccount/providers/vk/provider.py
@@ -33,9 +33,9 @@ class VKProvider(OAuth2Provider):
         return str(data['uid'])
 
     def extract_common_fields(self, data):
-        return dict(last_name=data.get('family_name'),
+        return dict(last_name=data.get('last_name'),
                     username=data.get('screen_name'),
-                    first_name=data.get('given_name'))
+                    first_name=data.get('first_name'))
 
 
 providers.registry.register(VKProvider)


### PR DESCRIPTION
there is no 'picture' property anymore. Using 'photo_big_url' or 'photo_medium_url' instead.
last_name and first_name fixed also.
