### PR TITLE
Deprecation cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   global:
    - TEST_APPS="allauth account socialaccount amazon angellist bitbucket coinbase evernote feedly foursquare douban dropbox dropbox_oauth2 facebook flickr google github hubic instagram linkedin linkedin_oauth2 mailru odnoklassniki windowslive openid orcid paypal persona soundcloud spotify stackexchange tumblr twitch twitter vimeo vk weibo bitly xing"
   matrix:
-   - DJANGO=Django==1.4.3
    - DJANGO=Django==1.5
    - DJANGO=Django==1.6
    - DJANGO=Django==1.7
@@ -21,15 +20,9 @@ install:
 branches:
  only:
   - master
-script: if [ $DJANGO == Django==1.4.3 -o $DJANGO == Django==1.5 ]; then coverage run manage.py test $TEST_APPS; else coverage run manage.py test allauth; fi
+script: if [ -o $DJANGO == Django==1.5 ]; then coverage run manage.py test $TEST_APPS; else coverage run manage.py test allauth; fi
 matrix:
   exclude:
-    - python: "3.4"
-      env: DJANGO=Django==1.4.3
-    - python: "3.3"
-      env: DJANGO=Django==1.4.3
-    - python: "3.2"
-      env: DJANGO=Django==1.4.3
     - python: "2.6"
       env: DJANGO=Django==1.7
 after_success:

--- a/allauth/socialaccount/providers/facebook/templates/facebook/fbconnect.html
+++ b/allauth/socialaccount/providers/facebook/templates/facebook/fbconnect.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load staticfiles %}
 <div id="fb-root"></div>
 <script id="allauth-facebook-settings" type="application/json">

--- a/allauth/socialaccount/providers/facebook/templates/facebook/fbconnect.html
+++ b/allauth/socialaccount/providers/facebook/templates/facebook/fbconnect.html
@@ -3,4 +3,4 @@
 <script id="allauth-facebook-settings" type="application/json">
 {{ fb_data }}
 </script>
-<script type="text/javascript" src="{% static "facebook/js/fbconnect.js" %}"></script>
+<script type="text/javascript" src="{% static 'facebook/js/fbconnect.js' %}"></script>

--- a/allauth/socialaccount/providers/persona/templates/persona/auth.html
+++ b/allauth/socialaccount/providers/persona/templates/persona/auth.html
@@ -21,7 +21,7 @@
         document.getElementById("_persona_next_url").value = nextUrl || '';
         document.getElementById("_persona_process").value = process;
         startWatching();
-        navigator.id.request({{request_parameters|safe}});
+        navigator.id.request({{ request_parameters|safe }});
     }
   }
 })();

--- a/allauth/socialaccount/providers/persona/templates/persona/auth.html
+++ b/allauth/socialaccount/providers/persona/templates/persona/auth.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <script src="https://login.persona.org/include.js"></script>
 <script type="text/javascript">
 (function() {

--- a/allauth/templates/account/email.html
+++ b/allauth/templates/account/email.html
@@ -1,7 +1,6 @@
 {% extends "account/base.html" %}
 
 {% load i18n %}
-{% load url from future %}
 
 {% block head_title %}{% trans "Account" %}{% endblock %}
 

--- a/allauth/templates/account/email_confirm.html
+++ b/allauth/templates/account/email_confirm.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load account %}
 

--- a/allauth/templates/account/email_confirm.html
+++ b/allauth/templates/account/email_confirm.html
@@ -12,8 +12,8 @@
 {% if confirmation %}
 
 {% user_display confirmation.email_address.user as user_display %}
-        
-<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{email}}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+
+<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
 
 <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
 {% csrf_token %}
@@ -24,7 +24,7 @@
 
 {% url 'account_email' as email_url %}
 
-<p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url}}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+<p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
 
 {% endif %}
 

--- a/allauth/templates/account/login.html
+++ b/allauth/templates/account/login.html
@@ -9,10 +9,10 @@
 
 <h1>{% trans "Sign In" %}</h1>
 
-{% if socialaccount.providers  %}
+{% if socialaccount.providers %}
 <p>{% blocktrans with site.name as site_name %}Please sign in with one
 of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
-for a {{site_name}} account and sign in below:{% endblocktrans %}</p>
+for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>
 
 <div class="socialaccount_ballot">
 

--- a/allauth/templates/account/login.html
+++ b/allauth/templates/account/login.html
@@ -2,7 +2,6 @@
 
 {% load i18n %}
 {% load account %}
-{% load url from future %}
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 

