### PR TITLE
Adds initial Evernote OAuth support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Martin Bächtold
 Mauro Stettler
 Nariman Gharib
 Niklas A Emanuelsson
+Patrick Paul
 Paulo Eduardo Neves
 Peter Bittner
 Rabi Alam

--- a/allauth/socialaccount/providers/evernote/models.py
+++ b/allauth/socialaccount/providers/evernote/models.py
@@ -1,0 +1,1 @@
+# Create your models here.

--- a/allauth/socialaccount/providers/evernote/provider.py
+++ b/allauth/socialaccount/providers/evernote/provider.py
@@ -1,0 +1,27 @@
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth.provider import OAuthProvider
+
+
+class EvernoteAccount(ProviderAccount):
+    def get_profile_url(self):
+        return None
+
+    def get_avatar_url(self):
+        return None
+
+
+class EvernoteProvider(OAuthProvider):
+    id = 'evernote'
+    name = 'Evernote'
+    package = 'allauth.socialaccount.providers.evernote'
+    account_class = EvernoteAccount
+
+    def extract_uid(self, data):
+        return str(data['edam_userId'])
+
+    def extract_common_fields(self, data):
+        return data
+
+
+providers.registry.register(EvernoteProvider)

--- a/allauth/socialaccount/providers/evernote/urls.py
+++ b/allauth/socialaccount/providers/evernote/urls.py
@@ -1,0 +1,6 @@
+from allauth.socialaccount.providers.oauth.urls import default_urlpatterns
+
+from .provider import EvernoteProvider
+
+urlpatterns = default_urlpatterns(EvernoteProvider)
+

--- a/allauth/socialaccount/providers/evernote/views.py
+++ b/allauth/socialaccount/providers/evernote/views.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from allauth.socialaccount.helpers import render_authentication_error
+from allauth.socialaccount.providers.oauth.client import OAuthError
+from allauth.socialaccount.helpers import complete_social_login
+from allauth.socialaccount.models import SocialToken, SocialLogin
+
+from ..base import AuthError
+
+import datetime
+
+from allauth.socialaccount.providers.oauth.views import (OAuthAdapter,
+                                                         OAuthCallbackView,
+                                                         OAuthLoginView)
+
+from .provider import EvernoteProvider
+
+
+class EvernoteOAuthAdapter(OAuthAdapter):
+    provider_id = EvernoteProvider.id
+    request_token_url = 'https://sandbox.evernote.com/oauth'
+    access_token_url = 'https://sandbox.evernote.com/oauth'
+    authorize_url = 'https://sandbox.evernote.com/OAuth.action'
+
+    def complete_login(self, request, app, token, raw_token):
+        token.expires_at = datetime.datetime.fromtimestamp(int(raw_token['edam_expires']) / 1000.0)
+        extra_data = raw_token
+        return self.get_provider().sociallogin_from_response(request,
+                                                             extra_data)
+
+
+class EvernoteOAuthCallbackView(OAuthCallbackView):
+    def dispatch(self, request):
+        """
+        Copies inherited view OAuthCallbackView just to patch a couple items.
+        - Fixes blank oauth_token_secret response from Evernote
+        - Adds expires_at assignment (by passing raw token response to extra_data)
+        """
+        login_done_url = reverse(self.adapter.provider_id + "_callback")
+        client = self._get_client(request, login_done_url)
+        if not client.is_valid():
+            if 'denied' in request.GET:
+                error = AuthError.CANCELLED
+            else:
+                error = AuthError.UNKNOWN
+            extra_context = dict(oauth_client=client)
+            return render_authentication_error(
+                request,
+                self.adapter.provider_id,
+                error=error,
+                extra_context=extra_context)
+        app = self.adapter.get_provider().get_app(request)
+        try:
+            access_token = client.get_access_token()
+            access_token['oauth_token_secret'] = ''  # Evernote returns empty oauth_token_secret= kwarg.
+            token = SocialToken(
+                app=app,
+                token=access_token['oauth_token'],
+                token_secret=access_token['oauth_token_secret']
+            )
+            login = self.adapter.complete_login(request, app, token, access_token)
+            login.token = token
+            login.state = SocialLogin.unstash_state(request)
+            return complete_social_login(request, login)
+        except OAuthError as e:
+            return render_authentication_error(
+                request,
+                self.adapter.provider_id,
+                exception=e)
+
+oauth_login = OAuthLoginView.adapter_view(EvernoteOAuthAdapter)
+oauth_callback = EvernoteOAuthCallbackView.adapter_view(EvernoteOAuthAdapter)

