### PR TITLE
Call super().get_context_data early to access form

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -189,10 +189,10 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
                                self.get_success_url())
 
     def get_context_data(self, **kwargs):
-        form = kwargs['form']
+        ret = super(SignupView, self).get_context_data(**kwargs)
+        form = ret['form']
         form.fields["email"].initial = self.request.session \
             .get('account_verified_email', None)
-        ret = super(SignupView, self).get_context_data(**kwargs)
         login_url = passthrough_next_redirect_url(self.request,
                                                   reverse("account_login"),
                                                   self.redirect_field_name)


### PR DESCRIPTION
In Django 1.9, form is no longer passed explicitly to FormView's
get_context_data. Instead, we need to call super(...).get_context_data
for it to be populated.

I understand that allauth does not yet support Django 1.9 (the test
suite has numerous failures), but this at least gets us a small step
closer and to is -- to the best of my knowledge -- backwards compatible.

Fixes #1142.