### PR TITLE
Include Commercial Support paragraph instead of duplication

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,12 +21,12 @@ Contents
    advanced
    faq
    changelog
+   support
 
 
 ==================
 Indices and tables
 ==================
 
-.. * :ref:`genindex`
-.. * :ref:`modindex`
+* :ref:`genindex`
 * :ref:`search`

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,0 +1,2 @@
+.. include:: ../README.rst
+    :start-after: with flows that just work.


### PR DESCRIPTION
Following-up on pull request #668: This a DRY, no-redundancy, solution leaving the docs unchanged as currently generated. (Also including link to index again, because another link to it is generated in the documentation footer anyway.)

Hope that's fine now! :smiley: 
