### PR TITLE
OAuth2Client: Do not include `scope` in request for access_token

### DIFF
--- a/allauth/socialaccount/providers/oauth2/client.py
+++ b/allauth/socialaccount/providers/oauth2/client.py
@@ -43,7 +43,6 @@ class OAuth2Client(object):
                 'redirect_uri': self.callback_url,
                 'grant_type': 'authorization_code',
                 'client_secret': self.consumer_secret,
-                'scope': self.scope,
                 'code': code}
         params = None
         self._strip_empty_keys(data)


### PR DESCRIPTION
OAuth2Client sends `scope` as part of the request for an access token. However, this appears to be against [RFC 6749](https://tools.ietf.org/html/rfc6749.html#section-4.1.3) when `grant_type` is "`authorization_code`".

I'm trying to integrate with the Firefox Accounts service, these Access Token requests are rejected with an error. This patch seems to fix the problem. [The service docs for FxA](https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1token) appear to agree with [RFC 6749](https://tools.ietf.org/html/rfc6749.html#section-4.1.3) on this.

But, I'm only working with one particular OAuth2 service for my application (i.e. FxA). So, I'm unsure if there are services that expect `scope` to be included