### PR TITLE
Remove references to (now deprecated) request.REQUEST

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -21,7 +21,7 @@ except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
 from ..utils import (import_callable, valid_email_or_none,
-                     get_user_model)
+                     get_user_model, get_request_param)
 
 from . import signals
 
@@ -35,7 +35,7 @@ def get_next_redirect_url(request, redirect_field_name="next"):
     Returns the next URL to redirect to, if it was explicitly passed
     via the request.
     """
-    redirect_to = request.REQUEST.get(redirect_field_name)
+    redirect_to = get_request_param(request, redirect_field_name)
     if not get_adapter().is_safe_url(redirect_to):
         redirect_to = None
     return redirect_to

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -14,7 +14,7 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.decorators import method_decorator
 
 from ..exceptions import ImmediateHttpResponse
-from ..utils import get_user_model, get_form_class
+from ..utils import get_user_model, get_form_class, get_request_param
 
 from .utils import (get_next_redirect_url, complete_signup,
                     get_login_redirect_url, perform_login,
@@ -119,8 +119,8 @@ class LoginView(RedirectAuthenticatedUserMixin,
         signup_url = passthrough_next_redirect_url(self.request,
                                                    reverse("account_signup"),
                                                    self.redirect_field_name)
-        redirect_field_value = self.request.REQUEST \
-            .get(self.redirect_field_name)
+        redirect_field_value = get_request_param(self.request,
+                                                 self.redirect_field_name)
         ret.update({"signup_url": signup_url,
                     "site": Site.objects.get_current(),
                     "redirect_field_name": self.redirect_field_name,
@@ -193,7 +193,8 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
                                                   reverse("account_login"),
                                                   self.redirect_field_name)
         redirect_field_name = self.redirect_field_name
-        redirect_field_value = self.request.REQUEST.get(redirect_field_name)
+        redirect_field_value = get_request_param(self.request,
+                                                 redirect_field_name)
         ret.update({"login_url": login_url,
                     "redirect_field_name": redirect_field_name,
                     "redirect_field_value": redirect_field_value})
@@ -637,8 +638,8 @@ class LogoutView(TemplateResponseMixin, View):
 
     def get_context_data(self, **kwargs):
         ctx = kwargs
-        redirect_field_value = self.request.REQUEST \
-            .get(self.redirect_field_name)
+        redirect_field_value = get_request_param(self.request,
+                                                 self.redirect_field_name)
         ctx.update({
             "redirect_field_name": self.redirect_field_name,
             "redirect_field_value": redirect_field_value})

--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -21,6 +21,7 @@ from allauth.utils import (get_user_model, serialize_instance,
 from . import app_settings
 from . import providers
 from .fields import JSONField
+from ..utils import get_request_param
 
 
 class SocialAppManager(models.Manager):
@@ -280,9 +281,9 @@ class SocialLogin(object):
         next_url = get_next_redirect_url(request)
         if next_url:
             state['next'] = next_url
-        state['process'] = request.REQUEST.get('process', 'login')
-        state['scope'] = request.REQUEST.get('scope', '')
-        state['auth_params'] = request.REQUEST.get('auth_params', '')
+        state['process'] = get_request_param(request, 'process', 'login')
+        state['scope'] = get_request_param(request, 'scope', '')
+        state['auth_params'] = get_request_param(request, 'auth_params', '')
         return state
 
     @classmethod

--- a/allauth/socialaccount/providers/oauth/client.py
+++ b/allauth/socialaccount/providers/oauth/client.py
@@ -9,6 +9,8 @@ from django.http import HttpResponseRedirect
 from django.utils.http import urlencode
 from django.utils.translation import gettext as _
 
+from allauth.utils import get_request_param
+
 try:
     from urllib.parse import parse_qsl, urlparse
 except ImportError:
@@ -97,8 +99,9 @@ class OAuthClient(object):
             # Passing along oauth_verifier is required according to:
             # http://groups.google.com/group/twitter-development-talk/browse_frm/thread/472500cfe9e7cdb9#
             # Though, the custom oauth_callback seems to work without it?
-            if 'oauth_verifier' in self.request.REQUEST:
-                at_url = at_url + '?' + urlencode({'oauth_verifier': self.request.REQUEST['oauth_verifier']})
+            oauth_verifier = get_request_param(self.request, 'oauth_verifier')
+            if oauth_verifier:
+                at_url = at_url + '?' + urlencode({'oauth_verifier': oauth_verifier})
             response = requests.post(url=at_url, auth=oauth)
             if response.status_code not in [200, 201]:
                 raise OAuthError(

--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -15,6 +15,7 @@ from allauth.socialaccount.providers.oauth2.client import (OAuth2Client,
                                                            OAuth2Error)
 from allauth.socialaccount.helpers import complete_social_login
 from allauth.socialaccount.models import SocialToken, SocialLogin
+from allauth.utils import get_request_param
 from ..base import AuthAction, AuthError
 
 
@@ -118,7 +119,7 @@ class OAuth2CallbackView(OAuth2View):
                 login.state = SocialLogin \
                     .verify_and_unstash_state(
                         request,
-                        request.REQUEST.get('state'))
+                        get_request_param(request, 'state'))
             else:
                 login.state = SocialLogin.unstash_state(request)
             return complete_social_login(request, login)

--- a/allauth/socialaccount/providers/openid/views.py
+++ b/allauth/socialaccount/providers/openid/views.py
@@ -30,7 +30,9 @@ def _openid_consumer(request):
 
 def login(request):
     if 'openid' in request.GET or request.method == 'POST':
-        form = LoginForm(request.REQUEST)
+        form = LoginForm(
+            dict(list(request.GET.items()) + list(request.POST.items()))
+        )
         if form.is_valid():
             client = _openid_consumer(request)
             try:
@@ -74,7 +76,7 @@ def login(request):
 def callback(request):
     client = _openid_consumer(request)
     response = client.complete(
-        dict(request.REQUEST.items()),
+        dict(list(request.GET.items()) + list(request.POST.items())),
         request.build_absolute_uri(request.path))
     if response.status == consumer.SUCCESS:
         login = providers.registry \

--- a/allauth/socialaccount/templatetags/socialaccount.py
+++ b/allauth/socialaccount/templatetags/socialaccount.py
@@ -2,6 +2,7 @@ from django.template.defaulttags import token_kwargs
 from django import template
 
 from allauth.socialaccount import providers
+from allauth.utils import get_request_param
 
 register = template.Library()
 
@@ -25,7 +26,7 @@ class ProviderLoginURLNode(template.Node):
         if auth_params is '':
             del query['auth_params']
         if 'next' not in query:
-            next = request.REQUEST.get('next')
+            next = get_request_param(request, 'next')
             if next:
                 query['next'] = next
             elif process == 'redirect':

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -202,3 +202,7 @@ def get_form_class(forms, form_id, default_form):
     if isinstance(form_class, six.string_types):
         form_class = import_attribute(form_class)
     return form_class
+
+
+def get_request_param(request, param, default=None):
+    return request.POST.get(param) or request.GET.get(param, default)


### PR DESCRIPTION
This removes references to request.REQUEST. It should be be completely backwards compatible (it prefers values in request.POST, etc).

Tests pass locally, and I've done _some_ manual testing, but it does impact some code that is not currently covered by the test suite (specifically in the OAuth providers), so please review with care.