### PR TITLE
Extract 'name' from Facebook data

### DIFF
--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -169,7 +169,8 @@ class FacebookProvider(OAuth2Provider):
         return dict(email=data.get('email'),
                     username=data.get('username'),
                     first_name=data.get('first_name'),
-                    last_name=data.get('last_name'))
+                    last_name=data.get('last_name'),
+                    name=data.get('name'))
 
     def extract_email_addresses(self, data):
         ret = []


### PR DESCRIPTION
Sometimes the Facebook profile data looks simply like this:

    {"id": "123456", "name": "Harvey McGillicuddy"}

In that case, the User object gets created without any name data, and the
resulting username looks something like "user17". Extracting the name
field in `FacebookProvider.extract_common_fields()` allows
`DefaultSocialAccountAdapter.populate_user()` to insert reasonable
first_name, last_name and username fields.