### PR TITLE
Update allauth to utilize url namespaces.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,7 @@
 [run]
 include = allauth*
+omit =
+    */migrations/*
+    *__init__*
+    *test*
+    *app_settings*

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ omit =
     *__init__*
     *test*
     *app_settings*
+    allauth/socialaccount/providers/*/models.py

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ pep8.txt
 *.tmp
 virtualenv
 .DS_Store
-
+htmlcov/
+.coverage
 *.prefs

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq sloccount
 install:
- - pip install $DJANGO --use-mirrors
- - pip install . --use-mirrors
+ - pip install $DJANGO
+ - pip install .
  - pip install coverage
 branches:
  only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
  - "3.4"
 env:
   global:
-   - TEST_APPS="allauth account socialaccount amazon angellist bitbucket coinbase feedly foursquare dropbox facebook flickr google github hubic instagram linkedin linkedin_oauth2 mailru odnoklassniki windowslive openid orcid paypal persona soundcloud stackexchange tumblr twitch twitter vimeo vk weibo bitly xing"
+   - TEST_APPS="allauth account socialaccount amazon angellist bitbucket coinbase dropbox feedly foursquare facebook flickr google github hubic instagram linkedin linkedin_oauth2 mailru odnoklassniki windowslive openid orcid paypal persona soundcloud stackexchange tumblr twitch twitter vimeo vk weibo bitly xing"
   matrix:
    - DJANGO=Django==1.4.3
    - DJANGO=Django==1.5

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -28,6 +28,7 @@ try:
 except ImportError:
     from django.utils.importlib import import_module
 
+
 class PasswordField(forms.CharField):
 
     def __init__(self, *args, **kwargs):
@@ -95,7 +96,7 @@ class LoginForm(forms.Form):
                                                          "Login"),
                                           widget=login_widget)
         self.fields["login"] = login_field
-        set_form_field_order(self,  ["login", "password", "remember"])
+        set_form_field_order(self, ["login", "password", "remember"])
         if app_settings.SESSION_REMEMBER is not None:
             del self.fields['remember']
 
@@ -423,7 +424,7 @@ class ResetPasswordForm(forms.Form):
             current_site = Site.objects.get_current()
 
             # send the password reset email
