### PR TITLE
Auth: fixed `perform_login()` call

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -616,7 +616,7 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
                                     user=self.reset_user)
 
         if app_settings.LOGIN_ON_PASSWORD_RESET:
-            return perform_login(request, self.reset_user,
+            return perform_login(self.request, self.reset_user,
                                  email_verification=app_settings.EMAIL_VERIFICATION)
 
         return super(PasswordResetFromKeyView, self).form_valid(form)


### PR DESCRIPTION
The reference to `request` was incorrect (I had a local variable at the time of creating the patch, sorry about that). Note this prevents the `LOGIN_ON_PASSWORD_RESET` from working properly, so might as well need a release.