### PR TITLE
Remove deprecated django.core.context_processors.request

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -30,7 +30,6 @@ if django.VERSION >= (1, 8):
                     'django.template.context_processors.request',
                     'django.contrib.auth.context_processors.auth',
                     'django.contrib.messages.context_processors.messages',
-                    'django.core.context_processors.request',
                     'allauth.account.context_processors.account',
                     'allauth.socialaccount.context_processors.socialaccount',
                 ],


### PR DESCRIPTION
`django.core.context_processors.request` is deprecated since Django 1.8. 
It's suggested to remove it in django version >= 1.8 case to avoid confusion.