### PR TITLE
Replace pypip badges with shield.io ( badges/pypipins#37 )

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ Welcome to django-allauth!
 .. image:: https://travis-ci.org/pennersr/django-allauth.png
    :target: http://travis-ci.org/pennersr/django-allauth
 
-.. image:: https://pypip.in/d/django-allauth/badge.png
-   :target: https://crate.io/packages/django-allauth?version=latest
+.. image:: https://img.shields.io/pypi/v/django-allauth.svg
+   :target: https://pypi.python.org/pypi/django-allauth
 
 .. image:: https://coveralls.io/repos/pennersr/django-allauth/badge.png?branch=master
    :alt: Coverage Status


### PR DESCRIPTION
The badge hosting at 'pypip.in' has been broken for a while now