### PR TITLE
don't check for active==True during form validation for consistency

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -125,11 +125,7 @@ class LoginForm(forms.Form):
             return
         user = authenticate(**self.user_credentials())
         if user:
-            if user.is_active:
-                self.user = user
-            else:
-                raise forms.ValidationError(
-                    self.error_messages['account_inactive'])
+            self.user = user
         else:
             raise forms.ValidationError(
                 self.error_messages[


### PR DESCRIPTION
handle it during perform_login to keep consistency between account & socialaccount workflows
ie. all users are redirected to account_inactive