--- a/allauth/templates/account/logout.html
+++ b/allauth/templates/account/logout.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Sign Out" %}{% endblock %}

--- a/allauth/templates/account/logout.html
+++ b/allauth/templates/account/logout.html
@@ -12,7 +12,7 @@
 <form method="post" action="{% url 'account_logout' %}">
   {% csrf_token %}
   {% if redirect_field_value %}
-  <input type="hidden" name="{{redirect_field_name}}" value="{{redirect_field_value}}"/>
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
   {% endif %}
   <button type="submit">{% trans 'Sign Out' %}</button>
 </form>

--- a/allauth/templates/account/password_change.html
+++ b/allauth/templates/account/password_change.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Change Password" %}{% endblock %}

--- a/allauth/templates/account/password_reset.html
+++ b/allauth/templates/account/password_reset.html
@@ -2,7 +2,6 @@
 
 {% load i18n %}
 {% load account %}
-{% load url from future %}
 
 {% block head_title %}{% trans "Password Reset" %}{% endblock %}
 

--- a/allauth/templates/account/password_reset.html
+++ b/allauth/templates/account/password_reset.html
@@ -17,7 +17,7 @@
     <form method="POST" action="{% url 'account_reset_password' %}" class="password_reset">
         {% csrf_token %}
         {{ form.as_p }}
-        <input type="submit" value="{% trans "Reset My Password" %}" />
+        <input type="submit" value="{% trans 'Reset My Password' %}" />
     </form>
 
     <p>{% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}</p>

--- a/allauth/templates/account/password_reset_from_key.html
+++ b/allauth/templates/account/password_reset_from_key.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 

--- a/allauth/templates/account/password_reset_from_key.html
+++ b/allauth/templates/account/password_reset_from_key.html
@@ -14,7 +14,7 @@
             <form method="POST" action=".">
                 {% csrf_token %}
                 {{ form.as_p }}
-                <input type="submit" name="action" value="{% trans "change password" %}"/>
+                <input type="submit" name="action" value="{% trans 'change password' %}"/>
             </form>
         {% else %}
             <p>{% trans 'Your password is now changed.' %}</p>

--- a/allauth/templates/account/password_reset_from_key_done.html
+++ b/allauth/templates/account/password_reset_from_key_done.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% block head_title %}{% trans "Change Password" %}{% endblock %}
 

--- a/allauth/templates/account/password_set.html
+++ b/allauth/templates/account/password_set.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Set Password" %}{% endblock %}

--- a/allauth/templates/account/password_set.html
+++ b/allauth/templates/account/password_set.html
@@ -10,6 +10,6 @@
     <form method="POST" action="{% url 'account_set_password' %}" class="password_set">
         {% csrf_token %}
         {{ form.as_p }}
-        <input type="submit" name="action" value="{% trans "Set Password" %}"/>
+        <input type="submit" name="action" value="{% trans 'Set Password' %}"/>
     </form>
 {% endblock %}

--- a/allauth/templates/account/signup.html
+++ b/allauth/templates/account/signup.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Signup" %}{% endblock %}

--- a/allauth/templates/account/signup.html
+++ b/allauth/templates/account/signup.html
@@ -18,7 +18,4 @@
   <button type="submit">{% trans "Sign Up" %} &raquo;</button>
 </form>
 
-
 {% endblock %}
-
-

--- a/allauth/templates/account/signup_closed.html
+++ b/allauth/templates/account/signup_closed.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Sign Up Closed" %}{% endblock %}

--- a/allauth/templates/account/signup_closed.html
+++ b/allauth/templates/account/signup_closed.html
@@ -9,5 +9,3 @@
 
 <p>{% trans "We are sorry, but the sign up is currently closed." %}</p>
 {% endblock %}
-
-

--- a/allauth/templates/account/verified_email_required.html
+++ b/allauth/templates/account/verified_email_required.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}

--- a/allauth/templates/account/verified_email_required.html
+++ b/allauth/templates/account/verified_email_required.html
@@ -17,7 +17,7 @@ verify ownership of your e-mail address. {% endblocktrans %}</p>
 verification. Please click on the link inside this e-mail. Please
 contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
 
-<p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{email_url}}">change your e-mail address</a>.{% endblocktrans %}</p>
+<p>{% blocktrans %}<strong>Note:</strong> you can still <a href="{{ email_url }}">change your e-mail address</a>.{% endblocktrans %}</p>
 
 
 {% endblock %}

--- a/allauth/templates/base.html
+++ b/allauth/templates/base.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <!DOCTYPE html>
 <html>
   <head>

