### PR TITLE
Add ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE setting

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,6 +66,7 @@ Radek Czajka
 Rense VanderHoek
 Robert Balfre
 Roberto Novaes
+Rod Xavier Bondoc
 Sam Solomon
 Seizan Shimazaki
 Serafeim Papastefanos

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -198,6 +198,10 @@ class AppSettings(object):
         return self._setting('LOGOUT_ON_GET', False)
 
     @property
+    def LOGOUT_ON_PASSWORD_CHANGE(self):
+        return self._setting('LOGOUT_ON_PASSWORD_CHANGE', False)
+
+    @property
     def USER_MODEL_USERNAME_FIELD(self):
         return self._setting('USER_MODEL_USERNAME_FIELD', 'username')
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -28,9 +28,10 @@ from . import app_settings
 
 from .adapter import get_adapter
 
-import django
-if django.VERSION >= (1, 7):
+try:
     from django.contrib.auth import update_session_auth_hash
+except ImportError:
+    update_session_auth_hash = None
 
 
 sensitive_post_parameters_m = method_decorator(
@@ -467,7 +468,8 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
 
     def form_valid(self, form):
         form.save()
-        if django.VERSION >= (1, 7) and not app_settings.LOGOUT_ON_PASSWORD_CHANGE:
+        if (update_session_auth_hash is not None and 
+            not app_settings.LOGOUT_ON_PASSWORD_CHANGE):
             update_session_auth_hash(self.request, form.user)
         get_adapter().add_message(self.request,
                                   messages.SUCCESS,

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -1,6 +1,5 @@
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.sites.models import Site
-from django.contrib.auth import update_session_auth_hash
 from django.http import (HttpResponseRedirect, Http404,
                          HttpResponsePermanentRedirect)
 from django.views.generic.base import TemplateResponseMixin, View, TemplateView
@@ -28,6 +27,10 @@ from . import signals
 from . import app_settings
 
 from .adapter import get_adapter
+
+import django
+if django.VERSION >= (1, 7):
+    from django.contrib.auth import update_session_auth_hash
 
 
 sensitive_post_parameters_m = method_decorator(
@@ -464,7 +467,7 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
 
     def form_valid(self, form):
         form.save()
-        if not app_settings.LOGOUT_ON_PASSWORD_CHANGE:
+        if django.VERSION >= (1, 7) and not app_settings.LOGOUT_ON_PASSWORD_CHANGE:
             update_session_auth_hash(self.request, form.user)
         get_adapter().add_message(self.request,
                                   messages.SUCCESS,

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -1,5 +1,6 @@
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.sites.models import Site
+from django.contrib.auth import update_session_auth_hash
 from django.http import (HttpResponseRedirect, Http404,
                          HttpResponsePermanentRedirect)
 from django.views.generic.base import TemplateResponseMixin, View, TemplateView
@@ -463,6 +464,8 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
 
     def form_valid(self, form):
         form.save()
+        if not app_settings.LOGOUT_ON_PASSWORD_CHANGE:
+            update_session_auth_hash(self.request, form.user)
         get_adapter().add_message(self.request,
                                   messages.SUCCESS,
                                   'account/messages/password_changed.txt')

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -60,8 +60,7 @@ ACCOUNT_LOGOUT_ON_GET (=False)
 
 ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE (=False)
   Determines whether or not the user is automatically logged out after
-  changing the password. See documentation for `Django's session invalidation on password change` 
-  for details. (Django 1.7+)
+  changing the password. See documentation for `Django's session invalidation on password change <https://docs.djangoproject.com/en/1.8/topics/auth/default/#session-invalidation-on-password-change>`_. (Django 1.7+)
 
 ACCOUNT_LOGOUT_REDIRECT_URL (="/")
   The URL (or URL name) to return to after the user logs out. This is

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -58,6 +58,11 @@ ACCOUNT_LOGOUT_ON_GET (=False)
   mere GET request. See documentation for the `LogoutView` for
   details.
 
+ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE (=False)
+  Determines whether or not the user is automatically logged out after
+  changing the password. See documentation for `Django's session invalidation on password change` 
+  for details.
+
 ACCOUNT_LOGOUT_REDIRECT_URL (="/")
   The URL (or URL name) to return to after the user logs out. This is
   the counterpart to Django's `LOGIN_REDIRECT_URL`.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,7 +61,7 @@ ACCOUNT_LOGOUT_ON_GET (=False)
 ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE (=False)
   Determines whether or not the user is automatically logged out after
   changing the password. See documentation for `Django's session invalidation on password change` 
-  for details.
+  for details. (Django 1.7+)
 
 ACCOUNT_LOGOUT_REDIRECT_URL (="/")
   The URL (or URL name) to return to after the user logs out. This is


### PR DESCRIPTION
Since Django 1.7, if the SessionAuthenticationMiddleware is enabled, the session is invalidated when the user changes the account's password.

Starting Django 2.0, session verification will become mandatory whether or not the SessionAuthenticationMiddleware is enabled.

I figured this may be a good time to add this setting.

[Source: Session invalidation on password change](https://docs.djangoproject.com/en/1.8/topics/auth/default/#session-invalidation-on-password-change)