### PR TITLE
Replace social account ctx processor with template tag

### DIFF
--- a/allauth/account/context_processors.py
+++ b/allauth/account/context_processors.py
@@ -1,6 +1,0 @@
-def account(request):
-    # We used to have this due to the now removed
-    # settings.CONTACT_EMAIL. Let's see if we need a context processor
-    # in the future, otherwise, deprecate this context processor
-    # completely.
-    return { }

--- a/allauth/app_settings.py
+++ b/allauth/app_settings.py
@@ -1,39 +1,6 @@
-import django
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-from django import template
 
 SOCIALACCOUNT_ENABLED = 'allauth.socialaccount' in settings.INSTALLED_APPS
-
-
-def check_context_processors():
-    allauth_ctx = 'allauth.socialaccount.context_processors.socialaccount'
-    ctx_present = False
-
-    if django.VERSION < (1, 8,):
-        setting = "settings.TEMPLATE_CONTEXT_PROCESSORS"
-        if allauth_ctx in settings.TEMPLATE_CONTEXT_PROCESSORS:
-            ctx_present = True
-    else:
-        for name, engine in template.engines.templates.items():
-            if allauth_ctx in engine.get('OPTIONS', {})\
-                    .get('context_processors', []):
-                ctx_present = True
-            else:
-                setting = "settings.TEMPLATES['{}']['OPTIONS']['context_processors']"
-                setting = setting.format(name)
-
-    if not ctx_present:
-        excmsg = ("socialaccount context processor "
-                  "not found in {}. "
-                  "See settings.py instructions here: "
-                  "http://django-allauth.readthedocs.org/en/latest/installation.html")
-        raise ImproperlyConfigured(excmsg.format(setting))
-
-
-if SOCIALACCOUNT_ENABLED:
-    check_context_processors()
-
 
 LOGIN_REDIRECT_URL = getattr(settings, 'LOGIN_REDIRECT_URL', '/')
 

--- a/allauth/socialaccount/context_processors.py
+++ b/allauth/socialaccount/context_processors.py
@@ -1,5 +1,0 @@
-from . import providers
-
-def socialaccount(request):
-    ctx = { 'providers': providers.registry.get_list() }
-    return dict(socialaccount=ctx)

--- a/allauth/socialaccount/templatetags/socialaccount.py
+++ b/allauth/socialaccount/templatetags/socialaccount.py
@@ -78,3 +78,16 @@ def get_social_accounts(user):
         providers = accounts.setdefault(account.provider, [])
         providers.append(account)
     return accounts
+
+
+@register.assignment_tag
+def get_providers():
+    """
+    Returns a list of social authentication providers.
+
+    Usage: `{% get_providers as socialaccount_providers %}`.
+
+    Then within the template context, `socialaccount_providers` will hold
+    a list of social providers configured for the current site.
+    """
+    return providers.registry.get_list()

--- a/allauth/templates/account/login.html
+++ b/allauth/templates/account/login.html
@@ -1,7 +1,7 @@
 {% extends "account/base.html" %}
 
 {% load i18n %}
-{% load account %}
+{% load account socialaccount %}
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
@@ -9,7 +9,9 @@
 
 <h1>{% trans "Sign In" %}</h1>
 
-{% if socialaccount.providers %}
+{% get_providers as socialaccount_providers %}
+
+{% if socialaccount_providers %}
 <p>{% blocktrans with site.name as site_name %}Please sign in with one
 of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
 for a {{ site_name }} account and sign in below:{% endblocktrans %}</p>

--- a/allauth/templates/socialaccount/snippets/provider_list.html
+++ b/allauth/templates/socialaccount/snippets/provider_list.html
@@ -1,6 +1,8 @@
 {% load socialaccount %}
 
-{% for provider in socialaccount.providers %}
+{% get_providers as socialaccount_providers %}
+
+{% for provider in socialaccount_providers %}
 {% if provider.id == "openid" %}
 {% for brand in provider.get_brands %}
 <li>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,15 @@ Changelog
 This chapter contains notes on upgrading.
 
 
