### PR TITLE
Upgrade to latest Facebook JS SDK

### DIFF
--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -123,7 +123,6 @@ class FacebookProvider(OAuth2Provider):
             "locale": locale,
             "loginOptions": self.get_fb_login_options(request),
             "loginByTokenUrl": abs_uri('facebook_login_by_token'),
-            "channelUrl": abs_uri('facebook_channel'),
             "cancelUrl": abs_uri('socialaccount_login_cancelled'),
             "logoutUrl": abs_uri('account_logout'),
             "loginUrl": request.build_absolute_uri(self.get_login_url(

--- a/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
+++ b/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
@@ -41,7 +41,6 @@
                     version    : opts.version,
                     status     : true,
                     cookie     : true,
-                    oauth      : true,
                     xfbml      : true
                 });
                 allauth.facebook.onInit();
@@ -50,7 +49,7 @@
             (function(d){
                 var js, id = 'facebook-jssdk'; if (d.getElementById(id)) {return;}
                 js = d.createElement('script'); js.id = id; js.async = true;
-                js.src = "//connect.facebook.net/"+opts.locale+"/all.js";
+                js.src = "//connect.facebook.net/"+opts.locale+"/sdk.js";
                 d.getElementsByTagName('head')[0].appendChild(js);
             }(document));
         },
@@ -61,8 +60,8 @@
         login: function(nextUrl, action, process) {
             var self = this;
             if (typeof(FB) == 'undefined') {
-		var url = this.opts.loginUrl + '?next=' + encodeURIComponent(nextUrl) + '&action=' + encodeURIComponent(action) + '&process=' + encodeURIComponent(process);
-		setLocationHref(url);
+                var url = this.opts.loginUrl + '?next=' + encodeURIComponent(nextUrl) + '&action=' + encodeURIComponent(action) + '&process=' + encodeURIComponent(process);
+                setLocationHref(url);
                 return;
             }
             if (action == 'reauthenticate') {

--- a/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
+++ b/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
@@ -39,7 +39,6 @@
                 FB.init({
                     appId      : opts.appId,
                     version    : opts.version,
-                    channelUrl : opts.channelUrl,
                     status     : true,
                     cookie     : true,
                     oauth      : true,

--- a/allauth/socialaccount/providers/facebook/templates/facebook/channel.html
+++ b/allauth/socialaccount/providers/facebook/templates/facebook/channel.html
@@ -1,1 +1,0 @@
- <script src="//connect.facebook.net/{{facebook_jssdk_locale}}/all.js"></script>

--- a/allauth/socialaccount/providers/facebook/tests.py
+++ b/allauth/socialaccount/providers/facebook/tests.py
@@ -106,10 +106,6 @@ class FacebookTests(create_oauth2_tests(registry.by_id(FacebookProvider.id))):
             self.assertEqual('http://testserver/accounts/profile/',
                              resp['location'])
 
-    def test_channel(self):
-        resp = self.client.get(reverse('facebook_channel'))
-        self.assertTemplateUsed(resp, 'facebook/channel.html')
-
     @override_settings(
         SOCIALACCOUNT_PROVIDERS={
             'facebook': {

--- a/allauth/socialaccount/providers/facebook/urls.py
+++ b/allauth/socialaccount/providers/facebook/urls.py
@@ -8,7 +8,6 @@ from . import views
 urlpatterns = default_urlpatterns(FacebookProvider)
 
 urlpatterns += patterns('',
-   url('^facebook/login/token/$', views.login_by_token, 
+   url('^facebook/login/token/$', views.login_by_token,
        name="facebook_login_by_token"),
-   url('^facebook/channel/$', views.channel, name='facebook_channel'),
    )

--- a/allauth/socialaccount/providers/facebook/views.py
+++ b/allauth/socialaccount/providers/facebook/views.py
@@ -1,9 +1,6 @@
 import logging
 import requests
 
-from django.utils.cache import patch_response_headers
-from django.shortcuts import render
-
 
 from allauth.socialaccount.models import (SocialLogin,
                                           SocialToken)
@@ -83,14 +80,3 @@ def login_by_token(request):
                                           FacebookProvider.id,
                                           exception=auth_exception)
     return ret
-
-
-def channel(request):
-    provider = providers.registry.by_id(FacebookProvider.id)
-    locale = provider.get_locale_for_request(request)
-    response = render(request, 'facebook/channel.html',
-                      {'facebook_jssdk_locale': locale})
-    cache_expire = 60 * 60 * 24 * 365
-    patch_response_headers(response, cache_expire)
-    response['Pragma'] = 'Public'
-    return response


### PR DESCRIPTION
Minor changes related to the "new" Facebook JS SDK

+ Use "new" Facebook JS SDK 
    See Upgrading Web Apps (JavaScript) https://developers.facebook.com/docs/apps/upgrading/
+ Remove unused FB.init params
  https://developers.facebook.com/docs/javascript/reference/FB.init/
+ Removing Facebook channelUrl, since it is not supported since long.
  https://developers.facebook.com/blog/post/2013/11/21/platform-updates--new-design-for-follow-button-and-like-box--ios-sdk-improvements-and-more/