### PR TITLE
Repair link to use reStructuredText markup.

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -88,7 +88,7 @@ SCOPE:
     By default, `email` scope is required depending whether or not
     `SOCIALACCOUNT_QUERY_EMAIL` is enabled.
     Except permissions for `email`, `public_profile` and `user_friends`, apps using other permissions require review by Facebook.
-    You can look at [Permissions with Facebook Login](https://developers.facebook.com/docs/facebook-login/permissions/v2.3).
+    You can look at `Permissions with Facebook Login <https://developers.facebook.com/docs/facebook-login/permissions>`_.
 
 AUTH_PARAMS:
     Use `AUTH_PARAMS` to pass along other parameters to the `FB.login`


### PR DESCRIPTION
Also make the link unversioned, which FB will redirect to latest.