### PR TITLE
Avoid OAuth2 scope duplicates (closes #1065)

### DIFF
--- a/allauth/socialaccount/providers/oauth2/provider.py
+++ b/allauth/socialaccount/providers/oauth2/provider.py
@@ -1,3 +1,5 @@
+import re
+
 try:
     from urllib.parse import parse_qsl
 except ImportError:
@@ -32,7 +34,7 @@ class OAuth2Provider(Provider):
             scope = self.get_default_scope()
         dynamic_scope = request.GET.get('scope', None)
         if dynamic_scope:
-            scope.extend(dynamic_scope.split(','))
+            scope.extend(set(re.split(',| ', dynamic_scope)) - set(scope))
         return scope
 
     def get_default_scope(self):


### PR DESCRIPTION
This is a fix for issues discussed here: https://github.com/pennersr/django-allauth/issues/1065
I only tested it with Twitch, but as long as there is no use case/application where scope duplicates actually *do* something - it should work for all other providers, too.
This bug might have been introduced unintentionally by adding this dynamic scope feature here: https://github.com/pennersr/django-allauth/pull/761 (see also the related feature suggestion: https://github.com/pennersr/django-allauth/issues/381)

It's the shortest possible fix I could think of without breaking anything - at least I hope so. (You could also do things like changing the scope setting to a set instead of a list and stuff...)
However, I'm always open to criticism.