-            path = reverse("account_reset_password_from_key",
+            path = reverse("account:reset_password_from_key",
                            kwargs=dict(uidb36=user_pk_to_url_str(user),
                                        key=temp_key))
             url = build_absolute_uri(request, path,

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -118,7 +118,7 @@ class EmailConfirmation(models.Model):
     def send(self, request, signup=False, **kwargs):
         current_site = kwargs["site"] if "site" in kwargs \
             else Site.objects.get_current()
-        activate_url = reverse("account_confirm_email", args=[self.key])
+        activate_url = reverse("account:confirm_email", args=[self.key])
         activate_url = build_absolute_uri(request,
                                           activate_url,
                                           protocol=app_settings.DEFAULT_HTTP_PROTOCOL)

--- a/allauth/account/templatetags/account.py
+++ b/allauth/account/templatetags/account.py
@@ -4,17 +4,18 @@ from allauth.account.utils import user_display
 
 register = template.Library()
 
+
 class UserDisplayNode(template.Node):
 
     def __init__(self, user, as_var=None):
         self.user_var = template.Variable(user)
         self.as_var = as_var
-    
+
     def render(self, context):
         user = self.user_var.resolve(context)
-        
+
         display = user_display(user)
-        
+
         if self.as_var:
             context[self.as_var] = display
             return ""
@@ -25,14 +26,14 @@ class UserDisplayNode(template.Node):
 def do_user_display(parser, token):
     """
     Example usage::
-    
+
         {% user_display user %}
-    
+
     or if you need to use in a {% blocktrans %}::
-    
+
         {% user_display user as user_display %}
         {% blocktrans %}{{ user_display }} has sent you a gift.{% endblocktrans %}
-    
+
     """
     bits = token.split_contents()
     if len(bits) == 2:
@@ -43,5 +44,5 @@ def do_user_display(parser, token):
         as_var = bits[3]
     else:
         raise template.TemplateSyntaxError("'%s' takes either two or four arguments" % bits[0])
-    
+
     return UserDisplayNode(user, as_var)

--- a/allauth/account/urls.py
+++ b/allauth/account/urls.py
@@ -5,22 +5,22 @@ from . import views
 
 urlpatterns = patterns(
     "",
-    url(r"^signup/$", views.signup, name="account_signup"),
-    url(r"^login/$", views.login, name="account_login"),
-    url(r"^logout/$", views.logout, name="account_logout"),
+    url(r"^signup/$", views.signup, name="signup"),
+    url(r"^login/$", views.login, name="login"),
+    url(r"^logout/$", views.logout, name="logout"),
 
     url(r"^password/change/$", views.password_change,
-        name="account_change_password"),
-    url(r"^password/set/$", views.password_set, name="account_set_password"),
+        name="change_password"),
+    url(r"^password/set/$", views.password_set, name="set_password"),
 
-    url(r"^inactive/$", views.account_inactive, name="account_inactive"),
+    url(r"^inactive/$", views.account_inactive, name="inactive"),
 
     # E-mail
-    url(r"^email/$", views.email, name="account_email"),
+    url(r"^email/$", views.email, name="email"),
     url(r"^confirm-email/$", views.email_verification_sent,
-        name="account_email_verification_sent"),
+        name="email_verification_sent"),
     url(r"^confirm-email/(?P<key>\w+)/$", views.confirm_email,
-        name="account_confirm_email"),
+        name="confirm_email"),
     # Handle old redirects
     url(r"^confirm_email/(?P<key>\w+)/$",
         RedirectView.as_view(url='/accounts/confirm-email/%(key)s/',
@@ -28,12 +28,12 @@ urlpatterns = patterns(
 
     # password reset
     url(r"^password/reset/$", views.password_reset,
-        name="account_reset_password"),
+        name="reset_password"),
     url(r"^password/reset/done/$", views.password_reset_done,
-        name="account_reset_password_done"),
+        name="reset_password_done"),
     url(r"^password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$",
         views.password_reset_from_key,
-        name="account_reset_password_from_key"),
+        name="reset_password_from_key"),
     url(r"^password/reset/key/done/$", views.password_reset_from_key_done,
-        name="account_reset_password_from_key_done"),
+        name="reset_password_from_key_done"),
 )

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -116,7 +116,7 @@ def perform_login(request, user, email_verification,
         if not has_verified_email:
             send_email_confirmation(request, user, signup=signup)
             return HttpResponseRedirect(
-                reverse('account_email_verification_sent'))
+                reverse('account:email_verification_sent'))
     # Local users are stopped due to form validation checking
     # is_active, yet, adapter methods could toy with is_active in a
     # `user_signed_up` signal. Furthermore, social users should be

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -117,7 +117,7 @@ class LoginView(RedirectAuthenticatedUserMixin,
     def get_context_data(self, **kwargs):
         ret = super(LoginView, self).get_context_data(**kwargs)
         signup_url = passthrough_next_redirect_url(self.request,
-                                                   reverse("account_signup"),
+                                                   reverse("account:signup"),
                                                    self.redirect_field_name)
         redirect_field_value = self.request.REQUEST \
             .get(self.redirect_field_name)
@@ -190,7 +190,7 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
             .get('account_verified_email', None)
         ret = super(SignupView, self).get_context_data(**kwargs)
         login_url = passthrough_next_redirect_url(self.request,
-                                                  reverse("account_login"),
+                                                  reverse("account:login"),
                                                   self.redirect_field_name)
         redirect_field_name = self.redirect_field_name
         redirect_field_value = self.request.REQUEST.get(redirect_field_name)
@@ -300,7 +300,7 @@ confirm_email = ConfirmEmailView.as_view()
 class EmailView(AjaxCapableProcessFormViewMixin, FormView):
     template_name = "account/email.html"
     form_class = AddEmailForm
-    success_url = reverse_lazy('account_email')
+    success_url = reverse_lazy('account:email')
 
     def get_form_class(self):
         return get_form_class(app_settings.FORMS, 'add_email', self.form_class)
@@ -338,7 +338,7 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
                 res = self._action_remove(request)
             elif "action_primary" in request.POST:
                 res = self._action_primary(request)
-            res = res or HttpResponseRedirect(reverse('account_email'))
+            res = res or HttpResponseRedirect(reverse('account:email'))
             # Given that we bypassed AjaxCapableProcessFormViewMixin,
             # we'll have to call invoke it manually...
             res = _ajax_response(request, res)
@@ -442,7 +442,7 @@ email = login_required(EmailView.as_view())
 class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
     template_name = "account/password_change.html"
     form_class = ChangePasswordForm
-    success_url = reverse_lazy("account_change_password")
+    success_url = reverse_lazy("account:change_password")
 
     def get_form_class(self):
         return get_form_class(app_settings.FORMS,
@@ -452,7 +452,7 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
     @sensitive_post_parameters_m
     def dispatch(self, request, *args, **kwargs):
         if not request.user.has_usable_password():
-            return HttpResponseRedirect(reverse('account_set_password'))
+            return HttpResponseRedirect(reverse('account:set_password'))
         return super(PasswordChangeView, self).dispatch(request, *args,
                                                         **kwargs)
 
@@ -484,7 +484,7 @@ password_change = login_required(PasswordChangeView.as_view())
 class PasswordSetView(AjaxCapableProcessFormViewMixin, FormView):
     template_name = "account/password_set.html"
     form_class = SetPasswordForm
-    success_url = reverse_lazy("account_set_password")
+    success_url = reverse_lazy("account:set_password")
 
     def get_form_class(self):
         return get_form_class(app_settings.FORMS,
@@ -494,7 +494,7 @@ class PasswordSetView(AjaxCapableProcessFormViewMixin, FormView):
     @sensitive_post_parameters_m
     def dispatch(self, request, *args, **kwargs):
         if request.user.has_usable_password():
-            return HttpResponseRedirect(reverse('account_change_password'))
+            return HttpResponseRedirect(reverse('account:change_password'))
         return super(PasswordSetView, self).dispatch(request, *args, **kwargs)
 
     def get_form_kwargs(self):
@@ -524,7 +524,7 @@ password_set = login_required(PasswordSetView.as_view())
 class PasswordResetView(AjaxCapableProcessFormViewMixin, FormView):
     template_name = "account/password_reset.html"
     form_class = ResetPasswordForm
-    success_url = reverse_lazy("account_reset_password_done")
+    success_url = reverse_lazy("account:reset_password_done")
 
     def get_form_class(self):
         return get_form_class(app_settings.FORMS,
@@ -555,7 +555,7 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
     template_name = "account/password_reset_from_key.html"
     form_class = ResetPasswordKeyForm
     token_generator = default_token_generator
-    success_url = reverse_lazy("account_reset_password_from_key_done")
+    success_url = reverse_lazy("account:reset_password_from_key_done")
 
     def get_form_class(self):
         return get_form_class(app_settings.FORMS,

--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -104,7 +104,7 @@ class DefaultSocialAccountAdapter(object):
         connecting a social account.
         """
         assert request.user.is_authenticated()
-        url = reverse('socialaccount_connections')
+        url = reverse('socialaccount:connections')
         return url
 
     def validate_disconnect(self, account, accounts):

--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -25,7 +25,7 @@ def _process_signup(request, sociallogin):
                                                        sociallogin)
     if not auto_signup:
         request.session['socialaccount_sociallogin'] = sociallogin.serialize()
-        url = reverse('socialaccount_signup')
+        url = reverse('socialaccount:signup')
         ret = HttpResponseRedirect(url)
     else:
         # Ok, auto signup it is, at least the e-mail address is ok.
@@ -75,7 +75,7 @@ def render_authentication_error(request,
     except ImmediateHttpResponse as e:
         return e.response
     if error == AuthError.CANCELLED:
-        return HttpResponseRedirect(reverse('socialaccount_login_cancelled'))
+        return HttpResponseRedirect(reverse('socialaccount:login_cancelled'))
     context = {
         'auth_error': {
             'provider': provider_id,
@@ -93,7 +93,7 @@ def _add_social_account(request, sociallogin):
     if request.user.is_anonymous():
         # This should not happen. Simply redirect to the connections
         # view (which has a login required)
-        return HttpResponseRedirect(reverse('socialaccount_connections'))
+        return HttpResponseRedirect(reverse('socialaccount:connections'))
     level = messages.INFO
     message = 'socialaccount/messages/account_connected.txt'
     if sociallogin.is_existing:

--- a/allauth/socialaccount/providers/coinbase/tests.py
+++ b/allauth/socialaccount/providers/coinbase/tests.py
@@ -4,6 +4,7 @@ from allauth.socialaccount.providers import registry
 
 from .provider import CoinbaseProvider
 
+
 class CoinbaseTests(create_oauth2_tests(registry.by_id(CoinbaseProvider.id))):
     def get_mocked_response(self):
         return MockedResponse(200, """

--- a/allauth/socialaccount/providers/coinbase/views.py
+++ b/allauth/socialaccount/providers/coinbase/views.py
@@ -1,10 +1,10 @@
 import requests
-from allauth.socialaccount import providers
 from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
                                                           OAuth2LoginView,
                                                           OAuth2CallbackView)
 
 from .provider import CoinbaseProvider
+
 
 class CoinbaseOAuth2Adapter(OAuth2Adapter):
     provider_id = CoinbaseProvider.id

--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -22,7 +22,7 @@ from .locale import get_default_locale_callable
 
 
 GRAPH_API_VERSION = getattr(settings, 'SOCIALACCOUNT_PROVIDERS', {}).get(
-    'facebook',  {}).get('VERSION', 'v2.2')
+    'facebook', {}).get('VERSION', 'v2.2')
 GRAPH_API_URL = 'https://graph.facebook.com/' + GRAPH_API_VERSION
 
 NONCE_SESSION_KEY = 'allauth_facebook_nonce'
@@ -124,12 +124,12 @@ class FacebookProvider(OAuth2Provider):
             "loginOptions": self.get_fb_login_options(request),
             "loginByTokenUrl": abs_uri('facebook_login_by_token'),
             "channelUrl": abs_uri('facebook_channel'),
-            "cancelUrl": abs_uri('socialaccount_login_cancelled'),
-            "logoutUrl": abs_uri('account_logout'),
+            "cancelUrl": abs_uri('socialaccount:login_cancelled'),
+            "logoutUrl": abs_uri('account:logout'),
             "loginUrl": request.build_absolute_uri(self.get_login_url(
                 request,
                 method='oauth2')),
-            "errorUrl": abs_uri('socialaccount_login_error'),
+            "errorUrl": abs_uri('socialaccount:login_error'),
             "csrfToken": get_token(request)
         }
         ctx = {'fb_data': mark_safe(json.dumps(fb_data))}

--- a/allauth/socialaccount/providers/facebook/tests.py
+++ b/allauth/socialaccount/providers/facebook/tests.py
@@ -70,13 +70,13 @@ class FacebookTests(create_oauth2_tests(registry.by_id(FacebookProvider.id))):
 
     def test_media_js(self):
         provider = providers.registry.by_id(FacebookProvider.id)
-        request = RequestFactory().get(reverse('account_login'))
+        request = RequestFactory().get(reverse('account:login'))
         request.session = {}
         script = provider.media_js(request)
         self.assertTrue('"appId": "app123id"' in script)
 
     def test_login_by_token(self):
-        resp = self.client.get(reverse('account_login'))
+        resp = self.client.get(reverse('account:login'))
         with patch('allauth.socialaccount.providers.facebook.views'
                    '.requests') as requests_mock:
             mocks = [self.get_mocked_response().json()]
@@ -93,7 +93,7 @@ class FacebookTests(create_oauth2_tests(registry.by_id(FacebookProvider.id))):
                 'AUTH_PARAMS': {'auth_type': 'reauthenticate'},
                 'VERIFIED_EMAIL': False}})
     def test_login_by_token_reauthenticate(self):
