### PR TITLE
Minor test cleanups

### DIFF
--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -219,7 +219,7 @@ class AccountTests(TestCase):
         # Same should happen when accessing the page directly
         response = self.client.get(url)
         self.assertTemplateUsed(response, 'account/password_reset_from_key.html')
-        self.assertEqual(response.context_data['token_fail'], True)
+        self.assertTrue(response.context_data['token_fail'])
 
         # When in XHR views, it should respond with a 400 bad request
         # code, and the response body should contain the JSON-encoded

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -155,8 +155,6 @@ class AccountTests(TestCase):
         resp = c.get(reverse(urlname))
         return resp
 
-    @override_settings(
-        ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod.USERNAME)  # noqa
     def test_password_forgotten_username_hint(self):
         self._request_new_password()
         body = mail.outbox[0].body
@@ -387,9 +385,7 @@ class AccountTests(TestCase):
 
     @override_settings(
         ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod
-        .OPTIONAL,
-        ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod
-        .USERNAME)
+        .OPTIONAL)
     def test_ajax_login_success(self):
         user = get_user_model().objects.create(username='john', is_active=True)
         user.set_password('doe')


### PR DESCRIPTION
Spotted that I was using `assertEqual()` instead of `assertTrue()` only after my last PR was merged. Also, some tests don't require overriding settings that are already set at the class level.