### PR TITLE
activate_url should be set in the adapter.

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -10,6 +10,7 @@ from django.template.loader import render_to_string
 from django.template import TemplateDoesNotExist
 from django.contrib.sites.models import Site
 from django.core.mail import EmailMultiAlternatives, EmailMessage
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django import forms
 from django.contrib import messages
@@ -19,9 +20,13 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
-from ..utils import (import_attribute, get_user_model,
-                     generate_unique_username,
-                     resolve_url)
+from ..utils import (
+    build_absolute_uri,
+    generate_unique_username,
+    get_user_model,
+    import_attribute,
+    resolve_url
+)
 
 from . import app_settings
 
@@ -317,6 +322,13 @@ class DefaultAccountAdapter(object):
     def is_safe_url(self, url):
         from django.utils.http import is_safe_url
         return is_safe_url(url)
+
+    def get_activate_url(self, request, key):
+        activate_url = reverse("account_confirm_email", args=[key])
+        activate_url = build_absolute_uri(request,
+                                          activate_url,
+                                          protocol=app_settings.DEFAULT_HTTP_PROTOCOL)
+        return activate_url
 
 
 def get_adapter():

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import datetime
 
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
@@ -11,7 +10,6 @@ from django.contrib.sites.models import Site
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.crypto import get_random_string
 
-from ..utils import build_absolute_uri
 from .. import app_settings as allauth_app_settings
 from . import app_settings
 from . import signals
@@ -118,13 +116,10 @@ class EmailConfirmation(models.Model):
     def send(self, request, signup=False, **kwargs):
         current_site = kwargs["site"] if "site" in kwargs \
             else Site.objects.get_current()
-        activate_url = reverse("account_confirm_email", args=[self.key])
-        activate_url = build_absolute_uri(request,
-                                          activate_url,
-                                          protocol=app_settings.DEFAULT_HTTP_PROTOCOL)
+
         ctx = {
             "user": self.email_address.user,
-            "activate_url": activate_url,
+            "activate_url": get_adapter().get_activate_url(request, self.key),
             "current_site": current_site,
             "key": self.key,
         }


### PR DESCRIPTION
We have a strictly seperated rest-api from javascript frontend.
The link in the email should direct to an endpoint in the javascript app.
The easiest way is move get_activate_url to adapter.