### PR TITLE
Add support for Baidu provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
  - "3.4"
 env:
   global:
-   - TEST_APPS="allauth account socialaccount amazon angellist bitbucket coinbase evernote feedly foursquare douban dropbox dropbox_oauth2 facebook flickr google github hubic instagram linkedin linkedin_oauth2 mailru odnoklassniki windowslive openid orcid paypal persona soundcloud spotify stackexchange tumblr twitch twitter vimeo vk weibo bitly xing"
+   - TEST_APPS="allauth account socialaccount amazon angellist baidu bitbucket coinbase evernote feedly foursquare douban dropbox dropbox_oauth2 facebook flickr google github hubic instagram linkedin linkedin_oauth2 mailru odnoklassniki windowslive openid orcid paypal persona soundcloud spotify stackexchange tumblr twitch twitter vimeo vk weibo bitly xing"
   matrix:
    - DJANGO=Django==1.5
    - DJANGO=Django==1.6

--- a/allauth/socialaccount/providers/baidu/models.py
+++ b/allauth/socialaccount/providers/baidu/models.py
@@ -1,0 +1,1 @@
+# Create your models here.

--- a/allauth/socialaccount/providers/baidu/provider.py
+++ b/allauth/socialaccount/providers/baidu/provider.py
@@ -1,0 +1,32 @@
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class BaiduAccount(ProviderAccount):
+    def get_profile_url(self):
+        return 'https://openapi.baidu.com/rest/2.0/passport/users/getLoggedInUser'
+
+    def get_avatar_url(self):
+        return 'http://tb.himg.baidu.com/sys/portraitn/item/' + self.account.extra_data.get('portrait')
+
+    def to_str(self):
+        dflt = super(BaiduAccount, self).to_str()
+        return self.account.extra_data.get('uname', dflt)
+
+
+class BaiduProvider(OAuth2Provider):
+    id = 'baidu'
+    name = 'Baidu'
+    package = 'allauth.socialaccount.providers.baidu'
+    account_class = BaiduAccount
+
+    def extract_uid(self, data):
+        return data['uid']
+
+    def extract_common_fields(self, data):
+        return dict(username=data.get('uid'),
+                    name=data.get('uname'))
+
+
+providers.registry.register(BaiduProvider)

--- a/allauth/socialaccount/providers/baidu/tests.py
+++ b/allauth/socialaccount/providers/baidu/tests.py
@@ -1,0 +1,11 @@
+from allauth.socialaccount.tests import create_oauth2_tests
+from allauth.tests import MockedResponse
+from allauth.socialaccount.providers import registry
+
+from .provider import BaiduProvider
+
+class BaiduTests(create_oauth2_tests(registry.by_id(BaiduProvider.id))):
+    def get_mocked_response(self):
+        return MockedResponse(200, """{"bi_followers_count": 0, "domain": "", "avatar_large": "http://tp3.sinaimg.cn/3195025850/180/0/0", "block_word": 0, "star": 0, "id": 3195025850, "city": "1", "verified": false, "follow_me": false, "verified_reason": "", "followers_count": 6, "location": "\u5317\u4eac \u4e1c\u57ce\u533a", "mbtype": 0, "profile_url": "u/3195025850", "province": "11", "statuses_count": 0, "description": "", "friends_count": 0, "online_status": 0, "mbrank": 0, "idstr": "3195025850", "profile_image_url": "http://tp3.sinaimg.cn/3195025850/50/0/0", "allow_all_act_msg": false, "allow_all_comment": true, "geo_enabled": true, "name": "pennersr", "lang": "zh-cn", "weihao": "", "remark": "", "favourites_count": 0, "screen_name": "pennersr", "url": "", "gender": "f", "created_at": "Tue Feb 19 19:43:39 +0800 2013", "verified_type": -1, "following": false}
+
+""")

--- a/allauth/socialaccount/providers/baidu/tests.py
+++ b/allauth/socialaccount/providers/baidu/tests.py
@@ -6,6 +6,4 @@ from .provider import BaiduProvider
 
 class BaiduTests(create_oauth2_tests(registry.by_id(BaiduProvider.id))):
     def get_mocked_response(self):
-        return MockedResponse(200, """{"bi_followers_count": 0, "domain": "", "avatar_large": "http://tp3.sinaimg.cn/3195025850/180/0/0", "block_word": 0, "star": 0, "id": 3195025850, "city": "1", "verified": false, "follow_me": false, "verified_reason": "", "followers_count": 6, "location": "\u5317\u4eac \u4e1c\u57ce\u533a", "mbtype": 0, "profile_url": "u/3195025850", "province": "11", "statuses_count": 0, "description": "", "friends_count": 0, "online_status": 0, "mbrank": 0, "idstr": "3195025850", "profile_image_url": "http://tp3.sinaimg.cn/3195025850/50/0/0", "allow_all_act_msg": false, "allow_all_comment": true, "geo_enabled": true, "name": "pennersr", "lang": "zh-cn", "weihao": "", "remark": "", "favourites_count": 0, "screen_name": "pennersr", "url": "", "gender": "f", "created_at": "Tue Feb 19 19:43:39 +0800 2013", "verified_type": -1, "following": false}
-
-""")
+        return MockedResponse(200, """{"portrait": "78c0e9839de59bbde7859ccf43", "uname": "\u90dd\u56fd\u715c", "uid": "3225892368"}""")

--- a/allauth/socialaccount/providers/baidu/urls.py
+++ b/allauth/socialaccount/providers/baidu/urls.py
@@ -1,0 +1,6 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+
+from .provider import BaiduProvider
+
+urlpatterns = default_urlpatterns(BaiduProvider)
+

--- a/allauth/socialaccount/providers/baidu/views.py
+++ b/allauth/socialaccount/providers/baidu/views.py
@@ -1,0 +1,25 @@
+import requests
+
+from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
+                                                          OAuth2LoginView,
+                                                          OAuth2CallbackView)
+
+from .provider import BaiduProvider
+
+
+class BaiduOAuth2Adapter(OAuth2Adapter):
+    provider_id = BaiduProvider.id
+    access_token_url = 'https://openapi.baidu.com/oauth/2.0/token'
+    authorize_url = 'https://openapi.baidu.com/oauth/2.0/authorize'
+    profile_url = 'https://openapi.baidu.com/rest/2.0/passport/users/getLoggedInUser'
+
+    def complete_login(self, request, app, token, **kwargs):
+        resp = requests.get(self.profile_url,
+                            params={'access_token': token.token})
+        extra_data = resp.json()
+        return self.get_provider().sociallogin_from_response(request,
+                                                             extra_data)
+
+
+oauth2_login = OAuth2LoginView.adapter_view(BaiduOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(BaiduOAuth2Adapter)

--- a/test_settings.py
+++ b/test_settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount',
     'allauth.socialaccount.providers.amazon',
     'allauth.socialaccount.providers.angellist',
+    'allauth.socialaccount.providers.baidu',
     'allauth.socialaccount.providers.bitbucket',
     'allauth.socialaccount.providers.bitly',
     'allauth.socialaccount.providers.coinbase',


### PR DESCRIPTION
The Baidu OAuth2 authentication document is here:
1. http://developer.baidu.com/wiki/index.php?title=docs/oauth/refresh
2. http://developer.baidu.com/wiki/index.php?title=docs/oauth/rest/file_data_apis_lista

Baidu developer platform provides several set of useful APIs, for example
the PCS API could be used to operate user's Cloud Storage.