### PR TITLE
Added support for custom username regexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 *.egg*
 example/local_settings.py
 coverage.xml
+.ropeproject/*
 pep8.txt
 *.bak
 .#*

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -166,10 +166,13 @@ class DefaultAccountAdapter(object):
         if app_settings.USER_MODEL_USERNAME_FIELD:
             user_username(user,
                           username
-                          or generate_unique_username([first_name,
-                                                       last_name,
-                                                       email,
-                                                       'user']))
+                          or self.generate_unique_username([first_name,
+                                                            last_name,
+                                                            email,
+                                                            'user']))
+
+    def generate_unique_username(self, txts, regex=None):
+        return generate_unique_username(txts, regex)
 
     def save_user(self, request, user, form, commit=True):
         """

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -17,14 +17,15 @@ except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
 
-def _generate_unique_username_base(txts):
+def _generate_unique_username_base(txts, regex=None):
     username = None
+    regex = regex or '[^\w\s@+.-]'
     for txt in txts:
         if not txt:
             continue
         username = unicodedata.normalize('NFKD', force_text(txt))
         username = username.encode('ascii', 'ignore').decode('ascii')
-        username = force_text(re.sub('[^\w\s@+.-]', '', username).lower())
+        username = force_text(re.sub(regex, '', username).lower())
         # Django allows for '@' in usernames in order to accomodate for
         # project wanting to use e-mail for username. In allauth we don't
         # use this, we already have a proper place for putting e-mail
@@ -38,9 +39,9 @@ def _generate_unique_username_base(txts):
     return username or 'user'
 
 
-def generate_unique_username(txts):
+def generate_unique_username(txts, regex=None):
     from .account.app_settings import USER_MODEL_USERNAME_FIELD
-    username = _generate_unique_username_base(txts)
+    username = _generate_unique_username_base(txts, regex)
     User = get_user_model()
     try:
         max_length = User._meta.get_field(USER_MODEL_USERNAME_FIELD).max_length

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -56,6 +56,10 @@ instances are created, and populated with data
   - `confirm_email(self, request, email_address)`: Marks the email address as
     confirmed and saves to the db.
 
+  - `generate_unique_username(txts, regex=None)`: Returns a unique username
+    from the combination of strings present in txts iterable. A regex pattern
+    can be passed to the method to make sure the generated username matches it.
+
 - `allauth.socialaccount.adapter.DefaultSocialAccountAdapter`:
 
   - `new_user(self, request, sociallogin)`: Instantiates a new, empty


### PR DESCRIPTION
    * Sometime users want to change the validation rules for the username. This lets the user configure `allauth` to use a custom regex for generating a unique username.