### PR TITLE
Fix migration error

### DIFF
--- a/allauth/socialaccount/south_migrations/0012_auto__chg_field_socialtoken_token_secret.py
+++ b/allauth/socialaccount/south_migrations/0012_auto__chg_field_socialtoken_token_secret.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import SchemaMigration


### PR DESCRIPTION
Running ./manage.py migrate with django 1.4.19, south 1.0.2, django-allauth 0.19.1 and python 2.7.3 returns :

```
Running migrations for socialaccount:
 - Migrating forwards to 0012_auto__chg_field_socialtoken_token_secret.
> socialaccount:0012_auto__chg_field_socialtoken_token_secret
Traceback (most recent call last):
  File "./manage.py", line 14, in <module>
    execute_manager(settings)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 459, in execute_manager
    utility.execute()
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(*args, **options)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/management/commands/migrate.py", line 111, in handle
    ignore_ghosts = ignore_ghosts,
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/migration/__init__.py", line 220, in migrate_app
    success = migrator.migrate_many(target, workplan, database)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/migration/migrators.py", line 256, in migrate_many
    result = migrator.__class__.migrate_many(migrator, target, migrations, database)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/migration/migrators.py", line 331, in migrate_many
    result = self.migrate(migration, database)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/migration/migrators.py", line 133, in migrate
    result = self.run(migration, database)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/migration/migrators.py", line 106, in run
    south.db.db.current_orm = self.orm(migration)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/migration/migrators.py", line 281, in orm
    return migration.orm()
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/utils/__init__.py", line 62, in method
    value = function(self)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/migration/base.py", line 443, in orm
    return FakeORM(self.migration_class(), self.app_label())
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/orm.py", line 48, in FakeORM
    _orm_cache[args] = _FakeORM(*args)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/orm.py", line 127, in __init__
    self.models[name] = self.make_model(app_label, model_name, data)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/south/orm.py", line 350, in make_model
    fields,
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/django/db/models/base.py", line 99, in __new__
    new_class.add_to_class(obj_name, obj)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/django/db/models/base.py", line 219, in add_to_class
    value.contribute_to_class(cls, name)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/django/db/models/fields/related.py", line 1228, in contribute_to_class
    self.rel.through = create_many_to_many_intermediary_model(self, cls)
  File "/home/www/pikacode.com/shared/env/local/lib/python2.7/site-packages/django/db/models/fields/related.py", line 1121, in create_many_to_many_intermediary_model
# -*- coding: utf-8 -*-
    to: models.ForeignKey(to_model, related_name='%s+' % name, db_tablespace=field.db_tablespace)
TypeError: type() argument 1 must be string, not unicode
```