### PR TITLE
Change wording in e-mail templates to avoid being classified as SPAM

### DIFF
--- a/allauth/templates/account/email/email_confirmation_message.txt
+++ b/allauth/templates/account/email/email_confirmation_message.txt
@@ -1,4 +1,8 @@
-{% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with current_site.name as site_name %}User {{ user_display }} at {{ site_name }} has given this as an email address.
+{% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
+
+You're receiving this e-mail because user {{ user_display }} at {{ site_domain }} has given yours as an e-mail address to connect their account.
 
 To confirm this is correct, go to {{ activate_url }}
 {% endblocktrans %}{% endautoescape %}
+{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you from {{ site_name }}!
+{{ site_domain }}{% endblocktrans %}

--- a/allauth/templates/account/email/email_confirmation_subject.txt
+++ b/allauth/templates/account/email/email_confirmation_subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans %}Confirm E-mail Address{% endblocktrans %}
+{% blocktrans %}Please Confirm Your E-mail Address{% endblocktrans %}
 {% endautoescape %}

--- a/allauth/templates/account/email/password_reset_key_message.txt
+++ b/allauth/templates/account/email/password_reset_key_message.txt
@@ -1,8 +1,11 @@
-{% load i18n %}{% blocktrans with site.domain as site_domain %}You're receiving this e-mail because you or someone else has requested a password for your user account at {{site_domain}}.
+{% load i18n %}{% blocktrans with site_name=site.name site_domain=site.domain %}Hello from {{ site_name }}!
+
+You're receiving this e-mail because you or someone else has requested a password for your user account at {{ site_domain }}.
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
 
 {{ password_reset_url }}
 
 {% if username %}{% blocktrans %}In case you forgot, your username is {{ username }}.{% endblocktrans %}
 
-{% endif %}{% trans 'Thanks for using our site!' %}
+{% endif %}{% blocktrans with site_name=site.name site_domain=site.domain %}Thank you for using {{ site_name }}!
+{{ site_domain }}{% endblocktrans %}


### PR DESCRIPTION
Fixes #822: Confirm email lands in SPAM