### PR TITLE
Add a `related_name` on `EmailAddress`

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -22,7 +22,8 @@ from .adapter import get_adapter
 class EmailAddress(models.Model):
 
     user = models.ForeignKey(allauth_app_settings.USER_MODEL,
-                             verbose_name=_('user'))
+                             verbose_name=_('user'),
+                             related_name='email_addresses')
     email = models.EmailField(unique=app_settings.UNIQUE_EMAIL,
                               max_length=254,
                               verbose_name=_('e-mail address'))


### PR DESCRIPTION
This allow us to access the email addresses of a given user by accessing the new `email_addresses` property of this user:

    user = User.objects.first()
    print(user.email_addresses.all())