+From 0.21.0
+***********
+
+- Allauth doesn't enforce template context processors anymore. The context
+  processor for ``allauth.account`` was already empty, and the context
+  processor for ``allauth.socialaccount`` has been converted into the
+  :doc:`{% get_providers %} <templates>` template tag.
+
+
 From 0.20.0
 ***********
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,6 @@ settings.py::
         'django.core.context_processors.request',
         ...
         # `allauth` specific context processors
-        'allauth.account.context_processors.account',
         'allauth.socialaccount.context_processors.socialaccount',
         ...
     )
@@ -37,7 +36,6 @@ settings.py::
                     'django.template.context_processors.request',
 
                     # `allauth` specific context processors
-                    'allauth.account.context_processors.account',
                     'allauth.socialaccount.context_processors.socialaccount',
                 ],
             },

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,9 +16,6 @@ settings.py::
         # Required by `allauth` template tags
         'django.core.context_processors.request',
         ...
-        # `allauth` specific context processors
-        'allauth.socialaccount.context_processors.socialaccount',
-        ...
     )
 
     # If you are running Django 1.8+, specify the context processors
@@ -34,9 +31,6 @@ settings.py::
 
                     # `allauth` needs this from django
                     'django.template.context_processors.request',
-
-                    # `allauth` specific context processors
-                    'allauth.socialaccount.context_processors.socialaccount',
                 ],
             },
         },

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -70,3 +70,14 @@ Then::
     {{accounts.twitter}} -- a list of connected Twitter accounts
     {{accounts.twitter.0}} -- the first Twitter account
     {% if accounts %} -- if there is at least one social account
+
+
+Finally, social authentication providers configured for the current site
+can be retrieved via::
+
+    {% get_providers as socialaccount_providers %}
+
+Which will populate the ``socialaccount_providers`` variable in the
+template context with a list of configured social authentication
+providers. This supersedes the context processor used in version 0.21 and
+below.

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -117,8 +117,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.static",
     "django.core.context_processors.request",
     "django.contrib.messages.context_processors.messages",
-
-    "allauth.socialaccount.context_processors.socialaccount",
 )
 
 TEMPLATE_DIRS = (

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -118,7 +118,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.request",
     "django.contrib.messages.context_processors.messages",
 
-    "allauth.account.context_processors.account",
     "allauth.socialaccount.context_processors.socialaccount",
 )
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -31,7 +31,6 @@ if django.VERSION >= (1, 8):
                     'django.contrib.auth.context_processors.auth',
                     'django.contrib.messages.context_processors.messages',
                     'django.core.context_processors.request',
-                    'allauth.socialaccount.context_processors.socialaccount',
                 ],
             },
         },
@@ -45,8 +44,6 @@ else:
         "django.core.context_processors.static",
         "django.core.context_processors.request",
         "django.contrib.messages.context_processors.messages",
-    
-        "allauth.socialaccount.context_processors.socialaccount",
     )
 
 MIDDLEWARE_CLASSES = (

--- a/test_settings.py
+++ b/test_settings.py
@@ -31,7 +31,6 @@ if django.VERSION >= (1, 8):
                     'django.contrib.auth.context_processors.auth',
                     'django.contrib.messages.context_processors.messages',
                     'django.core.context_processors.request',
-                    'allauth.account.context_processors.account',
                     'allauth.socialaccount.context_processors.socialaccount',
                 ],
             },
@@ -47,7 +46,6 @@ else:
         "django.core.context_processors.request",
         "django.contrib.messages.context_processors.messages",
     
-        "allauth.account.context_processors.account",
         "allauth.socialaccount.context_processors.socialaccount",
     )
 


### PR DESCRIPTION
This basically removes the need to use a ctx processor even if sites don't need it.

It also removes the empty ctx processor from `allauth.account`.

Fixes #949.