--- a/allauth/socialaccount/providers/evernote/views.py
+++ b/allauth/socialaccount/providers/evernote/views.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
+from allauth.socialaccount import app_settings
+
 from allauth.socialaccount.helpers import render_authentication_error
 from allauth.socialaccount.providers.oauth.client import OAuthError
 from allauth.socialaccount.helpers import complete_social_login
@@ -20,9 +22,14 @@ from .provider import EvernoteProvider
 
 class EvernoteOAuthAdapter(OAuthAdapter):
     provider_id = EvernoteProvider.id
-    request_token_url = 'https://sandbox.evernote.com/oauth'
-    access_token_url = 'https://sandbox.evernote.com/oauth'
-    authorize_url = 'https://sandbox.evernote.com/OAuth.action'
+    settings = app_settings.PROVIDERS.get(provider_id, {})
+    request_token_url = 'https://%s/oauth' % (settings.get('EVERNOTE_HOSTNAME', 'sandbox.evernote.com'))
+    access_token_url = 'https://%s/oauth' % (settings.get('EVERNOTE_HOSTNAME', 'sandbox.evernote.com'))
+    authorize_url = 'https://%s/OAuth.action' % (settings.get('EVERNOTE_HOSTNAME', 'sandbox.evernote.com'))
+
+    def __init__(self, *args, **kwargs):
+        print self.authorize_url
+        super(EvernoteOAuthAdapter, self).__init__(*args, **kwargs)
 
     def complete_login(self, request, app, token, raw_token):
         token.expires_at = datetime.datetime.fromtimestamp(int(raw_token['edam_expires']) / 1000.0)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -334,6 +334,12 @@ Evernote
 
 Register your OAuth2 application at `https://dev.evernote.com/doc/articles/authentication.php`.
 
+    SOCIALACCOUNT_PROVIDERS = {
+        'evernote': {
+            'EVERNOTE_HOSTNAME': 'evernote.com'  # defaults to sandbox.evernote.com
+        }
+    }
+
 
 Stack Exchange
 --------------

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -329,6 +329,12 @@ latter.
 Development callback URL
     http://example.com/accounts/soundcloud/login/callback/
 
+Evernote
+----------
+
+Register your OAuth2 application at `https://dev.evernote.com/doc/articles/authentication.php`.
+
+
 Stack Exchange
 --------------
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.douban',
     'allauth.socialaccount.providers.dropbox',
     'allauth.socialaccount.providers.dropbox_oauth2',
+    'allauth.socialaccount.providers.evernote',
     'allauth.socialaccount.providers.feedly',
     'allauth.socialaccount.providers.facebook',
     'allauth.socialaccount.providers.flickr',


### PR DESCRIPTION
I ended up copying/pasting the entire `OAuthCallbackView` to fix a `KeyError` because Evernote doesn't return an `oauth_token_secret`:

https://github.com/pztrick/django-allauth/compare/pennersr:master...feature/evernote_oauth#diff-6be7fa52b030f92e42ec8b081697b3cfR57

We could make the `OAuthCallbackView` use `access_token.get('oauth_token_secret', None)` to avoid the `KeyError` but wasn't sure if this is a desired approach / if the KeyError should in fact occur for other services.