### PR TITLE
Added option to automatically sign in after password reset

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -190,6 +190,13 @@ class AppSettings(object):
         return self._setting('LOGIN_ON_EMAIL_CONFIRMATION', False)
 
     @property
+    def LOGIN_ON_PASSWORD_RESET(self):
+        """
+        Automatically log the user in immediately after resetting their password.
+        """
+        return self._setting('LOGIN_ON_PASSWORD_RESET', False)
+
+    @property
     def LOGOUT_REDIRECT_URL(self):
         return self._setting('LOGOUT_REDIRECT_URL', '/')
 

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -185,9 +185,9 @@ class AppSettings(object):
     @property
     def LOGIN_ON_EMAIL_CONFIRMATION(self):
         """
-        Autmatically log the user in once they confirmed their email address
+        Automatically log the user in once they confirmed their email address
         """
-        return self._setting('LOGIN_ON_EMAIL_CONFIRMATION', True)
+        return self._setting('LOGIN_ON_EMAIL_CONFIRMATION', False)
 
     @property
     def LOGOUT_REDIRECT_URL(self):

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -614,6 +614,11 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
         signals.password_reset.send(sender=self.reset_user.__class__,
                                     request=self.request,
                                     user=self.reset_user)
+
+        if app_settings.LOGIN_ON_PASSWORD_RESET:
+            return perform_login(request, self.reset_user,
+                                 email_verification=app_settings.EMAIL_VERIFICATION)
+
         return super(PasswordResetFromKeyView, self).form_valid(form)
 
 password_reset_from_key = PasswordResetFromKeyView.as_view()

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -110,14 +110,15 @@ ACCOUNT_PASSWORD_INPUT_RENDER_VALUE (=False)
 ACCOUNT_PASSWORD_MIN_LENGTH (=6)
   An integer specifying the minimum password length.
 
-ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION (=True)
-  The default behaviour is to automatically log users in once they confirm
-  their email address. Note however that this only works when confirming
-  the email address **immediately after signing up**, assuming users
+ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION (=False)
+  The default behaviour is not log users in and to redirect them to
+  `ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL`.
+
+  By changing this setting to `True`, users will automatically be logged in once
+  they confirm their email address. Note however that this only works when
+  confirming the email address **immediately after signing up**, assuming users
   didn't close their browser or used some sort of private browsing mode.
 
-  By changing this setting to `False` they will not be logged in, but
-  redirected to the `ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL`
 
 ACCOUNT_SESSION_REMEMBER (=None)
   Controls the life time of the session. Set to `None` to ask the user

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -119,6 +119,10 @@ ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION (=False)
   confirming the email address **immediately after signing up**, assuming users
   didn't close their browser or used some sort of private browsing mode.
 
+ACCOUNT_LOGIN_ON_PASSWORD_RESET (=False)
+  By changing this setting to `True`, users will automatically be logged in
+  once they have reset their password. By default they are redirected to the
+  password reset done page.
 
 ACCOUNT_SESSION_REMEMBER (=None)
   Controls the life time of the session. Set to `None` to ask the user


### PR DESCRIPTION
As discussed in #735, this PR adds the option to automatically sign users in after they have reset their password successfully.

Based on the opinions on the issue, the default for `LOGIN_ON_EMAIL_CONFIRMATION` has also been adjusted to `False`.