### PR TITLE
isolate the populate_username functions from DefaultSocialAccountAdapter

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -192,7 +192,7 @@ class DefaultAccountAdapter(object):
         """
         from .utils import user_username, user_email, user_field
 
-        try:
+        if form:
             data = form.cleaned_data
             first_name = data.get('first_name')
             last_name = data.get('last_name')
@@ -208,7 +208,7 @@ class DefaultAccountAdapter(object):
                 user.set_password(data["password1"])
             else:
                 user.set_unusable_password()
-        except AttributeError:
+        else:
             user.set_unusable_password()
         self.populate_username(request, user)
         if commit:

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -192,20 +192,23 @@ class DefaultAccountAdapter(object):
         """
         from .utils import user_username, user_email, user_field
 
-        data = form.cleaned_data
-        first_name = data.get('first_name')
-        last_name = data.get('last_name')
-        email = data.get('email')
-        username = data.get('username')
-        user_email(user, email)
-        user_username(user, username)
-        if first_name:
-            user_field(user, 'first_name', first_name)
-        if last_name:
-            user_field(user, 'last_name', last_name)
-        if 'password1' in data:
-            user.set_password(data["password1"])
-        else:
+        try:
+            data = form.cleaned_data
+            first_name = data.get('first_name')
+            last_name = data.get('last_name')
+            email = data.get('email')
+            username = data.get('username')
+            user_email(user, email)
+            user_username(user, username)
+            if first_name:
+                user_field(user, 'first_name', first_name)
+            if last_name:
+                user_field(user, 'last_name', last_name)
+            if 'password1' in data:
+                user.set_password(data["password1"])
+            else:
+                user.set_unusable_password()
+        except AttributeError:
             user.set_unusable_password()
         self.populate_username(request, user)
         if commit:

--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -61,10 +61,7 @@ class DefaultSocialAccountAdapter(object):
         """
         u = sociallogin.user
         u.set_unusable_password()
-        if form:
-            get_account_adapter().save_user(request, u, form)
-        else:
-            get_account_adapter().populate_username(request, u)
+        get_account_adapter().save_user(request, u, form)
         sociallogin.save(request)
         return u
 


### PR DESCRIPTION
the original flows of `DefaultSocialAccountAdapter.save_user` are two:

1. `DefaultSocialAccountAdapter.save_user` => `DefaultAccountAdapter.populate_username`
2. `DefaultSocialAccountAdapter.save_user` => `DefaultAccountAdapter.save_user` => `DefaultAccountAdapter.populate_username`

So I merged the first flow to the second one. 

The final flow will only be

* `DefaultSocialAccountAdapter.save_user` => `DefaultAccountAdapter.save_user` => `DefaultAccountAdapter.populate_username`

The `DefaultSocialAccountAdapter.save_user` only calls `DefaultAccountAdapter.save_user` whether `form` is `None` or not.
