### PR TITLE
Removed remaining reliance on context_processors

### DIFF
--- a/example/example/templates/bootstrap/allauth/account/login.html
+++ b/example/example/templates/bootstrap/allauth/account/login.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 {% load bootstrap %}
-{% load account %}
+{% load account socialaccount %}
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
@@ -11,7 +11,8 @@
 
 <h1>{% trans "Sign In" %}</h1>
 
-{% if socialaccount.providers %}
+{% get_providers as socialaccount_providers %}
+{% if socialaccount_providers %}
 <p>{% blocktrans with site.name as site_name %}Please sign in with one
 of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
 for a {{ site_name }} account and sign in

--- a/example/example/templates/uniform/allauth/account/login.html
+++ b/example/example/templates/uniform/allauth/account/login.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 {% load uni_form_tags %}
-{% load account %}
+{% load account socialaccount %}
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
@@ -11,7 +11,8 @@
 
 <h1>{% trans "Sign In" %}</h1>
 
-{% if socialaccount.providers  %}
+{% get_providers as socialaccount_providers %}
+{% if socialaccount_providers %}
 <p>{% blocktrans with site.name as site_name %}Please sign in with one
 of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
 for a {{site_name}} account and sign in


### PR DESCRIPTION
Removed reliance on context_processors from Bootstrap and Uniform examples; fixes #949.