### PR TITLE
Remove deprecated `patterns` calls from URL confs

### DIFF
--- a/allauth/account/urls.py
+++ b/allauth/account/urls.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic import RedirectView
 
 from . import views
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^signup/$", views.signup, name="account_signup"),
     url(r"^login/$", views.login, name="account_login"),
     url(r"^logout/$", views.logout, name="account_logout"),
@@ -32,4 +31,4 @@ urlpatterns = patterns(
         name="account_reset_password_from_key"),
     url(r"^password/reset/key/done/$", views.password_reset_from_key_done,
         name="account_reset_password_from_key_done"),
-)
+]

--- a/allauth/socialaccount/providers/facebook/urls.py
+++ b/allauth/socialaccount/providers/facebook/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
 
@@ -7,7 +7,7 @@ from . import views
 
 urlpatterns = default_urlpatterns(FacebookProvider)
 
-urlpatterns += patterns('',
+urlpatterns += [
    url('^facebook/login/token/$', views.login_by_token,
        name="facebook_login_by_token"),
-   )
+]

--- a/allauth/socialaccount/providers/openid/urls.py
+++ b/allauth/socialaccount/providers/openid/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
-urlpatterns = patterns('',
-                       url('^openid/login/$', views.login,
-                           name="openid_login"),
-                       url('^openid/callback/$', views.callback,
-                           name='openid_callback'),
-                       )
+urlpatterns = [
+   url('^openid/login/$', views.login,
+       name="openid_login"),
+   url('^openid/callback/$', views.callback,
+       name='openid_callback'),
+]

--- a/allauth/socialaccount/providers/persona/urls.py
+++ b/allauth/socialaccount/providers/persona/urls.py
@@ -1,8 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
-urlpatterns = patterns('',
-                       url('^persona/login/$',
-                           views.persona_login,
-                           name="persona_login"))
+urlpatterns = [
+   url('^persona/login/$', views.persona_login, name="persona_login")
+]

--- a/allauth/socialaccount/urls.py
+++ b/allauth/socialaccount/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url('^login/cancelled/$', views.login_cancelled,
         name='socialaccount_login_cancelled'),
     url('^login/error/$', views.login_error, name='socialaccount_login_error'),
     url('^signup/$', views.signup, name='socialaccount_signup'),
-    url('^connections/$', views.connections, name='socialaccount_connections'))
+    url('^connections/$', views.connections, name='socialaccount_connections')
+]

--- a/allauth/urls.py
+++ b/allauth/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 
 try:
     import importlib
@@ -9,11 +9,10 @@ from allauth.socialaccount import providers
 
 from . import app_settings
 
-urlpatterns = patterns('', url('^', include('allauth.account.urls')))
+urlpatterns = [url('^', include('allauth.account.urls'))]
 
 if app_settings.SOCIALACCOUNT_ENABLED:
-    urlpatterns += patterns('', url('^social/',
-                                    include('allauth.socialaccount.urls')))
+    urlpatterns += [url('^social/', include('allauth.socialaccount.urls'))]
 
 for provider in providers.registry.get_list():
     try:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -94,11 +94,11 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
 
 urls.py::
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         ...
-        (r'^accounts/', include('allauth.urls')),
+        url(r'^accounts/', include('allauth.urls')),
         ...
-    )
+    ]
 
 
 Post-Installation

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic.base import TemplateView
 admin.autodiscover()
 
-urlpatterns = patterns('',
-                       (r'^accounts/', include('allauth.urls')),
-                       url(r'^$', TemplateView.as_view(template_name='index.html')),
-                       url(r'^accounts/profile/$', TemplateView.as_view(template_name='profile.html')),
-                       url(r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    url(r'^accounts/', include('allauth.urls')),
+    url(r'^$', TemplateView.as_view(template_name='index.html')),
+    url(r'^accounts/profile/$', TemplateView.as_view(template_name='profile.html')),
+    url(r'^admin/', include(admin.site.urls)),
+]


### PR DESCRIPTION
Addresses various warnings running against Django 1.8.4:

> `RemovedInDjango110Warning`: `django.conf.urls.patterns()` is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of `django.conf.urls.url()` instances instead.

* [x] Remove bare `patterns` calls. 
* [ ] Remove `patterns` call from both OAuth `default_urlpatterns` implementations.

       * `allauth/socialaccount/providers/oauth2/urls.py`
       * `allauth/socialaccount/providers/oauth/urls.py`


The `default_urlpatterns` are using `patterns` and the string prefix argument and the string view argument to `url`, which is also deprecated, requiring the callable to be passed instead. As such, I wanted to ask how you wanted that handled before progressing?