### PR TITLE
Added default ordering to EmailAddress

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -32,6 +32,7 @@ class EmailAddress(models.Model):
     class Meta:
         verbose_name = _("email address")
         verbose_name_plural = _("email addresses")
+        ordering = ('email',)
         if not app_settings.UNIQUE_EMAIL:
             unique_together = [("user", "email")]
 


### PR DESCRIPTION
So that emails listed on the reverse("account_email") page stay in a consistent order and don't change sorting based on arbitrary database results.  It can theoretically result in a performance hit having to order the query results, but it's really the only way to do it if you access the emails via User.emailaddress_set.all(), such as in the default templates, and I doubt it'll make that much of a difference unless a user has several thousand emails in the system, and at that point, you probably have bigger problems with template rendering performance.
