### PR TITLE
Maintain atomic transactions across django 1.4 to 1.8

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -65,7 +65,12 @@ class EmailAddress(models.Model):
         """
         Given a new email address, change self and re-confirm.
         """
-        with transaction.commit_on_success():
+        try:
+            atomic_transaction = transaction.atomic
+        except AttributeError:
+            atomic_transaction = transaction.commit_on_success
+
+        with atomic_transaction():
             user_email(self.user, new_email)
             self.user.save()
             self.email = new_email


### PR DESCRIPTION
Make sure we use the proper decorator for an atomic transaction across all Django versions.