### PR TITLE
Prefer stdlib importlib

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Jeff Triplett
 John Bazik
 Jonas Aule
 Josh Owen
+Josh Wright
 Joshua Sorenson
 Justin Michalicek
 Justin Pogrob

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -7,7 +7,6 @@ from django.core.urlresolvers import reverse
 from django.core import exceptions
 from django.db.models import Q
 from django.utils.translation import pgettext, ugettext_lazy as _, ugettext
-from django.utils.importlib import import_module
 
 from django.contrib.auth import authenticate
 from django.contrib.auth.tokens import default_token_generator
@@ -24,6 +23,10 @@ from .app_settings import AuthenticationMethod
 from . import app_settings
 from .adapter import get_adapter
 
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 class PasswordField(forms.CharField):
 

--- a/allauth/socialaccount/providers/__init__.py
+++ b/allauth/socialaccount/providers/__init__.py
@@ -1,5 +1,10 @@
 from django.conf import settings
-from django.utils import importlib
+
+try:
+    import importlib
+except ImportError:
+    from django.utils import importlib
+
 
 class ProviderRegistry(object):
     def __init__(self):

--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -4,10 +4,14 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.utils.importlib import import_module
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.core import mail
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 from allauth.socialaccount.tests import create_oauth2_tests
 from allauth.account import app_settings as account_settings

--- a/allauth/urls.py
+++ b/allauth/urls.py
@@ -1,5 +1,9 @@
 from django.conf.urls import url, patterns, include
-from django.utils import importlib
+
+try:
+    import importlib
+except ImportError:
+    from django.utils import importlib
 
 from allauth.socialaccount import providers
 
@@ -8,7 +12,7 @@ from . import app_settings
 urlpatterns = patterns('', url('^', include('allauth.account.urls')))
 
 if app_settings.SOCIALACCOUNT_ENABLED:
-    urlpatterns += patterns('', url('^social/', 
+    urlpatterns += patterns('', url('^social/',
                                     include('allauth.socialaccount.urls')))
 
 for provider in providers.registry.get_list():

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -8,13 +8,18 @@ from django.core import urlresolvers
 from django.db.models import FieldDoesNotExist
 from django.db.models.fields import (DateTimeField, DateField,
                                      EmailField, TimeField)
-from django.utils import importlib, six, dateparse
+from django.utils import six, dateparse
 from django.utils.datastructures import SortedDict
 from django.core.serializers.json import DjangoJSONEncoder
 try:
     from django.utils.encoding import force_text
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
+
+try:
+    import importlib
+except:
+    from django.utils import importlib
 
 
 def _generate_unique_username_base(txts):


### PR DESCRIPTION
This addresses a DeprecationWarning in Django 1.8. It falls back to the
importlib provided in django.utils, as there are still versions of
Django that support Python <= 2.6.