### PR TITLE
Fix mismatched parentheses and missing comma in south migration.

### DIFF
--- a/allauth/socialaccount/south_migrations/0001_initial.py
+++ b/allauth/socialaccount/south_migrations/0001_initial.py
@@ -21,10 +21,10 @@ class Migration(SchemaMigration):
         # Adding model 'SocialAccount'
         db.create_table('socialaccount_socialaccount', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=get_user_model())
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=get_user_model())),
             ('last_login', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
             ('date_joined', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
-        )))
+        ))
         db.send_create_signal('socialaccount', ['SocialAccount'])
 
 


### PR DESCRIPTION
Was having some trouble getting the latest django-allauth migrations to run on a Django 1.5 project using south, turns out there's some mismatched parentheses. 

It took an embarrassingly long time for me to notice this. Let's pretend I was totally pro and saw it immediately instead of playing in pdb for close to an hour trying to figure out what was wrong. :D
