### PR TITLE
Example app: The TEMPLATE_DIRS setting must be a tuple

### DIFF
--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -125,7 +125,7 @@ TEMPLATE_DIRS = (
     # project and tweak it according to your needs
     # os.path.join(PROJECT_ROOT, 'templates', 'uniform', 'allauth'),
     # example project specific templates
-    os.path.join(PROJECT_ROOT, 'templates', 'plain', 'example')
+    os.path.join(PROJECT_ROOT, 'templates', 'plain', 'example'),
 )
 
 INSTALLED_APPS = (


### PR DESCRIPTION
Minor fix for the following error when starting the example app: 
`django.core.exceptions.ImproperlyConfigured: The TEMPLATE_DIRS setting must be a tuple. Please fix your settings.`
