### PR TITLE
Match custom email field max_length

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from django.contrib.sites.models import Site
 from django.utils.encoding import python_2_unicode_compatible
-from django.contrib.auth import get_user_model
+from allauth.utils import get_user_model
 
 from .. import app_settings as allauth_app_settings
 from . import app_settings


### PR DESCRIPTION
Added a lookup to get the max_length of the provided USER_MODEL_EMAIL_FIELD and use that as the max_length in EmailAddress so that emails stored in one will fit in the other.  If there is no email_field, or if it's set to None, then default back to 75.
