### PR TITLE
Send client_id with Twitch requests (closes #1052)

### DIFF
--- a/allauth/socialaccount/providers/twitch/views.py
+++ b/allauth/socialaccount/providers/twitch/views.py
@@ -15,7 +15,7 @@ class TwitchOAuth2Adapter(OAuth2Adapter):
 
     def complete_login(self, request, app, token, **kwargs):
         resp = requests.get(self.profile_url,
-                            params={'oauth_token': token.token})
+                            params={ 'oauth_token': token.token, 'client_id': app.client_id })
         extra_data = resp.json()
         return self.get_provider().sociallogin_from_response(request,
                                                              extra_data)


### PR DESCRIPTION
I think this is the fix which needs to be applied as discussed in https://github.com/pennersr/django-allauth/issues/1052.