### PR TITLE
Delete email confirmations after address is verified

### DIFF
--- a/allauth/account/managers.py
+++ b/allauth/account/managers.py
@@ -69,3 +69,6 @@ class EmailConfirmationManager(models.Manager):
 
     def delete_expired_confirmations(self):
         self.all_expired().delete()
+
+    def delete_confirmations(self, email_address):
+        self.filter(email_address__user=email_address.user).delete()

--- a/allauth/account/managers.py
+++ b/allauth/account/managers.py
@@ -71,4 +71,4 @@ class EmailConfirmationManager(models.Manager):
         self.all_expired().delete()
 
     def delete_confirmations(self, email_address):
-        self.filter(email_address__user=email_address.user).delete()
+        self.filter(email_address__user=email_address.user).delete() 

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -106,6 +106,7 @@ class EmailConfirmation(models.Model):
         if not self.key_expired() and not self.email_address.verified:
             email_address = self.email_address
             get_adapter().confirm_email(request, email_address)
+            EmailConfirmation.objects.delete_confirmations(email_address)
             signals.email_confirmed.send(sender=self.__class__,
                                          request=request,
                                          email_address=email_address)

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -106,7 +106,7 @@ class EmailConfirmation(models.Model):
         if not self.key_expired() and not self.email_address.verified:
             email_address = self.email_address
             get_adapter().confirm_email(request, email_address)
-            EmailConfirmation.objects.delete_confirmations(email_address)
+            EmailConfirmation.objects.delete_confirmations(email_address) 
             signals.email_confirmed.send(sender=self.__class__,
                                          request=request,
                                          email_address=email_address)


### PR DESCRIPTION
Model manager has a new method to delete all confirmations for a given email address. This is called inside model's `confirm()` method right after it calls `get_adapter().confirm_email`