### PR TITLE
Password reset: perform token validation via form

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -2,27 +2,24 @@ from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.sites.models import Site
 from django.http import (HttpResponseRedirect, Http404,
                          HttpResponsePermanentRedirect)
-from django.shortcuts import get_object_or_404
 from django.views.generic.base import TemplateResponseMixin, View, TemplateView
 from django.views.generic.edit import FormView
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import logout as auth_logout
-from django.contrib.auth.tokens import default_token_generator
 from django.shortcuts import redirect
 from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.decorators import method_decorator
 
 from ..exceptions import ImmediateHttpResponse
-from ..utils import get_user_model, get_form_class, get_request_param
+from ..utils import get_form_class, get_request_param
 
 from .utils import (get_next_redirect_url, complete_signup,
                     get_login_redirect_url, perform_login,
-                    passthrough_next_redirect_url,
-                    url_str_to_user_pk)
+                    passthrough_next_redirect_url)
 from .forms import AddEmailForm, ChangePasswordForm
 from .forms import LoginForm, ResetPasswordKeyForm
-from .forms import ResetPasswordForm, SetPasswordForm, SignupForm
+from .forms import ResetPasswordForm, SetPasswordForm, SignupForm, UserTokenForm
 from .utils import sync_user_email_addresses
 from .models import EmailAddress, EmailConfirmation
 
@@ -557,7 +554,6 @@ password_reset_done = PasswordResetDoneView.as_view()
 class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
     template_name = "account/password_reset_from_key.html"
     form_class = ResetPasswordKeyForm
-    token_generator = default_token_generator
     success_url = reverse_lazy("account_reset_password_from_key_done")
 
     def get_form_class(self):
@@ -565,21 +561,20 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
                               'reset_password_from_key',
                               self.form_class)
 
-    def _get_user(self, uidb36):
-        try:
-            pk = url_str_to_user_pk(uidb36)
-        except ValueError:
-            raise Http404
-        return get_object_or_404(get_user_model(), pk=pk)
-
     def dispatch(self, request, uidb36, key, **kwargs):
         self.request = request
-        self.uidb36 = uidb36
         self.key = key
-        self.reset_user = self._get_user(uidb36)
-        if not self.token_generator.check_token(self.reset_user, key):
-            return self._response_bad_token(request, uidb36, key, **kwargs)
+
+        # (Ab)using forms here to be able to handle errors in XHR #890
+        token_form = UserTokenForm(data={'uidb36': uidb36, 'key': key})
+
+        if not token_form.is_valid():
+            response = self.render_to_response(
+                self.get_context_data(token_fail=True)
+            )
+            return _ajax_response(self.request, response, form=token_form)
         else:
+            self.reset_user = token_form.reset_user
             return super(PasswordResetFromKeyView, self).dispatch(request,
                                                                   uidb36,
                                                                   key,
@@ -600,9 +595,6 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
                                     request=self.request,
                                     user=self.reset_user)
         return super(PasswordResetFromKeyView, self).form_valid(form)
-
-    def _response_bad_token(self, request, uidb36, key, **kwargs):
-        return self.render_to_response(self.get_context_data(token_fail=True))
 
 password_reset_from_key = PasswordResetFromKeyView.as_view()
 


### PR DESCRIPTION
This allows to reuse the handlers for XHR responses, and therefore return an error message with a 400 status code when the token is invalid.

Note that this implements the alternative approach as suggested in #894.

Fixes #890.