### PR TITLE
Unset email widget's is_required status too

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -228,6 +228,7 @@ class BaseSignupForm(_base_signup_form_class()):
         else:
             self.fields["email"].label = ugettext("E-mail (optional)")
             self.fields["email"].required = False
+            self.fields["email"].widget.is_required = False
             if self.username_required:
                 field_order = ['username', 'email']
 


### PR DESCRIPTION
I've only noticed this when email is optional, and also using
django-bootstrap3.

The bootstrap3 default render checks the widget's `is_required` status,
which is only initialised in the django field constructor.  So, setting
field.required to False after initialisation still leaves
`widget.is_required` in the default state of True, which then causes the
bootstrap renderer to mistakenly add a required=required attribute.