### PR TITLE
RedirectAuthenticatedUserMixin does not handle AJAX request correctly when user is already authenticated

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -55,7 +55,7 @@ class RedirectAuthenticatedUserMixin(object):
         if request.user.is_authenticated():
             redirect_to = self.get_authenticated_redirect_url()
             response = HttpResponseRedirect(redirect_to)
-            return response
+            return _ajax_response(request, response)
         else:
             response = super(RedirectAuthenticatedUserMixin,
                              self).dispatch(request,


### PR DESCRIPTION
This relates to #799.

If a user's already authenticated when an AJAX request is made to either ``LoginView`` or ``SignupView`` an ``HttpResponseRedirect`` is returned. This is due to the fact that ``RedirectAuthenticatedUserMixin`` does not process the request to check if it's AJAX.

