### PR TITLE
[FIX] ImportError: cannot import name to_native_string

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ django>=1.4.3
 # python-openid>=2.2.5
 # python3-openid>=3.0.1
 python-openid>=2.2.5
-requests>=1.0.3
+requests>=2.0.0
 requests-oauthlib>=0.3.0


### PR DESCRIPTION
Actual version of requests-oauthlib uses a `requests` util available only on requests>=2.0.0

Until requests-oauthlib merges [this PR](https://github.com/requests/requests-oauthlib/pull/151), is safer for django-allauth to ensure the `requests` version needed

See: http://stackoverflow.com/a/24955127/798575
And: https://github.com/requests/requests-oauthlib/pull/151
