### PR TITLE
Add Dropbox OAuth2 provider

### DIFF
--- a/allauth/socialaccount/providers/dropbox_oauth2/models.py
+++ b/allauth/socialaccount/providers/dropbox_oauth2/models.py
@@ -1,0 +1,1 @@
+# Create your models here.

--- a/allauth/socialaccount/providers/dropbox_oauth2/provider.py
+++ b/allauth/socialaccount/providers/dropbox_oauth2/provider.py
@@ -1,0 +1,24 @@
+from allauth.account.adapter import get_adapter
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class DropboxAccount(ProviderAccount):
+    pass
+
+
+class DropboxProvider(OAuth2Provider):
+    id = 'dropbox_oauth2'
+    name = 'Dropbox'
+    package = 'allauth.socialaccount.providers.dropbox_oauth2'
+    account_class = DropboxAccount
+
+    def extract_uid(self, data):
+        return data['uid']
+
+    def extract_common_fields(self, data):
+        return dict(name=data.get('display_name'),
+                    email=data.get('email'))
+
+providers.registry.register(DropboxProvider)

--- a/allauth/socialaccount/providers/dropbox_oauth2/tests.py
+++ b/allauth/socialaccount/providers/dropbox_oauth2/tests.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from allauth.socialaccount.tests import create_oauth2_tests
+from allauth.tests import MockedResponse
+from allauth.socialaccount.providers import registry
+
+from .provider import DropboxProvider
+
+
+class DropboxTests(create_oauth2_tests(registry.by_id(DropboxProvider.id))):
+    def get_mocked_response(self):
+        return [MockedResponse(200, """{
+            "display_name": "Björn Andersson",
+            "name_details": {
+                "surname": "Andersson",
+                "familiar_name": "Björn",
+                "given_name": "Björn"
+                },
+            "locale": "en",
+            "email": "test@example.se",
+            "uid": 1234567890,
+            "email_verified": true,
+            "quota_info": {
+                "shared": 3195052017,
+                "datastores": 0,
+                "quota": 61337501696,
+                "normal": 15455059441
+                },
+            "is_paired": true,
+            "team": null,
+            "referral_link": "https://db.tt/UzhBTVjU",
+            "country": "SE"
+        }""")]

--- a/allauth/socialaccount/providers/dropbox_oauth2/urls.py
+++ b/allauth/socialaccount/providers/dropbox_oauth2/urls.py
@@ -1,0 +1,5 @@
+from allauth.socialaccount.providers.oauth.urls import default_urlpatterns
+
+from .provider import DropboxProvider
+
+urlpatterns = default_urlpatterns(DropboxProvider)

--- a/allauth/socialaccount/providers/dropbox_oauth2/views.py
+++ b/allauth/socialaccount/providers/dropbox_oauth2/views.py
@@ -1,0 +1,32 @@
+from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
+                                                          OAuth2LoginView,
+                                                          OAuth2CallbackView)
+import requests
+
+from .provider import DropboxProvider
+
+
+class DropboxOAuthAdapter(OAuth2Adapter):
+    provider_id = DropboxProvider.id
+    access_token_url = 'https://api.dropbox.com/1/oauth2/token'
+    authorize_url = 'https://www.dropbox.com/1/oauth2/authorize'
+    profile_url = 'https://api.dropbox.com/1/account/info'
+    redirect_uri_protocol = 'https'
+
+    def complete_login(self, request, app, token, **kwargs):
+        extra_data = requests.get(self.profile_url, params={
+            'access_token': token.token
+        })
+
+        # This only here because of weird response from the test suite
+        if isinstance(extra_data, list):
+            extra_data = extra_data[0]
+
+        return self.get_provider().sociallogin_from_response(
+            request,
+            extra_data.json()
+        )
+
+
+oauth_login = OAuth2LoginView.adapter_view(DropboxOAuthAdapter)
+oauth_callback = OAuth2CallbackView.adapter_view(DropboxOAuthAdapter)


### PR DESCRIPTION
A basic provider which will as far as I can tell works well. 
I've gotten an access token and users to login, so I'm happy with it for now. :)

For this commit to work it relies on PR #820.
This closes issue #821.