### PR TITLE
Speedup travis: Save pip cache, install requirements as wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,17 @@ env:
    - DJANGO="Django<1.7"
    - DJANGO="Django<1.8"
    - DJANGO="Django<1.9"
+cache:
+  directories:
+    - $HOME/.cache/pip
 install:
- - pip install $DJANGO --use-mirrors
- - pip install . --use-mirrors
- - pip install coverage
+ - pip install "pip>=7.0.2" wheel
+ - pip install "$DJANGO" coverage coveralls "mock>=1.0.1"
+ - pip install .
 branches:
  only:
   - master
 script: coverage run manage.py test allauth
 after_success:
   - coverage report
-  - pip install --quiet python-coveralls
   - coveralls


### PR DESCRIPTION
Travis allows saving cache directories between job runs. This can eliminate
the need for pip to download/build requirements every time.

Additionally recent versions of pip will build requirements as wheels, and
cache the built wheel for future installs.

I've also taken the opportunity to
 - Remove uses of the deprecated --use-mirror switch
 - Install all requirements in a single transaction

Together these should speedup each job by 10-15 seconds.

References
 - http://docs.travis-ci.com/user/caching/#pip-cache