### PR TITLE
Context processor check fix ups.

### DIFF
--- a/allauth/app_settings.py
+++ b/allauth/app_settings.py
@@ -1,6 +1,7 @@
 import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django import template
 
 SOCIALACCOUNT_ENABLED = 'allauth.socialaccount' in settings.INSTALLED_APPS
 
@@ -13,7 +14,7 @@ def check_context_processors():
         if allauth_ctx in settings.TEMPLATE_CONTEXT_PROCESSORS:
             ctx_present = True
     else:
-        for engine in settings.TEMPLATES:
+        for engine in template.engines.templates.values():
             if allauth_ctx in engine.get('OPTIONS', {})\
                     .get('context_processors', []):
                 ctx_present = True

--- a/allauth/app_settings.py
+++ b/allauth/app_settings.py
@@ -11,21 +11,24 @@ def check_context_processors():
     ctx_present = False
 
     if django.VERSION < (1, 8,):
+        setting = "settings.TEMPLATE_CONTEXT_PROCESSORS"
         if allauth_ctx in settings.TEMPLATE_CONTEXT_PROCESSORS:
             ctx_present = True
     else:
-        for engine in template.engines.templates.values():
+        for name, engine in template.engines.templates.items():
             if allauth_ctx in engine.get('OPTIONS', {})\
                     .get('context_processors', []):
                 ctx_present = True
-                break
+            else:
+                setting = "settings.TEMPLATES['{}']['OPTIONS']['context_processors']"
+                setting = setting.format(name)
 
     if not ctx_present:
         excmsg = ("socialaccount context processor "
-                  "not found in settings.TEMPLATE_CONTEXT_PROCESSORS."
+                  "not found in {}. "
                   "See settings.py instructions here: "
-                  "https://github.com/pennersr/django-allauth#installation")
-        raise ImproperlyConfigured(excmsg)
+                  "http://django-allauth.readthedocs.org/en/latest/installation.html")
+        raise ImproperlyConfigured(excmsg.format(setting))
 
 
 if SOCIALACCOUNT_ENABLED:


### PR DESCRIPTION
As per #952, here is a proposed change so the context processor check works with an un-migrated django 1.8 settings file.

While I was at it, I also cleaned up the error message.