-        resp = self.client.get(reverse('account_login'))
+        resp = self.client.get(reverse('account:login'))
         nonce = json.loads(resp.context['fb_data'])['loginOptions']['auth_nonce']
         with patch('allauth.socialaccount.providers.facebook.views'
                    '.requests') as requests_mock:

--- a/allauth/socialaccount/providers/oauth2/urls.py
+++ b/allauth/socialaccount/providers/oauth2/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import patterns, url, include
 
 def default_urlpatterns(provider):
     urlpatterns = patterns(provider.package + '.views',
-                           url('^login/$', 'oauth2_login', 
+                           url('^login/$', 'oauth2_login',
                                name=provider.id + "_login"),
                            url('^login/callback/$', 'oauth2_callback',
                                name=provider.id + "_callback"))

--- a/allauth/socialaccount/tests.py
+++ b/allauth/socialaccount/tests.py
@@ -46,12 +46,12 @@ def create_oauth_tests(provider):
                           % self.provider.id)
             return
         resp = self.login(resp_mocks)
-        self.assertRedirects(resp, reverse('socialaccount_signup'))
-        resp = self.client.get(reverse('socialaccount_signup'))
+        self.assertRedirects(resp, reverse('socialaccount:signup'))
+        resp = self.client.get(reverse('socialaccount:signup'))
         sociallogin = resp.context['form'].sociallogin
         data = dict(email=user_email(sociallogin.user),
                     username=str(random.randrange(1000, 10000000)))
