### PR TITLE
OAuth2View.oauth2client_class to customize client per provider

### DIFF
--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -46,6 +46,8 @@ class OAuth2Adapter(object):
 
 
 class OAuth2View(object):
+    oauth2client_class = OAuth2Client
+
     @classmethod
     def adapter_view(cls, adapter):
         def view(request, *args, **kwargs):
@@ -64,11 +66,11 @@ class OAuth2View(object):
             protocol=protocol)
         provider = self.adapter.get_provider()
         scope = provider.get_scope(request)
-        client = OAuth2Client(self.request, app.client_id, app.secret,
-                              self.adapter.access_token_method,
-                              self.adapter.access_token_url,
-                              callback_url,
-                              scope)
+        client = self.oauth2client_class(self.request, app.client_id, app.secret,
+                                         self.adapter.access_token_method,
+                                         self.adapter.access_token_url,
+                                         callback_url,
+                                         scope)
         return client
 
 


### PR DESCRIPTION
Add `OAuth2View.oauth2client_class` to customize the client per provider. This should rarely be necessary, however I'm implementing against a provider that does whacky things like comma-separated scopes and JSON post/response with custom field names, so I need to subclass `OAuth2Client` to make it work.

Here's an example subclassed `OAuth2Client` and usage:

```python
class MyOAuth2Client(OAuth2Client):
    """
    Subclass of the default allauth OAuth2Client to handle provider's
    whackiness. Comma-separated scopes instead of spaces, and JSON
    post/response with custom field names.
    """
    def __init__(self, *args, **kwargs):
        super(MyOAuth2Client, self).__init__(*args, **kwargs)
        self.scope = ','.join(self.scope.split())

    def get_access_token(self, code):
        data = {'client_id': self.consumer_key,
                'client_secret': self.consumer_secret,
                'authorization_code': code}
        url = self.access_token_url
        resp = requests.post(url, data=json.dumps(data, compact=True))
        logger.info("MyOAuth2Client.get_access_token() %s %r returned %r",
                    url, data, resp.content)
        try:
            return resp.json()
        except Exception:
            raise OAuth2Error("Error retrieving access token: {}\n{}"
                              .format(resp.status_code, resp.content))

class MyOAuth2LoginView(OAuth2LoginView):
    oauth2client_class = MyOAuth2Client

class MyOAuth2CallbackView(OAuth2CallbackView):
    oauth2client_class = MyOAuth2Client

oauth2_login = MyOAuth2LoginView.adapter_view(MyOAuth2Adapter)
oauth2_callback = MyOAuth2CallbackView.adapter_view(MyOAuth2Adapter)
```