### PR TITLE
Moving account user stashing and logout logic to the DefaultAccountAdapter

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -44,10 +44,10 @@ class DefaultAccountAdapter(object):
         request.session['account_verified_email'] = None
         return ret
 
-    def stash_account_user(self, request, user):
+    def stash_user(self, request, user):
         request.session['account_user'] = user
 
-    def unstash_account_user(self, request):
+    def unstash_user(self, request):
         return request.session.pop('account_user', None)
 
     def is_email_verified(self, request, email):

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -316,7 +316,7 @@ def send_email_confirmation(request, user, signup=False):
                                       'email_confirmation_sent.txt',
                                       {'email': email})
     if signup:
-        get_adapter().stash_account_user(request, user_pk_to_url_str(user))
+        get_adapter().stash_user(request, user_pk_to_url_str(user))
 
 
 def sync_user_email_addresses(user):

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -316,7 +316,7 @@ def send_email_confirmation(request, user, signup=False):
                                       'email_confirmation_sent.txt',
                                       {'email': email})
     if signup:
-        request.session['account_user'] = user_pk_to_url_str(user)
+        get_adapter().stash_account_user(request, user_pk_to_url_str(user))
 
 
 def sync_user_email_addresses(user):

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -272,7 +272,7 @@ class ConfirmEmailView(TemplateResponseMixin, View):
         session gets lost), but at least we're secure.
         """
         user_pk = None
-        user_pk_str = self.request.session.pop('account_user', None)
+        user_pk_str = get_adapter().unstash_account_user(self.request)
         if user_pk_str:
             user_pk = url_str_to_user_pk(user_pk_str)
         user = confirmation.email_address.user

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -272,7 +272,7 @@ class ConfirmEmailView(TemplateResponseMixin, View):
         session gets lost), but at least we're secure.
         """
         user_pk = None
-        user_pk_str = get_adapter().unstash_account_user(self.request)
+        user_pk_str = get_adapter().unstash_user(self.request)
         if user_pk_str:
             user_pk = url_str_to_user_pk(user_pk_str)
         user = confirmation.email_address.user

--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -1,5 +1,4 @@
 from django.contrib import messages
-from django.contrib.auth import logout
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
 from django.forms import ValidationError
@@ -150,7 +149,7 @@ def _social_login_redirect(request, sociallogin):
 
 def _complete_social_login(request, sociallogin):
     if request.user.is_authenticated():
-        logout(request)
+        get_account_adapter().logout(request)
     if sociallogin.is_existing:
         # Login existing user
         ret = _login_social_account(request, sociallogin)


### PR DESCRIPTION
I am hitting issues using allauth in a pure API capacity. I do not support sessions/session auth on the API, only token-based auth. The problem is that allauth assumes the availability of `request.session` in several places.

In most instances I've been able to customize my adapters to avoid this dependency on sessions without loss of functionality. The rest are interactions with sessions in utility functions, which I cannot easily override.

This change is just shifting a little logic around to allow me to avoid hitting sessions in those remaining cases.