### PR TITLE
Fixed swedish spelling error

### DIFF
--- a/allauth/locale/sv/LC_MESSAGES/django.po
+++ b/allauth/locale/sv/LC_MESSAGES/django.po
@@ -467,7 +467,7 @@ msgstr "Tyvärr är anmälan stängd för närvarande."
 #: templates/account/verified_email_required.html:6
 #: templates/account/verified_email_required.html:9
 msgid "Verify Your E-mail Address"
-msgstr "Verifiera fin epost-adress"
+msgstr "Verifiera din epost-adress"
 
 #: templates/account/verification_sent.html:10
 #, fuzzy


### PR DESCRIPTION
Found a small spelling error (it says: Verify nice email address :))
