### PR TITLE
Fix Python3 related issues

### DIFF
--- a/allauth/__init__.py
+++ b/allauth/__init__.py
@@ -8,7 +8,7 @@
 
 """
 
-VERSION = (0, 23, 0, 'final', 0)
+VERSION = (0, 23, 1, 'dev', 1)
 
 __title__ = 'django-allauth'
 __version_info__ = VERSION

--- a/allauth/account/templatetags/account_tags.py
+++ b/allauth/account/templatetags/account_tags.py
@@ -3,4 +3,4 @@ import warnings
 warnings.warn("{% load account_tags %} is deprecated, use {% load account %}",
               DeprecationWarning)
 
-from account import *  # noqa
+from .account import *  # noqa

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -27,7 +27,11 @@ from .adapter import get_adapter
 from .utils import url_str_to_user_pk, user_pk_to_url_str
 
 import uuid
-import mock
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 @override_settings(

--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -27,7 +27,10 @@ from requests.exceptions import HTTPError
 
 from .provider import GoogleProvider
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 @override_settings(SOCIALACCOUNT_AUTO_SIGNUP=True,

--- a/allauth/socialaccount/templatetags/socialaccount_tags.py
+++ b/allauth/socialaccount/templatetags/socialaccount_tags.py
@@ -3,4 +3,4 @@ import warnings
 warnings.warn("{% load socialaccount_tags %} is deprecated, use"
               " {% load socialaccount %}", DeprecationWarning)
 
-from socialaccount import *
+from .socialaccount import *


### PR DESCRIPTION
This is minimum changes to make it work under Python 3:

* Importing mock library for different Python versions
* Explicit relative imports.

However, I still could not make it work with Django 1.9. It raises a `KeyError` exception:

![screen shot 2015-09-27 at 13 11 43](https://cloud.githubusercontent.com/assets/720283/10122742/99fe8e78-6519-11e5-929e-ccf62f50717c.png)
