### PR TITLE
Add UUID support for password reset

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -8,6 +8,7 @@ except ImportError:
 import django
 from django.contrib import messages
 from django.core.urlresolvers import reverse
+from django.db import models
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.utils import six
@@ -362,16 +363,25 @@ def passthrough_next_redirect_url(request, url, redirect_field_name):
 
 
 def user_pk_to_url_str(user):
+    """
+    This should return a string.
+    """
+    User = get_user_model()
+    if hasattr(models, 'UUIDField') and issubclass(type(User._meta.pk), models.UUIDField):
+        return user.pk.hex
+
     ret = user.pk
     if isinstance(ret, six.integer_types):
         ret = int_to_base36(user.pk)
-    return ret
+    return str(ret)
 
 
 def url_str_to_user_pk(s):
     User = get_user_model()
     # TODO: Ugh, isn't there a cleaner way to determine whether or not
     # the PK is a str-like field?
+    if hasattr(models, 'UUIDField') and issubclass(type(User._meta.pk), models.UUIDField):
+        return s
     try:
         User._meta.pk.to_python('a')
         pk = s


### PR DESCRIPTION
Fix for #994 
Basically add some tests for the uuid field serialization in the urls, and force casting to string on the user_pk_to_url_str method