### PR TITLE
Added support for custom username regexes

### DIFF
--- a/allauth/app_settings.py
+++ b/allauth/app_settings.py
@@ -14,3 +14,5 @@ if SOCIALACCOUNT_ENABLED:
 LOGIN_REDIRECT_URL = getattr(settings, 'LOGIN_REDIRECT_URL', '/')
 
 USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
+ACCOUNT_USERNAME_REGEX = getattr(settings, 'ACCOUNT_USERNAME_REGEX', '[^\w\s@+.-]')

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
+from . import app_settings
+
 
 def _generate_unique_username_base(txts):
     username = None
@@ -24,7 +26,8 @@ def _generate_unique_username_base(txts):
             continue
         username = unicodedata.normalize('NFKD', force_text(txt))
         username = username.encode('ascii', 'ignore').decode('ascii')
-        username = force_text(re.sub('[^\w\s@+.-]', '', username).lower())
+        username = force_text(re.sub(app_settings.ACCOUNT_USERNAME_REGEX, '',
+                                     username).lower())
         # Django allows for '@' in usernames in order to accomodate for
         # project wanting to use e-mail for username. In allauth we don't
         # use this, we already have a proper place for putting e-mail

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -78,6 +78,10 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD (="username")
   The name of the field containing the `username`, if any. See custom
   user models.
 
+ACCOUNT_USERNAME_REGEX (="[^\w\s@+.-]")
+  The regex that represents a valid username. This is used when
+  auto-generating a username for a new user.
+
 ACCOUNT_USER_MODEL_EMAIL_FIELD (="email")
   The name of the field containing the `email`, if any. See custom
   user models.


### PR DESCRIPTION
```
* Sometime users want to change the validation rules for the username. This lets the user configure `allauth` to use a custom regex for generating a unique username.
```
