### PR TITLE
Respect Google Provider's HTTP reponse

### DIFF
--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.core import mail
+from django.core.urlresolvers import reverse
 
 try:
     from importlib import import_module
@@ -16,13 +17,17 @@ except ImportError:
 from allauth.socialaccount.tests import create_oauth2_tests
 from allauth.account import app_settings as account_settings
 from allauth.account.models import EmailConfirmation, EmailAddress
-from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.socialaccount.providers import registry
 from allauth.tests import MockedResponse
 from allauth.account.signals import user_signed_up
 from allauth.account.adapter import get_adapter
 
+from requests.exceptions import HTTPError
+
 from .provider import GoogleProvider
+
+import mock
 
 
 @override_settings(SOCIALACCOUNT_AUTO_SIGNUP=True,
@@ -50,6 +55,35 @@ class GoogleTests(create_oauth2_tests(registry.by_id(GoogleProvider.id))):
                email,
                given_name,
                (repr(verified_email).lower())))
+
+    def test_google_compelete_login_401(self):
+        from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
+
+        class LessMockedResponse(MockedResponse):
+            def raise_for_status(self):
+                if self.status_code != 200:
+                    raise HTTPError(None)
+        request = RequestFactory().get(reverse(self.provider.id + '_login'),
+                               dict(process='login'))
+
+        adapter = GoogleOAuth2Adapter()
+        app = adapter.get_provider().get_app(request)
+        token = SocialToken(token='some_token')
+        response_with_401 = LessMockedResponse(401, """
+                                                {"error": {
+                                                  "errors": [{
+                                                    "domain": "global",
+                                                    "reason": "authError",
+                                                    "message": "Invalid Credentials",
+                                                    "locationType": "header",
+                                                    "location": "Authorization" } ],
+                                                  "code": 401,
+                                                  "message": "Invalid Credentials" }
+                                                }""")
+        with mock.patch('allauth.socialaccount.providers.google.views.requests') as patched_requests:
+            patched_requests.get.return_value = response_with_401
+            with self.assertRaises(HTTPError):
+                adapter.complete_login(request, app, token)
 
     def test_username_based_on_email(self):
         first_name = '明'

--- a/allauth/socialaccount/providers/google/views.py
+++ b/allauth/socialaccount/providers/google/views.py
@@ -17,6 +17,7 @@ class GoogleOAuth2Adapter(OAuth2Adapter):
         resp = requests.get(self.profile_url,
                             params={'access_token': token.token,
                                     'alt': 'json'})
+        resp.raise_for_status()
         extra_data = resp.json()
         login = self.get_provider() \
             .sociallogin_from_response(request,


### PR DESCRIPTION
 - if google responds to you with  a 401 where your token is no good,
   raise an `HTTPError` (resp.raise_for_status) so that you can handle
   the exception corretly.  Otherwise you just get a 500 stauts because
   of a `KeyError`.