### PR TITLE
fixed reference to email_address in template

### DIFF
--- a/allauth/templates/account/email_confirmed.html
+++ b/allauth/templates/account/email_confirmed.html
@@ -10,8 +10,8 @@
 
 <h1>{% trans "Confirm E-mail Address" %}</h1>
 
-{% user_display email_address.user as user_display %}
+{% user_display confirmation.email_address.user as user_display %}
         
-<p>{% blocktrans with email_address.email as email %}You have confirmed that <a href="mailto:{{email}}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+<p>{% blocktrans with confirmation.email_address.email as email %}You have confirmed that <a href="mailto:{{email}}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
 
 {% endblock %}


### PR DESCRIPTION
When attempted to render 'email_confirmed.html' template it would fail as it couldn't access 'email_address' key in context.
