### PR TITLE
fix verbose_name of field token in SocialToken

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -122,7 +122,7 @@ class SocialToken(models.Model):
     app = models.ForeignKey(SocialApp)
     account = models.ForeignKey(SocialAccount)
     token = models \
-        .TextField(verbose_name=_('social account'),
+        .TextField(verbose_name=_('token'),
                    help_text=_('"oauth_token" (OAuth1) or access token'
                                ' (OAuth2)'))
     token_secret = models \


### PR DESCRIPTION
When I was in the admin of my site, I saw the field label for token is "Social account", which doesn't make sense. I think it should be just "token", right? It's just copied from some where else.