### PR TITLE
Minor changes to account email view

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -343,6 +343,10 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
             # Given that we bypassed AjaxCapableProcessFormViewMixin,
             # we'll have to call invoke it manually...
             res = _ajax_response(request, res)
+        else:
+            # No email address selected
+            res = HttpResponseRedirect(reverse('account_email'))
+            res = _ajax_response(request, res)
         return res
 
     def _action_send(self, request, *args, **kwargs):

--- a/allauth/templates/account/email.html
+++ b/allauth/templates/account/email.html
@@ -17,7 +17,7 @@
 <div class="ctrlHolder">
       <label for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
 
-      <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
+      <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary or user.emailaddress_set.count == 1 %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
 
 {{ emailaddress.email }}
     {% if emailaddress.verified %}


### PR DESCRIPTION
Fixes a 500 error when submitting the email_list form without an address selected.
Pre-selects the user's only email address when they have no primary address set.