-        resp = self.client.post(reverse('socialaccount_signup'),
+        resp = self.client.post(reverse('socialaccount:signup'),
                                 data=data)
         self.assertEqual('http://testserver/accounts/profile/',
                          resp['location'])
@@ -84,7 +84,7 @@ def create_oauth_tests(provider):
                                    dict(process=process))
         p = urlparse(resp['location'])
         q = parse_qs(p.query)
-        complete_url = reverse(self.provider.id+'_callback')
+        complete_url = reverse(self.provider.id + '_callback')
         self.assertGreater(q['oauth_callback'][0]
                            .find(complete_url), 0)
         with mocked_response(MockedResponse(200,
@@ -100,7 +100,7 @@ def create_oauth_tests(provider):
             'login': login,
             'test_login': test_login,
             'get_mocked_response': get_mocked_response}
-    class_name = 'OAuth2Tests_'+provider.id
+    class_name = 'OAuth2Tests_' + provider.id
     Class = type(class_name, (TestCase,), impl)
     Class.provider = provider
     return Class
@@ -136,7 +136,7 @@ def create_oauth2_tests(provider):
                           % self.provider.id)
             return
         resp = self.login(resp_mock,)
-        self.assertRedirects(resp, reverse('socialaccount_signup'))
+        self.assertRedirects(resp, reverse('socialaccount:signup'))
 
     def test_account_tokens(self, multiple_login=False):
         email = 'some@mail.com'
