### PR TITLE
Run tests against Django 1.9b1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
  - pip install coverage==3.7.1
 matrix:
   allow_failures:
-    env: DJANGO="Django==1.9b1"
+   - env: DJANGO="Django==1.9b1"
 branches:
  only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,14 @@ env:
    - DJANGO="Django<1.7"
    - DJANGO="Django<1.8"
    - DJANGO="Django<1.9"
+   - DJANGO="Django==1.9b1"
 install:
  - pip install $DJANGO --use-mirrors
  - pip install . --use-mirrors
  - pip install coverage==3.7.1
+matrix:
+  allow_failures:
+    env: DJANGO="Django==1.9b1"
 branches:
  only:
   - master


### PR DESCRIPTION
For the time being, let them fail without causing the test suite in its
entirety to fail. This lets us track our progress towards Django 1.9
compatibility.