### PR TITLE
Username Blacklist fix

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -204,7 +204,8 @@ class DefaultAccountAdapter(object):
                                           "letters, digits and @/./+/-/_."))
 
         # TODO: Add regexp support to USERNAME_BLACKLIST
-        if username in app_settings.USERNAME_BLACKLIST:
+        username_blacklist_lower = [ub.lower() for ub in app_settings.USERNAME_BLACKLIST]
+        if username.lower() in username_blacklist_lower:
             raise forms.ValidationError(_("Username can not be used. "
                                           "Please use other username."))
         username_field = app_settings.USER_MODEL_USERNAME_FIELD


### PR DESCRIPTION
Username Blacklist should do a case insensitive comparison. Current version only checks for an exact match.
