### PR TITLE
Cleanup and update Travis and Tox file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
     - $HOME/.cache/pip
 install:
  - pip install "pip>=7.0.2" wheel
- - pip install "$DJANGO" coverage coveralls "mock>=1.0.1"
+ - pip install "$DJANGO" "coverage==3.7.1" coveralls "mock>=1.0.1"
  - pip install .
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
  - "3.5"
 env:
   matrix:
+   - DJANGO="Django<1.7"
    - DJANGO="Django<1.8"
    - DJANGO="Django<1.9"
    - DJANGO="Django==1.9b1"
@@ -18,6 +19,8 @@ install:
 matrix:
   allow_failures:
    - env: DJANGO="Django==1.9b1"
+  # TODO: Remove when https://github.com/necaris/python3-openid/issues/16 is resolved.
+   - python: "3.5"
   exclude:
     - python: "3.5"
       env: DJANGO="Django<1.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,22 @@ python:
  - "3.2"
  - "3.3"
  - "3.4"
+ - "3.5"
 env:
   matrix:
-   - DJANGO="Django<1.7"
    - DJANGO="Django<1.8"
    - DJANGO="Django<1.9"
    - DJANGO="Django==1.9b1"
 install:
- - pip install $DJANGO --use-mirrors
- - pip install . --use-mirrors
+ - pip install $DJANGO
+ - pip install .
  - pip install coverage==3.7.1
 matrix:
   allow_failures:
    - env: DJANGO="Django==1.9b1"
+  exclude:
+    - python: "3.5"
+      env: DJANGO="Django<1.8"
 branches:
  only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,13 @@ env:
    - DJANGO="Django<1.8"
    - DJANGO="Django<1.9"
    - DJANGO="Django==1.9b1"
+cache:
+  directories:
+    - $HOME/.cache/pip
 install:
- - pip install $DJANGO
+ - pip install "pip>=7.0.2" wheel
+ - pip install "$DJANGO" coverage coveralls "mock>=1.0.1"
  - pip install .
- - pip install coverage==3.7.1
 matrix:
   allow_failures:
    - env: DJANGO="Django==1.9b1"
@@ -30,5 +33,4 @@ branches:
 script: coverage run manage.py test allauth
 after_success:
   - coverage report
-  - pip install --quiet python-coveralls
   - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,32,33,34,35}-django{17,18},
+envlist = py{27,32,33,34,35}-django{16,17,18},
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py{27,32,33,34}-django{16,17,18},
+envlist = py{27,32,33,34,35}-django{17,18},
 
 [testenv]
 deps =
     coverage
     mock >= 1.0.1
-    django16: Django < 1.7
     django17: Django < 1.8
     django18: Django < 1.9
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py{27,32,33,34,35}-django{16,17,18},
 deps =
     coverage
     mock >= 1.0.1
+    django16: Django < 1.7
     django17: Django < 1.8
     django18: Django < 1.9
 commands =


### PR DESCRIPTION
* Removed Django 1.6 from testing. It is unsupported. See (https://www.djangoproject.com/download/)
* Added Python 3.5 to the list of Python versions to test against. It is supported since Django 1.8.6 (https://docs.djangoproject.com/en/1.8/releases/1.8.6/)
* Removed `--use-mirrors` from pip install command in the Travis config since it is deprecated. (https://github.com/pypa/pip/pull/1098) 

Current Python 3.5 build fails (https://travis-ci.org/Ecno92/django-allauth/jobs/89953488). It seems that one of the providers (openid) is not Python 3.5 compatible. Since this package has a dependency on it I would suggest to keep it failing until `python-openid` resolves the issue. 

Please let me know if it is necessary to open up a issue at the `python-openid` project. I didn't investigate this failing test that well to be sure if this is necessary. 