### PR TITLE
Fixes #846

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -329,19 +329,20 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 
     def post(self, request, *args, **kwargs):
         res = None
+        if request.POST.get("email") is None:
+            request.POST["email"] = request.user.email
         if "action_add" in request.POST:
             res = super(EmailView, self).post(request, *args, **kwargs)
-        elif request.POST.get("email"):
-            if "action_send" in request.POST:
-                res = self._action_send(request)
-            elif "action_remove" in request.POST:
-                res = self._action_remove(request)
-            elif "action_primary" in request.POST:
-                res = self._action_primary(request)
-            res = res or HttpResponseRedirect(reverse('account_email'))
-            # Given that we bypassed AjaxCapableProcessFormViewMixin,
-            # we'll have to call invoke it manually...
-            res = _ajax_response(request, res)
+        elif "action_send" in request.POST:
+            res = self._action_send(request)
+        elif "action_remove" in request.POST:
+            res = self._action_remove(request)
+        elif "action_primary" in request.POST:
+            res = self._action_primary(request)
+        res = res or HttpResponseRedirect(reverse('account_email'))
+        # Given that we bypassed AjaxCapableProcessFormViewMixin,
+        # we'll have to call invoke it manually...
+        res = _ajax_response(request, res)
         return res
 
     def _action_send(self, request, *args, **kwargs):


### PR DESCRIPTION
If there is no primary email selected by default, use the user's email.