### PR TITLE
New session length configuration settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -378,6 +378,14 @@ ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION (=True)
   his email address. By changing this setting to False he will not be logged
   in, but redirected to the ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL
 
+ALWAYS_REMEMBER_SESSION (=False)
+  Treat logins as if the `remember` parameter was passed as true so that users
+  do not have to check a box when they log in.
+
+SESSION_COOKIE_AGE (=1814400)
+  How long before the session cookie expires in seconds.  Defaults to 1814400 seconds,
+  or 3 weeks.
+
 SOCIALACCOUNT_ADAPTER (="allauth.socialaccount.adapter.DefaultSocialAccountAdapter")
   Specifies the adapter class to use, allowing you to alter certain
   default behaviour.

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -205,6 +205,22 @@ class AppSettings(object):
     def USER_MODEL_EMAIL_FIELD(self):
         return self._setting('USER_MODEL_EMAIL_FIELD', 'email')
 
+    @property
+    def SESSION_COOKIE_AGE(self):
+        """
+        Remembered sessions expire after this many seconds.
+        Defaults to 1814400 seconds which is 3 weeks.
+        """
+        return self._setting('SESSION_COOKIE_AGE', 60 * 60 * 24 * 7 * 3)
+
+    @property
+    def ALWAYS_REMEMBER_SESSION(self):
+        """
+        Always remember sessions withou the user needing to check the box.
+        Defaults to False.
+        """
+        return self._setting('ALWAYS_REMEMBER_SESSION', False)
+
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -137,8 +137,9 @@ class LoginForm(forms.Form):
         ret = perform_login(request, self.user,
                             email_verification=app_settings.EMAIL_VERIFICATION,
                             redirect_url=redirect_url)
-        if self.cleaned_data["remember"]:
-            request.session.set_expiry(60 * 60 * 24 * 7 * 3)
+
+        if self.cleaned_data["remember"] or app_settings.ALWAYS_REMEMBER_SESSION:
+            request.session.set_expiry(app_settings.SESSION_COOKIE_AGE)
         else:
             request.session.set_expiry(0)
         return ret


### PR DESCRIPTION
Added SESSION_COOKIE_AGE to mirror Django's but with 3 week expire time which allauth
has traditionally had.

Added ALWAYS_REMEMBER_SESSION setting to always remember the session rather than
requiring users to check a box on a form.