@@ -184,7 +184,7 @@ def create_oauth2_tests(provider):
                                dict(process=process))
         p = urlparse(resp['location'])
         q = parse_qs(p.query)
-        complete_url = reverse(self.provider.id+'_callback')
+        complete_url = reverse(self.provider.id + '_callback')
         self.assertGreater(q['redirect_uri'][0]
                            .find(complete_url), 0)
         response_json = self \
@@ -208,7 +208,7 @@ def create_oauth2_tests(provider):
             test_account_refresh_token_saved_next_login,
             'get_login_response_json': get_login_response_json,
             'get_mocked_response': get_mocked_response}
-    class_name = 'OAuth2Tests_'+provider.id
+    class_name = 'OAuth2Tests_' + provider.id
     Class = type(class_name, (TestCase,), impl)
     Class.provider = provider
     return Class

--- a/allauth/socialaccount/urls.py
+++ b/allauth/socialaccount/urls.py
@@ -3,8 +3,8 @@ from django.conf.urls import patterns, url
 from . import views
 
 urlpatterns = patterns('',
-    url('^login/cancelled/$', views.login_cancelled, 
-        name='socialaccount_login_cancelled'),
-    url('^login/error/$', views.login_error, name='socialaccount_login_error'),
-    url('^signup/$', views.signup, name='socialaccount_signup'),
-    url('^connections/$', views.connections, name='socialaccount_connections'))
+    url('^login/cancelled/$', views.login_cancelled,
+        name='login_cancelled'),
+    url('^login/error/$', views.login_error, name='login_error'),
+    url('^signup/$', views.signup, name='signup'),
+    url('^connections/$', views.connections, name='connections'))

--- a/allauth/templates/account/email.html
+++ b/allauth/templates/account/email.html
@@ -10,7 +10,7 @@
 {% if user.emailaddress_set.all %}
 <p>{% trans 'The following e-mail addresses are associated with your account:' %}</p>
 
-<form action="{% url 'account_email' %}" class="email_list" method="post">
+<form action="{% url 'account:email' %}" class="email_list" method="post">
 {% csrf_token %}
 <fieldset class="blockLabels">
 
@@ -48,7 +48,7 @@
 
     <h2>{% trans "Add E-mail Address" %}</h2>
 
-    <form method="post" action="{% url 'account_email' %}" class="add_email">
+    <form method="post" action="{% url 'account:email' %}" class="add_email">
         {% csrf_token %}
         {{ form.as_p}}
         <button name="action_add" type="submit">{% trans "Add E-mail" %}</button>

--- a/allauth/templates/account/email_confirm.html
+++ b/allauth/templates/account/email_confirm.html
@@ -16,14 +16,14 @@
         
 <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{email}}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
 
-<form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+<form method="post" action="{% url 'account:confirm_email' confirmation.key %}">
 {% csrf_token %}
     <button type="submit">{% trans 'Confirm' %}</button>
 </form>
 
 {% else %}
 
-{% url 'account_email' as email_url %}
+{% url 'account:email' as email_url %}
 
 <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url}}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
 

--- a/allauth/templates/account/login.html
+++ b/allauth/templates/account/login.html
@@ -32,13 +32,13 @@ for a {{site_name}} account and sign in below:{% endblocktrans %}</p>
 <a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
 {% endif %}
 
-<form class="login" method="POST" action="{% url 'account_login' %}">
+<form class="login" method="POST" action="{% url 'account:login' %}">
   {% csrf_token %}
   {{ form.as_p }}
   {% if redirect_field_value %}
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}
-  <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+  <a class="button secondaryAction" href="{% url 'account:reset_password' %}">{% trans "Forgot Password?" %}</a>
   <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
 </form>
 

--- a/allauth/templates/account/logout.html
+++ b/allauth/templates/account/logout.html
@@ -10,7 +10,7 @@
 
 <p>{% trans 'Are you sure you want to sign out?' %}</p>
 
-<form method="post" action="{% url 'account_logout' %}">
+<form method="post" action="{% url 'account:logout' %}">
   {% csrf_token %}
   {% if redirect_field_value %}
   <input type="hidden" name="{{redirect_field_name}}" value="{{redirect_field_value}}"/>

