### PR TITLE
ORCID provider: fix extract_from_dict

### DIFF
--- a/allauth/socialaccount/providers/orcid/provider.py
+++ b/allauth/socialaccount/providers/orcid/provider.py
@@ -58,5 +58,5 @@ def extract_from_dict(data, path):
         for key in path:
             value = value[key]
         return value
-    except (KeyError, IndexError):
+    except (KeyError, IndexError, TypeError):
         return ''


### PR DESCRIPTION
extract_from_dict fails when one of the intermediate values is None, raising a TypeError that was not caught properly. This happens when the some of the information is not present in the profile (e.g. the email address that can be hidden).