### PR TITLE
Use twitter.com instead of api.twitter.com

### DIFF
--- a/allauth/socialaccount/providers/twitter/provider.py
+++ b/allauth/socialaccount/providers/twitter/provider.py
@@ -37,9 +37,9 @@ class TwitterProvider(OAuthProvider):
 
     def get_auth_url(self, request, action):
         if action == AuthAction.REAUTHENTICATE:
-            url = 'https://api.twitter.com/oauth/authorize'
+            url = 'https://twitter.com/oauth/authorize'
         else:
-            url = 'https://api.twitter.com/oauth/authenticate'
+            url = 'https://twitter.com/oauth/authenticate'
         return url
 
     def extract_uid(self, data):


### PR DESCRIPTION
There seems to be an issue with Twitter auth on mobile devices:

1. User with a mobile user agent chooses to login to our site with Twitter.
2. User goes to `https://api.twitter.com/oauth/...`.
3. User is not authenticated on Twitter, so he or she sees a login form.
4. User enters incorrect login or password.
5. Twitter sends user into redirect loop and user receives `net::ERR_TOO_MANY_REDIRECTS` error.

All sites from [documentation showcase](http://django-allauth.readthedocs.org/en/latest/showcase.html) with Twitter login demonstrate this behavior, e.g. [smartgoalapp.com](http://www.smartgoalapp.com/), [pizzacharts.com](https://pizzacharts.com/).

It is clear that the issue is on Twitter's side and should be fixed there, but there are reports from more than a year ago on [twittercommunity.com](https://twittercommunity.com) about this bug, so we can wait for a long time before this get resolved.

A possible workaround is using the same urls, but on `twitter.com` instead of `api.twitter.com`. In this case on step 5 Twitter redirects user to page on `mobile.twitter.com` with an error message, as it should be. I found this solution working on [klout.com](https://klout.com/).