--- a/allauth/templates/account/password_change.html
+++ b/allauth/templates/account/password_change.html
@@ -8,7 +8,7 @@
 {% block content %}
     <h1>{% trans "Change Password" %}</h1>
 
-    <form method="POST" action="{% url 'account_change_password' %}" class="password_change">
+    <form method="POST" action="{% url 'account:change_password' %}" class="password_change">
         {% csrf_token %}
         {{ form.as_p }}
         <button type="submit" name="action">{% trans "Change Password" %}</button>

--- a/allauth/templates/account/password_reset.html
+++ b/allauth/templates/account/password_reset.html
@@ -15,7 +15,7 @@
 
     <p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
 
-    <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
+    <form method="POST" action="{% url 'account:reset_password' %}" class="password_reset">
         {% csrf_token %}
         {{ form.as_p }}
         <input type="submit" value="{% trans "Reset My Password" %}" />

--- a/allauth/templates/account/password_reset_from_key.html
+++ b/allauth/templates/account/password_reset_from_key.html
@@ -8,7 +8,7 @@
     <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
 
     {% if token_fail %}
-        {% url 'account_reset_password' as passwd_reset_url %}
+        {% url 'account:reset_password' as passwd_reset_url %}
         <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
     {% else %}
         {% if form %}

--- a/allauth/templates/account/password_set.html
+++ b/allauth/templates/account/password_set.html
@@ -8,7 +8,7 @@
 {% block content %}
     <h1>{% trans "Set Password" %}</h1>
 
-    <form method="POST" action="{% url 'account_set_password' %}" class="password_set">
+    <form method="POST" action="{% url 'account:set_password' %}" class="password_set">
         {% csrf_token %}
         {{ form.as_p }}
         <input type="submit" name="action" value="{% trans "Set Password" %}"/>

--- a/allauth/templates/account/signup.html
+++ b/allauth/templates/account/signup.html
@@ -10,7 +10,7 @@
 
 <p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
 
-<form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
+<form class="signup" id="signup_form" method="post" action="{% url 'account:signup' %}">
   {% csrf_token %}
   {{ form.as_p }}
   {% if redirect_field_value %}

--- a/allauth/templates/account/verified_email_required.html
+++ b/allauth/templates/account/verified_email_required.html
@@ -8,7 +8,7 @@
 {% block content %}
 <h1>{% trans "Verify Your E-mail Address" %}</h1>
 
-{% url 'account_email' as email_url %}
+{% url 'account:email' as email_url %}
 
 <p>{% blocktrans %}This part of the site requires us to verify that
 you are who you claim to be. For this purpose, we require that you

--- a/allauth/templates/base.html
+++ b/allauth/templates/base.html
@@ -24,11 +24,11 @@
       <strong>Menu:</strong>
       <ul>
 	{% if user.is_authenticated %}
-	<li><a href="{% url 'account_email' %}">Change E-mail</a></li>
-	<li><a href="{% url 'account_logout' %}">Sign Out</a></li>
+	<li><a href="{% url 'account:email' %}">Change E-mail</a></li>
+	<li><a href="{% url 'account:logout' %}">Sign Out</a></li>
 	{% else %}
-	<li><a href="{% url 'account_login' %}">Sign In</a></li>
-	<li><a href="{% url 'account_signup' %}">Sign Up</a></li>
+	<li><a href="{% url 'account:login' %}">Sign In</a></li>
+	<li><a href="{% url 'account:signup' %}">Sign Up</a></li>
 	{% endif %}
       </ul>
     </div>

--- a/allauth/templates/socialaccount/connections.html
+++ b/allauth/templates/socialaccount/connections.html
@@ -12,7 +12,7 @@
 <p>{% blocktrans %}You can sign in to your account using any of the following third party accounts:{% endblocktrans %}</p>
 
 
-<form method="post" action="{% url 'socialaccount_connections' %}">
+<form method="post" action="{% url 'socialaccount:connections' %}">
 {% csrf_token %}
 
 <fieldset>

--- a/allauth/templates/socialaccount/login_cancelled.html
+++ b/allauth/templates/socialaccount/login_cancelled.html
@@ -9,7 +9,7 @@
 
 <h1>{% trans "Login Cancelled" %}</h1>
 
-{% url 'account_login' as login_url %}
+{% url 'account:login' as login_url %}
 
 <p>{% blocktrans %}You decided to cancel logging in to our site using one of your existing accounts. If this was a mistake, please proceed to <a href="{{login_url}}">sign in</a>.{% endblocktrans %}</p>
 

