### PR TITLE
Added ACCOUNT_FORCE_REDIRECT_IF_LOGGED_IN option

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -183,6 +183,10 @@ class AppSettings(object):
         return self._setting('CONFIRM_EMAIL_ON_GET', False)
 
     @property
+    def AUTHENTICATED_LOGIN_REDIRECTS(self):
+        return self._setting('AUTHENTICATED_LOGIN_REDIRECTS', True)
+
+    @property
     def LOGIN_ON_EMAIL_CONFIRMATION(self):
         """
         Automatically log the user in once they confirmed their email address

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -485,6 +485,13 @@ class AccountTests(TestCase):
         # this is not the case:
         self.assertEqual(len(mail.outbox), 1)
 
+    @override_settings(ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS=False)
+    def test_account_authenticated_login_redirects_is_false(self):
+        user = self._create_user_and_login()
+
+        resp = self.client.get(reverse('account_login'))
+        self.assertEqual(resp.status_code, 200)
+
 
 class EmailFormTests(TestCase):
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -57,7 +57,8 @@ class RedirectAuthenticatedUserMixin(object):
         # WORKAROUND: https://code.djangoproject.com/ticket/19316
         self.request = request
         # (end WORKAROUND)
-        if request.user.is_authenticated():
+        if request.user.is_authenticated() and \
+                app_settings.AUTHENTICATED_LOGIN_REDIRECTS:
             redirect_to = self.get_authenticated_redirect_url()
             response = HttpResponseRedirect(redirect_to)
             return _ajax_response(request, response)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -133,6 +133,13 @@ ACCOUNT_SESSION_COOKIE_AGE (=1814400)
   How long before the session cookie expires in seconds.  Defaults to 1814400 seconds,
   or 3 weeks.
 
+ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS( (=True)
+  The default behaviour is to redirect authenticated users to
+  `ACCOUNT_LOGIN_REDIRECT_URL` when they try accessing login/signup pages.
+
+  By changing this setting to `False`, logged in users will not be redirected when
+  they access login/signup pages.
+
 SOCIALACCOUNT_ADAPTER (="allauth.socialaccount.adapter.DefaultSocialAccountAdapter")
   Specifies the adapter class to use, allowing you to alter certain
   default behaviour.


### PR DESCRIPTION
Allows choosing if you want logged in users to be redirected in login/signup pages.