### PR TITLE
Fix django 1.8 RequestSite error on LoginView

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.template import TemplateDoesNotExist
-from django.contrib.sites.models import Site
 from django.core.mail import EmailMultiAlternatives, EmailMessage
 from django.utils.translation import ugettext_lazy as _
 from django import forms
@@ -21,7 +20,7 @@ except ImportError:
 
 from ..utils import (import_attribute, get_user_model,
                      generate_unique_username,
-                     resolve_url)
+                     resolve_url, get_current_site)
 
 from . import app_settings
 
@@ -56,7 +55,7 @@ class DefaultAccountAdapter(object):
     def format_email_subject(self, subject):
         prefix = app_settings.EMAIL_SUBJECT_PREFIX
         if prefix is None:
-            site = Site.objects.get_current()
+            site = get_current_site()
             prefix = "[{name}] ".format(name=site.name)
         return prefix + force_text(subject)
 

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -9,12 +9,12 @@ from django.utils.translation import pgettext, ugettext_lazy as _, ugettext
 
 from django.contrib.auth import authenticate
 from django.contrib.auth.tokens import default_token_generator
-from django.contrib.sites.models import Site
 
 from ..utils import (email_address_exists,
                      set_form_field_order,
                      build_absolute_uri,
-                     get_username_max_length)
+                     get_username_max_length,
+                     get_current_site)
 
 from .models import EmailAddress
 from .utils import (perform_login, setup_user_email, url_str_to_user_pk,
@@ -422,7 +422,7 @@ class ResetPasswordForm(forms.Form):
             # password_reset = PasswordReset(user=user, temp_key=temp_key)
             # password_reset.save()
 
-            current_site = Site.objects.get_current()
+            current_site = get_current_site()
 
             # send the password reset email
             path = reverse("account_reset_password_from_key",

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -10,13 +10,12 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.client import Client
 from django.core import mail
-from django.contrib.sites.models import Site
 from django.test.client import RequestFactory
 from django.contrib.auth.models import AnonymousUser
 
 from allauth.account.forms import BaseSignupForm
 from allauth.account.models import EmailAddress, EmailConfirmation
-from allauth.utils import get_user_model
+from allauth.utils import get_user_model, get_current_site
 
 from . import app_settings
 
@@ -40,7 +39,7 @@ class AccountTests(TestCase):
             from ..socialaccount.models import SocialApp
             sa = SocialApp.objects.create(name='testfb',
                                           provider='facebook')
-            sa.sites.add(Site.objects.get_current())
+            sa.sites.add(get_current_site())
 
     @override_settings(
         ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod
@@ -287,7 +286,7 @@ class AccountTests(TestCase):
                          'http://testserver'+settings.LOGIN_REDIRECT_URL)
 
     def test_email_escaping(self):
-        site = Site.objects.get_current()
+        site = get_current_site()
         site.name = '<enc&"test>'
         site.save()
         u = get_user_model().objects.create(

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -1,5 +1,4 @@
 from django.core.urlresolvers import reverse, reverse_lazy
-from django.contrib.sites.models import Site
 from django.http import (HttpResponseRedirect, Http404,
                          HttpResponsePermanentRedirect)
 from django.views.generic.base import TemplateResponseMixin, View, TemplateView
@@ -12,7 +11,7 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.decorators import method_decorator
 
 from ..exceptions import ImmediateHttpResponse
-from ..utils import get_form_class, get_request_param
+from ..utils import get_form_class, get_request_param, get_current_site
 
 from .utils import (get_next_redirect_url, complete_signup,
                     get_login_redirect_url, perform_login,
@@ -118,11 +117,7 @@ class LoginView(RedirectAuthenticatedUserMixin,
                                                    self.redirect_field_name)
         redirect_field_value = get_request_param(self.request,
                                                  self.redirect_field_name)
-
-        if hasattr(Site.objects, '_get_site_by_request'):  # >= django 1.8
-            site = Site.objects.get_current(request=self.request)
-        else:
-            site = Site.objects.get_current()
+        site = get_current_site(self.request)
 
         ret.update({"signup_url": signup_url,
                     "site": site,

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -118,8 +118,14 @@ class LoginView(RedirectAuthenticatedUserMixin,
                                                    self.redirect_field_name)
         redirect_field_value = get_request_param(self.request,
                                                  self.redirect_field_name)
+
+        if hasattr(Site.objects, '_get_site_by_request'):  # >= django 1.8
+            site = Site.objects.get_current(request=self.request)
+        else:
+            site = Site.objects.get_current()
+
         ret.update({"signup_url": signup_url,
-                    "site": Site.objects.get_current(),
+                    "site": site,
                     "redirect_field_name": self.redirect_field_name,
                     "redirect_field_value": redirect_field_value})
         return ret

--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -15,8 +15,8 @@ except ImportError:
 import allauth.app_settings
 from allauth.account.models import EmailAddress
 from allauth.account.utils import get_next_redirect_url, setup_user_email
-from allauth.utils import (get_user_model, serialize_instance,
-                           deserialize_instance)
+from allauth.utils import (get_user_model, get_current_site,
+                           serialize_instance, deserialize_instance)
 
 from . import app_settings
 from . import providers
@@ -25,8 +25,8 @@ from ..utils import get_request_param
 
 
 class SocialAppManager(models.Manager):
-    def get_current(self, provider):
-        site = Site.objects.get_current()
+    def get_current(self, provider, request=None):
+        site = get_current_site(request)
         return self.get(sites__id=site.id,
                         provider=provider)
 

--- a/allauth/socialaccount/tests.py
+++ b/allauth/socialaccount/tests.py
@@ -9,7 +9,6 @@ import json
 from django.test.utils import override_settings
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from django.contrib.sites.models import Site
 from django.test.client import RequestFactory
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -19,7 +18,7 @@ from ..tests import MockedResponse, mocked_response
 from ..account import app_settings as account_settings
 from ..account.models import EmailAddress
 from ..account.utils import user_email
-from ..utils import get_user_model
+from ..utils import get_user_model, get_current_site
 
 from .models import SocialApp, SocialAccount, SocialLogin
 from .helpers import complete_social_login
@@ -36,7 +35,7 @@ def create_oauth_tests(provider):
                                        client_id='app123id',
                                        key=provider.id,
                                        secret='dummy')
-        app.sites.add(Site.objects.get_current())
+        app.sites.add(get_current_site())
 
     @override_settings(SOCIALACCOUNT_AUTO_SIGNUP=False)
     def test_login(self):
@@ -135,7 +134,7 @@ def create_oauth2_tests(provider):
                                        client_id='app123id',
                                        key=provider.id,
                                        secret='dummy')
-        app.sites.add(Site.objects.get_current())
+        app.sites.add(get_current_site())
 
     @override_settings(SOCIALACCOUNT_AUTO_SIGNUP=False)
     def test_login(self):

--- a/allauth/socialaccount/views.py
+++ b/allauth/socialaccount/views.py
@@ -1,7 +1,6 @@
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.core.urlresolvers import reverse, reverse_lazy
-from django.contrib.sites.models import Site
 from django.contrib.auth.decorators import login_required
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
@@ -9,7 +8,7 @@ from django.views.generic.edit import FormView
 from ..account.views import (CloseableSignupMixin,
                              RedirectAuthenticatedUserMixin)
 from ..account.adapter import get_adapter as get_account_adapter
-from ..utils import get_form_class
+from ..utils import get_form_class, get_current_site
 
 from .adapter import get_adapter
 from .models import SocialLogin
@@ -53,7 +52,7 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
 
     def get_context_data(self, **kwargs):
         ret = super(SignupView, self).get_context_data(**kwargs)
-        ret.update(dict(site=Site.objects.get_current(),
+        ret.update(dict(site=get_current_site(self.request),
                         account=self.sociallogin.account))
         return ret
 

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -5,6 +5,7 @@ import json
 from django.core.exceptions import ImproperlyConfigured
 from django.core.validators import validate_email, ValidationError
 from django.core import urlresolvers
+from django.contrib.sites.models import Site
 from django.db.models import FieldDoesNotExist
 from django.db.models.fields import (DateTimeField, DateField,
                                      EmailField, TimeField)
@@ -138,6 +139,20 @@ except ImportError:
                                        % app_settings.USER_MODEL)
         return user_model
 
+
+def get_current_site(request=None):
+    """Wrapper around ``Site.objects.get_current`` to handle ``Site`` lookups
+    by request in Django >= 1.8.
+
+    :param request: optional request object
+    :type request: :class:`django.http.HttpRequest`
+    """
+    if request and hasattr(Site.objects, '_get_site_by_request'):  # >= django 1.8
+        site = Site.objects.get_current(request=request)
+    else:
+        site = Site.objects.get_current()
+
+    return site
 
 def resolve_url(to):
     """

--- a/example/example/demo/models.py
+++ b/example/example/demo/models.py
@@ -1,8 +1,8 @@
 import sys
 
 from django.db.models.signals import post_syncdb
-from django.contrib.sites.models import Site
 
+from allauth.utils import get_current_site
 from allauth.socialaccount.providers import registry
 from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.providers.oauth.provider import OAuthProvider
@@ -13,9 +13,11 @@ def setup_dummy_social_apps(sender, **kwargs):
     `allauth` needs tokens for OAuth based providers. So let's
     setup some dummy tokens
     """
-    site = Site.objects.get_current()
+    request = kwargs.get('request')
+
+    site = get_current_site(request)
     for provider in registry.get_list():
-        if (isinstance(provider, OAuth2Provider) 
+        if (isinstance(provider, OAuth2Provider)
             or isinstance(provider, OAuthProvider)):
             try:
                 SocialApp.objects.get(provider=provider.id,


### PR DESCRIPTION
Django 1.8 will break if using sites framework

- https://docs.djangoproject.com/en/1.8/ref/contrib/sites/#get-current-site-shortcut
- https://github.com/django/django/blob/1.8/django/contrib/sites/models.py#L50

When using django 1.8 on settings without a ``SITE_ID``, an exception will be raised.

Tthis is permitted in 1.8, since django introduces [get_current_site](https://docs.djangoproject.com/en/1.8/ref/contrib/sites/#get-current-site-shortcut) support in ``get_current`` method in the Manager through the newly-added ``request`` kwarg.

   > Changed in Django 1.8:
   > This function will now lookup the current site based on request.get_host() if the SITE_ID setting is not defined.

Backward compatible with < 1.8.