--- a/allauth/templates/socialaccount/signup.html
+++ b/allauth/templates/socialaccount/signup.html
@@ -11,7 +11,7 @@
 <p>{% blocktrans with provider_name=account.get_provider.name site_name=site.name %}You are about to use your {{provider_name}} account to login to
 {{site_name}}. As a final step, please complete the following form:{% endblocktrans %}</p>
 
-<form class="signup" id="signup_form" method="post" action="{% url 'socialaccount_signup' %}">
+<form class="signup" id="signup_form" method="post" action="{% url 'socialaccount:signup' %}">
   {% csrf_token %}
   {{ form.as_p }}
   {% if redirect_field_value %}

--- a/allauth/urls.py
+++ b/allauth/urls.py
@@ -9,11 +9,13 @@ from allauth.socialaccount import providers
 
 from . import app_settings
 
-urlpatterns = patterns('', url('^', include('allauth.account.urls')))
+urlpatterns = patterns('', url('^', include(
+    'allauth.account.urls', namespace='account')))
 
 if app_settings.SOCIALACCOUNT_ENABLED:
-    urlpatterns += patterns('', url('^social/',
-                                    include('allauth.socialaccount.urls')))
+    urlpatterns += patterns('',
+        url('^social/', include(
+            'allauth.socialaccount.urls', namespace='socialaccount')))
 
 for provider in providers.registry.get_list():
     try:

--- a/example/example/templates/bootstrap/allauth/account/base.html
+++ b/example/example/templates/bootstrap/allauth/account/base.html
@@ -9,10 +9,10 @@
 
 <ul class="nav nav-tabs">
   <li class="{% block account_nav_email %}{% endblock %}">
-    <a href="{% url 'account_email' %}">{% trans 'E-mail Addresses' %}</a>
+    <a href="{% url 'account:email' %}">{% trans 'E-mail Addresses' %}</a>
   </li>
   <li class="{% block account_nav_change_password %}{% endblock %}">
-    <a href="{% url 'account_change_password' %}">{% trans 'Change Password' %}</a>
+    <a href="{% url 'account:change_password' %}">{% trans 'Change Password' %}</a>
   </li>
   {% url 'socialaccount_connections' as connections_url %}
   {% if connections_url %}

--- a/example/example/templates/bootstrap/allauth/account/email.html
+++ b/example/example/templates/bootstrap/allauth/account/email.html
@@ -13,7 +13,7 @@
 {% if user.emailaddress_set.all %}
 <p>{% trans 'The following e-mail addresses are associated to your account:' %}</p>
     
-<form action="{% url 'account_email' %}" class="email_list uniForm" method="post">
+<form action="{% url 'account:email' %}" class="email_list uniForm" method="post">
 {% csrf_token %}
 
 <table class="table">

--- a/example/example/templates/bootstrap/allauth/account/email_confirm.html
+++ b/example/example/templates/bootstrap/allauth/account/email_confirm.html
@@ -16,14 +16,14 @@
         
 <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{email}}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
 
-<form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+<form method="post" action="{% url 'account:confirm_email' confirmation.key %}">
 {% csrf_token %}
     <button class="btn btn-primary" type="submit">{% trans 'Confirm' %}</button>
 </form>
 
 {% else %}
 
-{% url 'account_email' as email_url %}
+{% url 'account:email' as email_url %}
 
 <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url}}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
 

--- a/example/example/templates/bootstrap/allauth/account/login.html
+++ b/example/example/templates/bootstrap/allauth/account/login.html
@@ -32,7 +32,7 @@ below:{% endblocktrans %}</p>
 
 {% endif %}
 
-<form class="login" method="POST" action="{% url 'account_login' %}">
+<form class="login" method="POST" action="{% url 'account:login' %}">
   {% csrf_token %}
   {{ form|bootstrap }}
   {% if redirect_field_value %}

--- a/example/example/templates/bootstrap/allauth/account/logout.html
+++ b/example/example/templates/bootstrap/allauth/account/logout.html
@@ -10,7 +10,7 @@
 
 <p>{% trans 'Are you sure you want to sign out?' %}</p>
 
-<form method="post" action="{% url 'account_logout' %}">
+<form method="post" action="{% url 'account:logout' %}">
   {% csrf_token %}
   {% if redirect_field_value %}
   <input type="hidden" name="{{redirect_field_name}}" value="{{redirect_field_value}}"/>

--- a/example/example/templates/bootstrap/allauth/account/password_reset_from_key.html
+++ b/example/example/templates/bootstrap/allauth/account/password_reset_from_key.html
@@ -10,7 +10,7 @@
 <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
     
 {% if token_fail %}
