### PR TITLE
Enable exchanging short-lived FB token for long-lived.

### DIFF
--- a/allauth/socialaccount/providers/facebook/views.py
+++ b/allauth/socialaccount/providers/facebook/views.py
@@ -65,6 +65,14 @@ def login_by_token(request):
                     ok = nonce and nonce == info.get('auth_nonce')
                 else:
                     ok = True
+                if ok and provider.get_settings().get('EXCHANGE_TOKEN'):
+                    resp = requests.get(
+                        GRAPH_API_URL + '/oauth/access_token',
+                        params={'grant_type': 'fb_exchange_token',
+                                'client_id': app.client_id,
+                                'client_secret': app.secret,
+                                'fb_exchange_token': access_token}).json()
+                    access_token = resp['access_token']
                 if ok:
                     token = SocialToken(app=app,
                                         token=access_token)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -95,9 +95,10 @@ The following Facebook settings are available::
 
     SOCIALACCOUNT_PROVIDERS = \
         {'facebook':
-           {'SCOPE': ['email', 'public_profile', 'user_friends'],
+           {'METHOD': 'oauth2',
+            'SCOPE': ['email', 'public_profile', 'user_friends'],
             'AUTH_PARAMS': {'auth_type': 'reauthenticate'},
-            'METHOD': 'oauth2',
+            'EXCHANGE_TOKEN': True,
             'LOCALE_FUNC': 'path.to.callable',
             'VERIFIED_EMAIL': False,
             'VERSION': 'v2.3'}}
@@ -114,6 +115,12 @@ SCOPE:
 AUTH_PARAMS:
     Use `AUTH_PARAMS` to pass along other parameters to the `FB.login`
     JS SDK call.
+
+EXCHANGE_TOKEN:
+    The JS SDK returns a short-lived token suitable for client-side use. Set
+    `EXCHANGE_TOKEN = True` to make a server-side request to upgrade to a
+    long-lived token before storing in the `SocialToken` record. See
+    `Expiration and Extending Tokens <https://developers.facebook.com/docs/facebook-login/access-tokens#extending>`_.
 
 LOCALE_FUNC:
     The locale for the JS SDK is chosen based on the current active language of


### PR DESCRIPTION
The JS SDK returns a short-lived (hours) token. This is fine for
client-side use, but not as suitable for storing in the database.
Add the EXCHANGE_TOKEN setting (False by default for now) to immediately
upgrade to a long-lived token before storing in the SocialToken record.