### PR TITLE
Strip away empty params in OAuth2 client on login

### DIFF
--- a/allauth/socialaccount/providers/oauth2/client.py
+++ b/allauth/socialaccount/providers/oauth2/client.py
@@ -46,6 +46,7 @@ class OAuth2Client(object):
                 'scope': self.scope,
                 'code': code}
         params = None
+        self._strip_empty_keys(data)
         url = self.access_token_url
         if self.access_token_method == 'GET':
             params = data
@@ -67,3 +68,11 @@ class OAuth2Client(object):
             raise OAuth2Error('Error retrieving access token: %s'
                               % resp.content)
         return access_token
+
+    def _strip_empty_keys(self, params):
+        """Added because the Dropbox OAuth2 flow doesn't 
+        work when scope is passed in, which is empty.
+        """
+        keys = [k for k, v in params.items() if v == '']
+        for key in keys:
+            del params[key]


### PR DESCRIPTION
I'm working on an update to the Dropbox provider, so that it'll work with OAuth2, and noticed that Dropbox doesn't work with the `scope` attribute.

I'm hoping this fix will be able to easily take care of that issue and at the same time not affect other providers.

My thinking is that if the key is empty the remote side ought to accept the value even when missing, having some kind of default.