### PR TITLE
Try application setting when looking for login redirect url after email

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -272,7 +272,9 @@ class ConfirmEmailView(TemplateResponseMixin, View):
         if user_pk == user.pk and self.request.user.is_anonymous():
             return perform_login(self.request,
                                  user,
-                                 app_settings.EmailVerificationMethod.NONE)
+                                 app_settings.EmailVerificationMethod.NONE,
+                                 app_settings.
+                                 EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL)
 
         return None
 


### PR DESCRIPTION
This fixes an issue I've encountered when using email confirmation with ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = '/' and LOGIN_REDIRECT_URL at default. The expected behavior is for django-allauth to redirect using relevant setting, but as of now only LOGIN_REDIRECT_URL and "next" field are tested.