### PR TITLE
Add `exclude` meta attribute for `SocialAppForm`.

### DIFF
--- a/allauth/socialaccount/admin.py
+++ b/allauth/socialaccount/admin.py
@@ -12,6 +12,7 @@ User = get_user_model()
 class SocialAppForm(forms.ModelForm):
     class Meta:
         model = SocialApp
+        exclude = []
         widgets = {
             'client_id': forms.TextInput(attrs={'size': '100'}),
             'key': forms.TextInput(attrs={'size': '100'}),


### PR DESCRIPTION
Django 1.7 requires ModelForms to have either a `fields` or an
`exclude` attribute in the `Meta` class.  Not putting either of the two
fields results in a

```
django.core.exceptions.ImproperlyConfigured: Creating a ModelForm without
either the 'fields' attribute or the 'exclude' attribute is prohibited;
form SocialAppForm needs updating.
```

exception.

Add an empty `exclude` Meta attribute to `SocialAppForm` to declare that
it should include all the model's fields.
