### PR TITLE
Add Tox support, reflecting Travis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,14 @@ build
 dist
 *.egg*
 example/local_settings.py
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
 coverage.xml
+
 .ropeproject/*
 pep8.txt
 *.bak

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py{27,32,33,34}-django{16,17,18},
+
+[testenv]
+deps =
+    coverage
+    mock >= 1.0.1
+    django16: Django < 1.7
+    django17: Django < 1.8
+    django18: Django < 1.9
+commands =
+    coverage run manage.py test allauth
+    coverage report
+    coverage html


### PR DESCRIPTION
This allows running the same test matrix that Travis does, but locally.

Rather than upload a report to coveralls this generates an html report
in `./htmlcov`.

Python versions can be installed on Ubuntu using
https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes