### PR TITLE
Provider: added base `extract_uid()` method

### DIFF
--- a/allauth/socialaccount/providers/base.py
+++ b/allauth/socialaccount/providers/base.py
@@ -65,6 +65,14 @@ class Provider(object):
         adapter.populate_user(request, sociallogin, common_fields)
         return sociallogin
 
+    def extract_uid(self, data):
+        """
+        Extracts the unique user ID from `data`
+        """
+        raise NotImplementedError(
+            'The provider must implement the `extract_uid()` method'
+        )
+
     def extract_extra_data(self, data):
         return data
 


### PR DESCRIPTION
As per the `sociallogin_from_response()` method, it's required to implement the `extract_uid()` method, but besides the call there's no reference to it in the base class. This commit enforces `extract_uid()` to be implemented by providers.