--- a/allauth/templates/openid/login.html
+++ b/allauth/templates/openid/login.html
@@ -1,6 +1,5 @@
 {% extends "openid/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}OpenID Sign In{% endblock %}

--- a/allauth/templates/socialaccount/connections.html
+++ b/allauth/templates/socialaccount/connections.html
@@ -1,7 +1,6 @@
 {% extends "socialaccount/base.html" %}
 
 {% load i18n %}
-{% load url from future %}
 
 {% block head_title %}{% trans "Account Connections" %}{% endblock %}
 

--- a/allauth/templates/socialaccount/connections.html
+++ b/allauth/templates/socialaccount/connections.html
@@ -16,16 +16,16 @@
 
 <fieldset>
 {% if form.non_field_errors %}
-<div id="errorMsg">{{form.non_field_errors}}</div>
+<div id="errorMsg">{{ form.non_field_errors }}</div>
 {% endif %}
 
 {% for base_account in form.accounts %}
 {% with base_account.get_provider_account as account %}
 <div>
-<label for="id_account_{{base_account.id}}">
-<input id="id_account_{{base_account.id}}" type="radio" name="account" value="{{base_account.id}}"/>
-<span class="socialaccount_provider {{base_account.provider}} {{account.get_brand.id}}">{{account.get_brand.name}}</span>
-{{account}}
+<label for="id_account_{{ base_account.id }}">
+<input id="id_account_{{ base_account.id }}" type="radio" name="account" value="{{ base_account.id }}"/>
+<span class="socialaccount_provider {{ base_account.provider }} {{ account.get_brand.id }}">{{account.get_brand.name}}</span>
+{{ account }}
 </label>
 </div>
 {% endwith %}

--- a/allauth/templates/socialaccount/login_cancelled.html
+++ b/allauth/templates/socialaccount/login_cancelled.html
@@ -1,6 +1,5 @@
 {% extends "socialaccount/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Login Cancelled" %}{% endblock %}

--- a/allauth/templates/socialaccount/signup.html
+++ b/allauth/templates/socialaccount/signup.html
@@ -1,5 +1,4 @@
 {% extends "socialaccount/base.html" %}
-{% load url from future %}
 
 {% load i18n %}
 

--- a/allauth/templates/socialaccount/signup.html
+++ b/allauth/templates/socialaccount/signup.html
@@ -19,5 +19,4 @@
   <button type="submit">{% trans "Sign Up" %} &raquo;</button>
 </form>
 
-
 {% endblock %}

--- a/example/example/templates/bootstrap/allauth/account/base.html
+++ b/example/example/templates/bootstrap/allauth/account/base.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block content %}

--- a/example/example/templates/bootstrap/allauth/account/base.html
+++ b/example/example/templates/bootstrap/allauth/account/base.html
@@ -16,7 +16,7 @@
   {% url 'socialaccount_connections' as connections_url %}
   {% if connections_url %}
   <li class="{% block account_nav_socialaccount_connections %}{% endblock %}">
-    <a href="{{ connections_url}}">{% trans 'Connected Accounts' %}</a>
+    <a href="{{ connections_url }}">{% trans 'Connected Accounts' %}</a>
   </li>
   {% endif %}
 </ul>
@@ -24,4 +24,3 @@
 {% endblock %}
 
 {% endblock %}
-

--- a/example/example/templates/bootstrap/allauth/account/email.html
+++ b/example/example/templates/bootstrap/allauth/account/email.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load bootstrap %}
 

--- a/example/example/templates/bootstrap/allauth/account/email.html
+++ b/example/example/templates/bootstrap/allauth/account/email.html
@@ -11,7 +11,7 @@
 
 {% if user.emailaddress_set.all %}
 <p>{% trans 'The following e-mail addresses are associated to your account:' %}</p>
-    
+
 <form action="{% url 'account_email' %}" class="email_list uniForm" method="post">
 {% csrf_token %}
 
@@ -30,8 +30,8 @@
     {% for emailaddress in user.emailaddress_set.all %}
     <tr>
       <td>
-        <label class="radio" for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
-  	<input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
+        <label class="radio" for="email_radio_{{ forloop.counter }}" class="{% if emailaddress.primary %}primary_email{% endif %}">
+  	<input id="email_radio_{{ forloop.counter }}" type="radio" name="email" {% if emailaddress.primary %}checked="checked"{% endif %} value="{{ emailaddress.email }}"/>
   	{{ emailaddress.email }}
         </label>
       </td>
@@ -57,14 +57,14 @@
 </fieldset>
 </form>
 
