### PR TITLE
Docs: added extra details for `ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION`

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -107,9 +107,13 @@ ACCOUNT_PASSWORD_MIN_LENGTH (=6)
   An integer specifying the minimum password length.
 
 ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION (=True)
-  The default behaviour is to automatically log the user in once they confirms
-  their email address. By changing this setting to False they will not be logged
-  in, but redirected to the ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL
+  The default behaviour is to automatically log users in once they confirm
+  their email address. Note however that this only works when confirming
+  the email address **immediately after signing up**, assuming users
+  didn't close their browser or used some sort of private browsing mode.
+
+  By changing this setting to `False` they will not be logged in, but
+  redirected to the `ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL`
 
 ACCOUNT_SESSION_REMEMBER (=None)
   Controls the life time of the session. Set to `None` to ask the user


### PR DESCRIPTION
Easy to miss out that this setting only works after sign up.