### PR TITLE
Moving control of email confirmation into adapter layer

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -2,16 +2,14 @@ from __future__ import unicode_literals
 
 import datetime
 
-from django.core.urlresolvers import reverse
+
 from django.db import models
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
-from django.contrib.sites.models import Site
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.crypto import get_random_string
 
-from ..utils import build_absolute_uri
 from .. import app_settings as allauth_app_settings
 from . import app_settings
 from . import signals
@@ -58,7 +56,7 @@ class EmailAddress(models.Model):
 
     def send_confirmation(self, request, signup=False):
         confirmation = EmailConfirmation.create(self)
-        confirmation.send(request, signup=signup)
+        confirmation.send(request, signup)
         return confirmation
 
     def change(self, request, new_email, confirm=True):
@@ -117,25 +115,10 @@ class EmailConfirmation(models.Model):
             return email_address
 
     def send(self, request, signup=False, **kwargs):
-        current_site = kwargs["site"] if "site" in kwargs \
-            else Site.objects.get_current()
-        activate_url = reverse("account_confirm_email", args=[self.key])
-        activate_url = build_absolute_uri(request,
-                                          activate_url,
-                                          protocol=app_settings.DEFAULT_HTTP_PROTOCOL)
-        ctx = {
-            "user": self.email_address.user,
-            "activate_url": activate_url,
-            "current_site": current_site,
-            "key": self.key,
-        }
-        if signup:
-            email_template = 'account/email/email_confirmation_signup'
-        else:
-            email_template = 'account/email/email_confirmation'
-        get_adapter().send_mail(email_template,
-                                self.email_address.email,
-                                ctx)
+        get_adapter().send_confirmation_mail(request,
+                                             self,
+                                             signup,
+                                             **kwargs)
         self.sent = timezone.now()
         self.save()
         signals.email_confirmation_sent.send(sender=self.__class__,


### PR DESCRIPTION
This pull request allows full control over sending of confirmation emails through the standard approach taken in this project: adapter customization. In my specific case, this is critical such that I can defer preparation and sending of this mail to an async queue plus take more sophisticated approaches to confirmation, such as deep-linking into a mobile application.

Also, it removes any remaining reversal/knowledge of specifically named URLs out of the model layer allowing easier use of allauth in a pure API capacity without forcing dependent projects to set up dummy url configurations. For example, https://github.com/Tivix/django-rest-auth/blob/master/rest_auth/registration/urls.py#L22.

Thanks! Let me know if there's anything you'd like adjusted. :)