-{% else %} 
+{% else %}
 <p><strong>{% trans 'Warning:'%}</strong> {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}</p>
 
 {% endif %}
 
 
     <h2>{% trans "Add E-mail Address" %}</h2>
-    
+
     <form method="post" action="">
         {% csrf_token %}
         {{ add_email_form|bootstrap }}
@@ -72,7 +72,7 @@
           <button class="btn btn-primary" name="action_add" type="submit">{% trans "Add E-mail" %}</button>
         </div>
     </form>
-    
+
 {% endblock %}
 
 

--- a/example/example/templates/bootstrap/allauth/account/email_confirm.html
+++ b/example/example/templates/bootstrap/allauth/account/email_confirm.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load account %}
 

--- a/example/example/templates/bootstrap/allauth/account/email_confirm.html
+++ b/example/example/templates/bootstrap/allauth/account/email_confirm.html
@@ -12,8 +12,8 @@
 {% if confirmation %}
 
 {% user_display confirmation.email_address.user as user_display %}
-        
-<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{email}}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+
+<p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
 
 <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
 {% csrf_token %}
@@ -24,7 +24,7 @@
 
 {% url 'account_email' as email_url %}
 
-<p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url}}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+<p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
 
 {% endif %}
 

--- a/example/example/templates/bootstrap/allauth/account/login.html
+++ b/example/example/templates/bootstrap/allauth/account/login.html
@@ -11,10 +11,10 @@
 
 <h1>{% trans "Sign In" %}</h1>
 
-{% if socialaccount.providers  %}
+{% if socialaccount.providers %}
 <p>{% blocktrans with site.name as site_name %}Please sign in with one
-of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a> 
-for a {{site_name}} account and sign in
+of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
+for a {{ site_name }} account and sign in
 below:{% endblocktrans %}</p>
 
 <div class="socialaccount_ballot">
@@ -45,4 +45,3 @@ below:{% endblocktrans %}</p>
 </form>
 
 {% endblock %}
-

--- a/example/example/templates/bootstrap/allauth/account/login.html
+++ b/example/example/templates/bootstrap/allauth/account/login.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load bootstrap %}
 {% load account %}

--- a/example/example/templates/bootstrap/allauth/account/logout.html
+++ b/example/example/templates/bootstrap/allauth/account/logout.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 
 {% block head_title %}{% trans "Sign Out" %}{% endblock %}

--- a/example/example/templates/bootstrap/allauth/account/logout.html
+++ b/example/example/templates/bootstrap/allauth/account/logout.html
@@ -12,7 +12,7 @@
 <form method="post" action="{% url 'account_logout' %}">
   {% csrf_token %}
   {% if redirect_field_value %}
-  <input type="hidden" name="{{redirect_field_name}}" value="{{redirect_field_value}}"/>
+  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
   {% endif %}
   <button class="btn btn-primary" type="submit">{% trans 'Sign Out' %}</button>
 </form>

--- a/example/example/templates/bootstrap/allauth/account/password_reset_from_key.html
+++ b/example/example/templates/bootstrap/allauth/account/password_reset_from_key.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
-    
+
 {% if token_fail %}
 {% url 'account_reset_password' as passwd_reset_url %}
 <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
@@ -16,7 +16,7 @@
 {% if form %}
 <form method="POST" action="" class="uniForm">
   {% csrf_token %}
-  {{form|bootstrap}}
+  {{ form|bootstrap }}
   <div class="form-actions">
     <button class="btn btn-primary" type="submit">{% trans "Change Password" %}</button>
   </div>

--- a/example/example/templates/bootstrap/allauth/account/password_reset_from_key.html
+++ b/example/example/templates/bootstrap/allauth/account/password_reset_from_key.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load bootstrap %}
 

--- a/example/example/templates/bootstrap/allauth/account/signup.html
+++ b/example/example/templates/bootstrap/allauth/account/signup.html
@@ -7,9 +7,9 @@
 
 {% block content %}
 <h1>{% trans "Sign Up" %}</h1>
-    
+
 <p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
-        
+
 <form id="signup_form" method="post" action="{% url 'account_signup' %}">
   {% csrf_token %}
   {{ form|bootstrap }}
@@ -22,5 +22,3 @@
 </form>
 
 {% endblock %}
-
-

--- a/example/example/templates/bootstrap/allauth/account/signup.html
+++ b/example/example/templates/bootstrap/allauth/account/signup.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load bootstrap %}
 {% load i18n %}
 

--- a/example/example/templates/plain/example/base.html
+++ b/example/example/templates/plain/example/base.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <!DOCTYPE html>
 <html>
   <head>

