### PR TITLE
Correct data extraction for Twitch username fields

### DIFF
--- a/allauth/socialaccount/providers/twitch/provider.py
+++ b/allauth/socialaccount/providers/twitch/provider.py
@@ -25,8 +25,8 @@ class TwitchProvider(OAuth2Provider):
         return str(data['_id'])
 
     def extract_common_fields(self, data):
-        return dict(username=data.get('display_name'),
-                    name=data.get('name'),
+        return dict(username=data.get('name'),
+                    name=data.get('display_name'),
                     email=data.get('email'))
 
 


### PR DESCRIPTION
To generate a Django user (username, first name, last name etc.) from a first-time login with a social account, user data extracted from the Twitch API is used. The extra common fields 'username' and 'name' are mapped as following to the Django user:
* username = Django user's unique username
* name = split(' ') up in parts, name[0] is first name etc.
That seems fine.

Currently Twitch API's JSON data contains a field 'name' and a field 'display_name'.
'name' is fixed and also represents the channel's name/channel URL.
'display_name' can be changed by users as often as they want. (They are only able to change capitalization - however there are Twitch staff members which have a 'display_name' being totally different from their 'name'.)

*Sources:*
* *http://help.twitch.tv/customer/portal/questions/11494383-is-my-channel-name-always-the-same-as-my-twitch-username*
* *https://groups.google.com/forum/#!msg/twitch-api/XRfbKnW6cDs/JkAv_pwW6P4J*
* *Me. Verified it.*

Instead of assigning the changeable 'display_name' to the unique/fixed 'username' and the fixed 'name' to the first name/last name thingy, it should be the other way around.

Would be great to hear about your opinion on this.