### PR TITLE
add douban provider, which is a very popular social site in China

### DIFF
--- a/allauth/socialaccount/providers/douban/models.py
+++ b/allauth/socialaccount/providers/douban/models.py
@@ -1,0 +1,1 @@
+# Create your models here.

--- a/allauth/socialaccount/providers/douban/provider.py
+++ b/allauth/socialaccount/providers/douban/provider.py
@@ -1,0 +1,32 @@
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class DoubanAccount(ProviderAccount):
+    def get_profile_url(self):
+        return self.account.extra_data.get('alt')
+
+    def get_avatar_url(self):
+        return self.account.extra_data.get('large_avatar')
+
+    def to_str(self):
+        dflt = super(DoubanAccount, self).to_str()
+        return self.account.extra_data.get('name', dflt)
+
+
+class DoubanProvider(OAuth2Provider):
+    id = 'douban'
+    name = 'Douban'
+    package = 'allauth.socialaccount.providers.douban'
+    account_class = DoubanAccount
+
+    def extract_uid(self, data):
+        return data['id']
+
+    def extract_common_fields(self, data):
+        return dict(username=data.get('id'),
+                    name=data.get('name'))
+
+
+providers.registry.register(DoubanProvider)

--- a/allauth/socialaccount/providers/douban/tests.py
+++ b/allauth/socialaccount/providers/douban/tests.py
@@ -1,0 +1,11 @@
+from allauth.socialaccount.tests import create_oauth2_tests
+from allauth.tests import MockedResponse
+from allauth.socialaccount.providers import registry
+
+from .provider import WeiboProvider
+
+class WeiboTests(create_oauth2_tests(registry.by_id(WeiboProvider.id))):
+    def get_mocked_response(self):
+        return MockedResponse(200, """{"bi_followers_count": 0, "domain": "", "avatar_large": "http://tp3.sinaimg.cn/3195025850/180/0/0", "block_word": 0, "star": 0, "id": 3195025850, "city": "1", "verified": false, "follow_me": false, "verified_reason": "", "followers_count": 6, "location": "\u5317\u4eac \u4e1c\u57ce\u533a", "mbtype": 0, "profile_url": "u/3195025850", "province": "11", "statuses_count": 0, "description": "", "friends_count": 0, "online_status": 0, "mbrank": 0, "idstr": "3195025850", "profile_image_url": "http://tp3.sinaimg.cn/3195025850/50/0/0", "allow_all_act_msg": false, "allow_all_comment": true, "geo_enabled": true, "name": "pennersr", "lang": "zh-cn", "weihao": "", "remark": "", "favourites_count": 0, "screen_name": "pennersr", "url": "", "gender": "f", "created_at": "Tue Feb 19 19:43:39 +0800 2013", "verified_type": -1, "following": false}
+
+""")

--- a/allauth/socialaccount/providers/douban/tests.py
+++ b/allauth/socialaccount/providers/douban/tests.py
@@ -2,10 +2,9 @@ from allauth.socialaccount.tests import create_oauth2_tests
 from allauth.tests import MockedResponse
 from allauth.socialaccount.providers import registry
 
-from .provider import WeiboProvider
+from .provider import DoubanProvider
 
-class WeiboTests(create_oauth2_tests(registry.by_id(WeiboProvider.id))):
+class WeiboTests(create_oauth2_tests(registry.by_id(DoubanProvider.id))):
     def get_mocked_response(self):
-        return MockedResponse(200, """{"bi_followers_count": 0, "domain": "", "avatar_large": "http://tp3.sinaimg.cn/3195025850/180/0/0", "block_word": 0, "star": 0, "id": 3195025850, "city": "1", "verified": false, "follow_me": false, "verified_reason": "", "followers_count": 6, "location": "\u5317\u4eac \u4e1c\u57ce\u533a", "mbtype": 0, "profile_url": "u/3195025850", "province": "11", "statuses_count": 0, "description": "", "friends_count": 0, "online_status": 0, "mbrank": 0, "idstr": "3195025850", "profile_image_url": "http://tp3.sinaimg.cn/3195025850/50/0/0", "allow_all_act_msg": false, "allow_all_comment": true, "geo_enabled": true, "name": "pennersr", "lang": "zh-cn", "weihao": "", "remark": "", "favourites_count": 0, "screen_name": "pennersr", "url": "", "gender": "f", "created_at": "Tue Feb 19 19:43:39 +0800 2013", "verified_type": -1, "following": false}
-
+        return MockedResponse(200, """{"name": "guoqiao", "created": "2009-02-18 01:07:52", "is_suicide": false, "alt": "http://www.douban.com/people/qguo/", "avatar": "http://img3.douban.com/icon/u3659811-3.jpg", "signature": "", "uid": "qguo", "is_banned": false, "desc": "\u4e0d\u662f\u5f88\u7231\u8bfb\u4e66", "type": "user", "id": "3659811", "large_avatar": "http://img3.douban.com/icon/up3659811-3.jpg"}
 """)

--- a/allauth/socialaccount/providers/douban/urls.py
+++ b/allauth/socialaccount/providers/douban/urls.py
@@ -1,0 +1,6 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+
+from .provider import DoubanProvider
+
+urlpatterns = default_urlpatterns(DoubanProvider)
+

--- a/allauth/socialaccount/providers/douban/views.py
+++ b/allauth/socialaccount/providers/douban/views.py
@@ -1,0 +1,24 @@
+import requests
+
+from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
+                                                          OAuth2LoginView,
+                                                          OAuth2CallbackView)
+
+from .provider import DoubanProvider
+
+
+class DoubanOAuth2Adapter(OAuth2Adapter):
+    provider_id = DoubanProvider.id
+    access_token_url = 'https://www.douban.com/service/auth2/token'
+    authorize_url = 'https://www.douban.com/service/auth2/auth'
+    profile_url = 'https://api.douban.com/v2/user/~me'
+
+    def complete_login(self, request, app, token, **kwargs):
+        headers = {'Authorization':'Bearer %s' % token.token}
+        resp = requests.get(self.profile_url, headers=headers)
+        extra_data = resp.json()
+        return self.get_provider().sociallogin_from_response(request, extra_data)
+
+
+oauth2_login = OAuth2LoginView.adapter_view(DoubanOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(DoubanOAuth2Adapter)


### PR DESCRIPTION
I'm a django web developer from China. After trying a lot of auth apps for django, I find django-allauth is the best one of them which saves me a lot of time for the signup and accounts stuff.  
I tried to fork django-allauth to support douban on one of my site: http://feedfree.me/  , and it works well for me. I hope douban support can be merged to the official repo, so a lot of Chinese sites can use it later.