--- a/example/example/templates/uniform/allauth/account/email.html
+++ b/example/example/templates/uniform/allauth/account/email.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load uni_form_tags %}
 

--- a/example/example/templates/uniform/allauth/account/email.html
+++ b/example/example/templates/uniform/allauth/account/email.html
@@ -10,16 +10,16 @@
 
 {% if user.emailaddress_set.all %}
 <p>{% trans 'The following e-mail addresses are associated to your account:' %}</p>
-    
+
 <form action="{% url 'account_email' %}" class="email_list uniForm" method="post">
 {% csrf_token %}
 <fieldset class="blockLabels">
 
   {% for emailaddress in user.emailaddress_set.all %}
 <div class="ctrlHolder">
-      <label for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
+      <label for="email_radio_{{ forloop.counter }}" class="{% if emailaddress.primary %}primary_email{% endif %}">
 
-      <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
+      <input id="email_radio_{{ forloop.counter }}" type="radio" name="email" {% if emailaddress.primary %}checked="checked"{% endif %} value="{{ emailaddress.email }}"/>
 
 {{ emailaddress.email }}
     {% if emailaddress.verified %}
@@ -41,14 +41,14 @@
 </fieldset>
 </form>
 
-{% else %} 
+{% else %}
 <p><strong>{% trans 'Warning:'%}</strong> {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}</p>
 
 {% endif %}
 
 
     <h2>{% trans "Add E-mail Address" %}</h2>
-    
+
     <form method="post" action="" class="add_email uniForm">
         {% csrf_token %}
         <fieldset class="inlineLabels">
@@ -58,7 +58,7 @@
             </div>
         </fieldset>
     </form>
-    
+
 {% endblock %}
 
 

--- a/example/example/templates/uniform/allauth/account/login.html
+++ b/example/example/templates/uniform/allauth/account/login.html
@@ -13,7 +13,7 @@
 
 {% if socialaccount.providers  %}
 <p>{% blocktrans with site.name as site_name %}Please sign in with one
-of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a> 
+of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
 for a {{site_name}} account and sign in
 below:{% endblocktrans %}</p>
 
@@ -47,4 +47,3 @@ below:{% endblocktrans %}</p>
 </form>
 
 {% endblock %}
-

--- a/example/example/templates/uniform/allauth/account/login.html
+++ b/example/example/templates/uniform/allauth/account/login.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load uni_form_tags %}
 {% load account %}

--- a/example/example/templates/uniform/allauth/account/password_reset_from_key.html
+++ b/example/example/templates/uniform/allauth/account/password_reset_from_key.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load uni_form_tags %}
 {% block head_title %}{% trans "Change Password" %}{% endblock %}

--- a/example/example/templates/uniform/allauth/account/password_reset_from_key.html
+++ b/example/example/templates/uniform/allauth/account/password_reset_from_key.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <h1>{% if token_fail %}{% trans "Bad Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
-    
+
     {% if token_fail %}
         {% url 'account_reset_password' as passwd_reset_url %}
         <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>

--- a/example/example/templates/uniform/allauth/account/signup.html
+++ b/example/example/templates/uniform/allauth/account/signup.html
@@ -24,5 +24,3 @@
 </form>
 
 {% endblock %}
-
-

--- a/example/example/templates/uniform/allauth/account/signup.html
+++ b/example/example/templates/uniform/allauth/account/signup.html
@@ -1,6 +1,5 @@
 {% extends "account/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load uni_form_tags %}
 

--- a/example/example/templates/uniform/allauth/openid/login.html
+++ b/example/example/templates/uniform/allauth/openid/login.html
@@ -1,6 +1,5 @@
 {% extends "openid/base.html" %}
 
-{% load url from future %}
 {% load i18n %}
 {% load uni_form_tags %}
 

--- a/example/example/templates/uniform/allauth/openid/login.html
+++ b/example/example/templates/uniform/allauth/openid/login.html
@@ -13,7 +13,7 @@
 <form id="openid_login_form" class="openid_login uniForm" method="post" action="{% url 'openid_login' %}">
 {% csrf_token %}
 <fieldset class="inlineLabels">
-{{form|as_uni_form}}
+{{ form|as_uni_form }}
 
 <div class="buttonHolder">
 <button type="submit">Sign In</button>


### PR DESCRIPTION
This drops the {% load url from future %} template tags, since 1.8 is the new LTS and support for 1.4 is being dropped, I think it's reasonable for django-allauth to drop support for 1.4 in its next release.

There are also some whitespace fixes my editor made automatically while working on this....

This addresses one of the issues mentioned in #858