### PR TITLE
Bugfix: avoid using mutable objects as default parameter values

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -247,13 +247,15 @@ class DefaultAccountAdapter(object):
         return password
 
     def add_message(self, request, level, message_template,
-                    message_context={}, extra_tags=''):
+                    message_context=None, extra_tags=''):
         """
         Wrapper of `django.contrib.messages.add_message`, that reads
         the message text from a template.
         """
         if 'django.contrib.messages' in settings.INSTALLED_APPS:
             try:
+                if message_context is None:
+                    message_context = {}
                 message = render_to_string(message_template,
                                            message_context).strip()
                 if message:

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -94,7 +94,7 @@ def user_email(user, *args):
 
 
 def perform_login(request, user, email_verification,
-                  redirect_url=None, signal_kwargs={},
+                  redirect_url=None, signal_kwargs=None,
                   signup=False):
     """
     Keyword arguments:
@@ -126,6 +126,9 @@ def perform_login(request, user, email_verification,
     get_adapter().login(request, user)
     response = HttpResponseRedirect(
         get_login_redirect_url(request, redirect_url))
+
+    if signal_kwargs is None:
+        signal_kwargs = {}
     signals.user_logged_in.send(sender=user.__class__,
                                 request=request,
                                 response=response,
@@ -140,7 +143,9 @@ def perform_login(request, user, email_verification,
 
 
 def complete_signup(request, user, email_verification, success_url,
-                    signal_kwargs={}):
+                    signal_kwargs=None):
+    if signal_kwargs is None:
+        signal_kwargs = {}
     signals.user_signed_up.send(sender=user.__class__,
                                 request=request,
                                 user=user,

--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -38,7 +38,7 @@ class DefaultSocialAccountAdapter(object):
                              provider_id,
                              error=None,
                              exception=None,
-                             extra_context={}):
+                             extra_context=None):
         """
         Invoked when there is an error in the authentication cycle. In this
         case, pre_social_login will not be reached.

--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -63,8 +63,10 @@ def render_authentication_error(request,
                                 provider_id,
                                 error=AuthError.UNKNOWN,
                                 exception=None,
-                                extra_context={}):
+                                extra_context=None):
     try:
+        if extra_context is None:
+            extra_context = {}
         get_adapter().authentication_error(request,
                                            provider_id,
                                            error=error,

--- a/allauth/tests.py
+++ b/allauth/tests.py
@@ -12,7 +12,10 @@ from . import utils
 
 
 class MockedResponse(object):
-    def __init__(self, status_code, content, headers={}):
+    def __init__(self, status_code, content, headers=None):
+        if headers is None:
+            headers = {}
+
         self.status_code = status_code
         self.content = content.encode('utf8')
         self.headers = headers


### PR DESCRIPTION
Current default parameter values are evaluated at function definition
time, thus enabling shared mutable state. This is very dangerous as the
code is unpredictable and can end up in unexpected behavior. Using
immutable objects as default parameters avoids nasty surprises.

Refs. http://python.net/~goodger/projects/pycon/2007/idiomatic/handout.html#default-parameter-values