### PR TITLE
Fix account initial migration

### DIFF
--- a/allauth/account/migrations/0001_initial.py
+++ b/allauth/account/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             name='EmailAddress',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('email', models.EmailField(unique=UNIQUE_EMAIL, max_length=75, verbose_name='e-mail address')),
+                ('email', models.EmailField(unique=UNIQUE_EMAIL, max_length=254, verbose_name='e-mail address')),
                 ('verified', models.BooleanField(default=False, verbose_name='verified')),
                 ('primary', models.BooleanField(default=False, verbose_name='primary')),
                 ('user', models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL)),


### PR DESCRIPTION
At Django 1.8 the default `max_length` for `EmailField` was increased from 75 to 254 in order to be compliant with RFC3696/5321.

[Reference](https://docs.djangoproject.com/en/1.8/ref/models/fields/#emailfield)