### PR TITLE
change redirect_ui to make Android cross client identity happy

### DIFF
--- a/allauth/socialaccount/providers/oauth2/client.py
+++ b/allauth/socialaccount/providers/oauth2/client.py
@@ -40,7 +40,7 @@ class OAuth2Client(object):
 
     def get_access_token(self, code):
         data = {'client_id': self.consumer_key,
-                'redirect_uri': self.callback_url,
+                'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
                 'grant_type': 'authorization_code',
                 'client_secret': self.consumer_secret,
                 'scope': self.scope,


### PR DESCRIPTION
This is a change that can make the code generated by Android for OAuth work. Using the standard logic here causes the incorrect redirect_uri value to be passed, which makes Google unhappy. This fix should not be pushed to production, because clearly it wipes out important functionality for other uses. This is a reference point only.