### PR TITLE
Password reset: deal with invalid tokens when in XHR

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -267,8 +267,10 @@ class DefaultAccountAdapter(object):
             except TemplateDoesNotExist:
                 pass
 
-    def ajax_response(self, request, response, redirect_to=None, form=None):
-        data = {}
+    def ajax_response(self, request, response, redirect_to=None, form=None,
+                      data=None):
+        if data is None:
+            data = {}
         status = response.status_code
 
         if redirect_to:

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -216,6 +216,16 @@ class AccountTests(TestCase):
         self.assertTemplateUsed(resp, 'account/password_reset_from_key.html')
         assert resp.context_data['token_fail']
 
+        # When in XHR views, it should respond with a 400 bad request
+        # code, and the response body should contain JSON-encoded `errors`
+        resp = self.client.post(url,
+                                {'password1': 'newpass123',
+                                 'password2': 'newpass123'},
+                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        assert resp.status_code == 400
+        data = json.loads(resp.content.decode('utf8'))
+        assert 'token_failed' in data['errors']
+
     def test_email_verification_mandatory(self):
         c = Client()
         # Signup

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -607,7 +607,19 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
         return super(PasswordResetFromKeyView, self).form_valid(form)
 
     def _response_bad_token(self, request, uidb36, key, **kwargs):
-        return self.render_to_response(self.get_context_data(token_fail=True))
+        # Special-casing ajax/non-ajax scenarios due to #890
+        if request.is_ajax():
+            data = {
+                'errors': ['token_failed'],
+            }
+            response = _ajax_response(request,
+                                      HttpResponseBadRequest(reason=data))
+        else:
+            response = self.render_to_response(
+                self.get_context_data(token_fail=True)
+            )
+
+        return response
 
 password_reset_from_key = PasswordResetFromKeyView.as_view()
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -36,7 +36,7 @@ sensitive_post_parameters_m = method_decorator(
     sensitive_post_parameters('password', 'password1', 'password2'))
 
 
-def _ajax_response(request, response, form=None):
+def _ajax_response(request, response, form=None, data=None):
     if request.is_ajax():
         if (isinstance(response, HttpResponseRedirect)
                 or isinstance(response, HttpResponsePermanentRedirect)):
@@ -46,7 +46,8 @@ def _ajax_response(request, response, form=None):
         response = get_adapter().ajax_response(request,
                                                response,
                                                form=form,
-                                               redirect_to=redirect_to)
+                                               redirect_to=redirect_to,
+                                               data=data)
     return response
 
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -1,6 +1,6 @@
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.sites.models import Site
-from django.http import (HttpResponseRedirect, Http404,
+from django.http import (HttpResponseBadRequest, HttpResponseRedirect, Http404,
                          HttpResponsePermanentRedirect)
 from django.shortcuts import get_object_or_404
 from django.views.generic.base import TemplateResponseMixin, View, TemplateView
@@ -43,6 +43,10 @@ def _ajax_response(request, response, form=None, data=None):
             redirect_to = response['Location']
         else:
             redirect_to = None
+
+        if isinstance(response, HttpResponseBadRequest):
+            data = response.reason_phrase
+
         response = get_adapter().ajax_response(request,
                                                response,
                                                form=form,


### PR DESCRIPTION
Not a big fan of special-casing here, but honestly I don't see any other way around without overhauling the entire architecture behind XHR views (but that's a separate topic).

Fixes #890.