### PR TITLE
Custom user models whose primary key was also a foreign key unable to reset their password.

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -387,11 +387,15 @@ def url_str_to_user_pk(s):
     User = get_user_model()
     # TODO: Ugh, isn't there a cleaner way to determine whether or not
     # the PK is a str-like field?
+    if hasattr(User._meta.pk, 'rel'):
+        pk_field = User._meta.pk.rel.to._meta.pk
+    else:
+        pk_field = User._meta.pk
     if (hasattr(models, 'UUIDField')
-            and issubclass(type(User._meta.pk), models.UUIDField)):
+            and issubclass(type(pk_field), models.UUIDField)):
         return s
     try:
-        User._meta.pk.to_python('a')
+        pk_field.to_python('a')
         pk = s
     except ValidationError:
         pk = base36_to_int(s)

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -387,7 +387,7 @@ def url_str_to_user_pk(s):
     User = get_user_model()
     # TODO: Ugh, isn't there a cleaner way to determine whether or not
     # the PK is a str-like field?
-    if hasattr(User._meta.pk, 'rel'):
+    if getattr(User._meta.pk, 'rel', None):
         pk_field = User._meta.pk.rel.to._meta.pk
     else:
         pk_field = User._meta.pk


### PR DESCRIPTION
The test if the PK is str-like by using .to_python fails on OneOnOneFields/ForeignKeys, because they don't override .to_python, and just return the value without validating. Since a concrete subclass of Django's user model is a pretty common custom user model, this can happen fairly often.

The code in UserTokenForm._get_user() obfuscates this issue, because it encounters a ValueError on the call to User.objects.get(pk=pk), while actually expecting the url_str_to_user_pk call (and the .to_python call within) to be the one throwing a ValueError. Thus any tokens generated by users with a PK larger than 9 will be rejected as invalid/expired tokens, and such users are not able to reset their passwords.

The fix below uses the .to_python of the field pointed to by the PK for validation.