### PR TITLE
Adjust JSONField for Django >=1.8

### DIFF
--- a/allauth/socialaccount/fields.py
+++ b/allauth/socialaccount/fields.py
@@ -1,6 +1,7 @@
 # Courtesy of django-social-auth
 import json
 
+import django
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import six
@@ -11,11 +12,17 @@ except ImportError:
     from django.utils.encoding import smart_text
 
 
-class JSONField(six.with_metaclass(models.SubfieldBase,
-                                   models.TextField)):
+if django.VERSION < (1, 8):
+    JSONFieldBase = six.with_metaclass(models.SubfieldBase, models.TextField)
+else:
+    JSONFieldBase = models.TextField
+
+class JSONField(JSONFieldBase):
     """Simple JSON field that stores python structures as JSON strings
     on database.
     """
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
     def to_python(self, value):
         """


### PR DESCRIPTION
Fixes #1117

* Removes deprecated metaclass. 
* Adds `from_db_value` (which just calls `to_python` — _plus ca change_...)

Test suite passed locally but I wasn't sure of the coverage here — will the JSON storage be exercised? If not I can add a test case for the field itself. 

I could move the duplicated code into a mixin but [very shortly](https://www.djangoproject.com/download/#supported-versions) everything in the <1.8 branch can just be deleted. Happy to follow your guidance. 