### PR TITLE
Use render instead of render_to_response

### DIFF
--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -1,8 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth import logout
-from django.shortcuts import render_to_response, render
+from django.shortcuts import render
 from django.http import HttpResponseRedirect
-from django.template import RequestContext
 from django.forms import ValidationError
 from django.core.urlresolvers import reverse
 
@@ -84,9 +83,8 @@ def render_authentication_error(request,
         }
     }
     context.update(extra_context)
-    return render_to_response(
-        "socialaccount/authentication_error.html",
-        context, context_instance=RequestContext(request))
+    return render(
+        request, "socialaccount/authentication_error.html", context)
 
 
 def _add_social_account(request, sociallogin):

--- a/allauth/socialaccount/providers/openid/views.py
+++ b/allauth/socialaccount/providers/openid/views.py
@@ -1,5 +1,4 @@
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+from django.shortcuts import render
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
@@ -68,8 +67,7 @@ def login(request):
         form = LoginForm(initial={'next': request.GET.get('next'),
                                   'process': request.GET.get('process')})
     d = dict(form=form)
-    return render_to_response('openid/login.html',
-                              d, context_instance=RequestContext(request))
+    return render(request, "openid/login.html", d)
 
 
 @csrf_exempt


### PR DESCRIPTION
render also wraps the context in a RequestContext, but works with the Jinja2 template backend in Django 1.8. Fixes #1133.

See [source of shortcuts.py](https://github.com/django/django/blob/master/django/shortcuts.py), and [deprecation note for context-instance](https://docs.djangoproject.com/en/1.8/releases/1.8/#dictionary-and-context-instance-arguments-of-rendering-functions).