### PR TITLE
Check if user.pk is already a string

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -373,6 +373,8 @@ def user_pk_to_url_str(user):
     User = get_user_model()
     if (hasattr(models, 'UUIDField')
             and issubclass(type(User._meta.pk), models.UUIDField)):
+        if isinstance(user.pk, six.string_types):
+            return user.pk
         return user.pk.hex
 
     ret = user.pk


### PR DESCRIPTION
Return the user.pk as str which contains 36chars UUID. This fixes attribute not found error on user.pk.hex when using UUIDField (Django 1.8).