### PR TITLE
Allow user to specify extra auth parameters for Flickr (and generic OAuth) providers

### DIFF
--- a/allauth/socialaccount/providers/flickr/provider.py
+++ b/allauth/socialaccount/providers/flickr/provider.py
@@ -28,6 +28,13 @@ class FlickrProvider(OAuthProvider):
         scope = []
         return scope
 
+    def get_auth_params(self, request, action):
+        ret = super(FlickrProvider, self).get_auth_params(request,
+                                                          action)
+        if 'perms' not in ret:
+            ret['perms'] = 'read'
+        return ret
+
     def get_profile_fields(self):
         default_fields = ['id',
                           'first-name',

--- a/allauth/socialaccount/providers/oauth/client.py
+++ b/allauth/socialaccount/providers/oauth/client.py
@@ -133,7 +133,7 @@ class OAuthClient(object):
             return False
         return True
 
-    def get_redirect(self, authorization_url):
+    def get_redirect(self, authorization_url, extra_params):
         """
         Returns a ``HttpResponseRedirect`` object to redirect the user
         to the URL the OAuth provider handles authorization.
@@ -142,6 +142,7 @@ class OAuthClient(object):
         params = {'oauth_token': request_token['oauth_token'],
                   'oauth_callback': self.request.build_absolute_uri(
                       self.callback_url)}
+        params.update(extra_params)
         url = authorization_url + '?' + urlencode(params)
         return HttpResponseRedirect(url)
 

--- a/allauth/socialaccount/providers/oauth/provider.py
+++ b/allauth/socialaccount/providers/oauth/provider.py
@@ -1,3 +1,8 @@
+try:
+    from urllib.parse import parse_qsl
+except ImportError:
+    from urlparse import parse_qsl
+
 from django.core.urlresolvers import reverse
 from django.utils.http import urlencode
 
@@ -11,6 +16,14 @@ class OAuthProvider(Provider):
         if kwargs:
             url = url + '?' + urlencode(kwargs)
         return url
+
+    def get_auth_params(self, request, action):
+        settings = self.get_settings()
+        ret = settings.get('AUTH_PARAMS', {})
+        dynamic_auth_params = request.GET.get('auth_params', None)
+        if dynamic_auth_params:
+            ret.update(dict(parse_qsl(dynamic_auth_params)))
+        return ret
 
     def get_auth_url(self, request, action):
         # TODO: This is ugly. Move authorization_url away from the

--- a/allauth/socialaccount/providers/oauth/views.py
+++ b/allauth/socialaccount/providers/oauth/views.py
@@ -57,9 +57,10 @@ class OAuthLoginView(OAuthView):
         provider = self.adapter.get_provider()
         auth_url = provider.get_auth_url(request,
                                          action) or self.adapter.authorize_url
+        auth_params = provider.get_auth_params(request, action)
         client = self._get_client(request, callback_url)
         try:
-            return client.get_redirect(auth_url)
+            return client.get_redirect(auth_url, auth_params)
         except OAuthError as e:
             return render_authentication_error(request,
                                                self.adapter.provider_id,

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -143,6 +143,22 @@ The provider is OAuth2 based. More info:
 
 Note: This is not the same as the Mozilla Persona provider below.
 
+Flickr
+------
+
+App registration
+    https://www.flickr.com/services/apps/create/
+
+You can optionally specify the application permissions to use. If no `perms`
+value is set, the Flickr provider will use `read` by default.::
+
+    SOCIALACCOUNT_PROVIDERS = \
+        { 'flickr':
+            { 'AUTH_PARAMS': { 'perms': 'write' } }}
+
+More info:
+    https://www.flickr.com/services/api/auth.oauth.html#authorization
+
 GitHub
 ------
 


### PR DESCRIPTION
Flickr apparently requires an app to pass a 'perms' parameter when authenticating, even though the API documentation states that it is optional. Users can now configure this for flickr (and any other OAuth provider) with the AUTH_PARAMS setting. This works the same way as the existing functionality for OAuth2 providers.