### PR TITLE
fixes issues #589 - populate_username & custom User model without first_name/last_name fields 

### DIFF
--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -20,6 +20,8 @@ except ImportError:
 def _generate_unique_username_base(txts):
     username = None
     for txt in txts:
+        if not txt:
+            continue
         username = unicodedata.normalize('NFKD', force_text(txt))
         username = username.encode('ascii', 'ignore').decode('ascii')
         username = force_text(re.sub('[^\w\s@+.-]', '', username).lower())


### PR DESCRIPTION
Fix from issue #559. I added an if to ignore first_name and last_name attributes when they are null for generating an username using the method generate_unique_username 
