### PR TITLE
Cleanup: removed dead code

### DIFF
--- a/allauth/socialaccount/providers/base.py
+++ b/allauth/socialaccount/providers/base.py
@@ -68,13 +68,6 @@ class Provider(object):
     def extract_extra_data(self, data):
         return data
 
-    def extract_basic_socialaccount_data(self, data):
-        """
-        Returns a tuple of basic/common social account data.
-        For example: ('123', {'first_name': 'John'})
-        """
-        raise NotImplementedError
-
     def extract_common_fields(self, data):
         """
         For example:


### PR DESCRIPTION
Rationale: it's unused and undocumented, and only adds confusion.