-{% url 'account_reset_password' as passwd_reset_url %}
+{% url 'account:reset_password' as passwd_reset_url %}
 <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
 
 {% else %}

--- a/example/example/templates/bootstrap/allauth/account/signup.html
+++ b/example/example/templates/bootstrap/allauth/account/signup.html
@@ -11,7 +11,7 @@
     
 <p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
         
-<form id="signup_form" method="post" action="{% url 'account_signup' %}">
+<form id="signup_form" method="post" action="{% url 'account:signup' %}">
   {% csrf_token %}
   {{ form|bootstrap }}
   {% if redirect_field_value %}

--- a/example/example/templates/plain/example/base.html
+++ b/example/example/templates/plain/example/base.html
@@ -26,11 +26,11 @@
       <strong>Menu:</strong>
       <ul>
 	{% if user.is_authenticated %}
-	<li><a href="{% url 'account_email' %}">Change E-mail</a></li>
-	<li><a href="{% url 'account_logout' %}">Sign Out</a></li>
+	<li><a href="{% url 'account:email' %}">Change E-mail</a></li>
+	<li><a href="{% url 'account:logout' %}">Sign Out</a></li>
 	{% else %}
-	<li><a href="{% url 'account_login' %}">Sign In</a></li>
-	<li><a href="{% url 'account_signup' %}">Sign Up</a></li>
+	<li><a href="{% url 'account:login' %}">Sign In</a></li>
+	<li><a href="{% url 'account:signup' %}">Sign Up</a></li>
 	{% endif %}
       </ul>
     </div>

--- a/example/example/templates/uniform/allauth/account/email.html
+++ b/example/example/templates/uniform/allauth/account/email.html
@@ -12,7 +12,7 @@
 {% if user.emailaddress_set.all %}
 <p>{% trans 'The following e-mail addresses are associated to your account:' %}</p>
     
-<form action="{% url 'account_email' %}" class="email_list uniForm" method="post">
+<form action="{% url 'account:email' %}" class="email_list uniForm" method="post">
 {% csrf_token %}
 <fieldset class="blockLabels">
 

--- a/example/example/templates/uniform/allauth/account/login.html
+++ b/example/example/templates/uniform/allauth/account/login.html
@@ -32,7 +32,7 @@ below:{% endblocktrans %}</p>
 
 {% endif %}
 
-<form class="login uniForm" method="POST" action="{% url 'account_login' %}">
+<form class="login uniForm" method="POST" action="{% url 'account:login' %}">
   {% csrf_token %}
   <fieldset class="inlineLabels">
     {{ form|as_uni_form }}
@@ -40,7 +40,7 @@ below:{% endblocktrans %}</p>
     <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
     {% endif %}
     <div class="buttonHolder">
-      <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
+      <a class="button secondaryAction" href="{% url 'account:reset_password' %}">{% trans "Forgot Password?" %}</a>
 
       <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
     </div>

--- a/example/example/templates/uniform/allauth/account/password_reset_from_key.html
+++ b/example/example/templates/uniform/allauth/account/password_reset_from_key.html
@@ -9,7 +9,7 @@
     <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
     
     {% if token_fail %}
-        {% url 'account_reset_password' as passwd_reset_url %}
+        {% url 'account:reset_password' as passwd_reset_url %}
         <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
     {% else %}
         {% if form %}

--- a/example/example/templates/uniform/allauth/account/signup.html
+++ b/example/example/templates/uniform/allauth/account/signup.html
@@ -11,7 +11,7 @@
 
 <p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
 
-<form class="signup uniForm" id="signup_form" method="post" action="{% url 'account_signup' %}">
+<form class="signup uniForm" id="signup_form" method="post" action="{% url 'account:signup' %}">
   {% csrf_token %}
   <fieldset class="inlineLabels">
     {{ form|as_uni_form }}

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -4,8 +4,8 @@ from django.views.generic.base import TemplateView
 admin.autodiscover()
 
 urlpatterns = patterns('',
-                       (r'^accounts/', include('allauth.urls')),
-                       url(r'^$', TemplateView.as_view(template_name='index.html')),
-                       url(r'^accounts/profile/$', TemplateView.as_view(template_name='profile.html')),
-                       url(r'^admin/', include(admin.site.urls)),
+    (r'^accounts/', include('allauth.urls')),
+    url(r'^$', TemplateView.as_view(template_name='index.html')),
+    url(r'^accounts/profile/$', TemplateView.as_view(template_name='profile.html')),
+    url(r'^admin/', include(admin.site.urls)),
 )


### PR DESCRIPTION
Allauth was using urls like `account_signup` and this seemed to be antiquated with the existence of namespaces. I updated it to utilize namespaces. The entire test-suite is now passing.