### PR TITLE
Fixed formatting email subject in multisite environment.

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -62,10 +62,13 @@ class DefaultAccountAdapter(object):
             ret = verified_email.lower() == email.lower()
         return ret
 
-    def format_email_subject(self, subject):
+    def format_email_subject(self, subject, context=None):
         prefix = app_settings.EMAIL_SUBJECT_PREFIX
         if prefix is None:
-            site = get_current_site()
+            if context and 'current_site' in context:
+                site = context.get('current_site')
+            else:
+                site = get_current_site()
             prefix = "[{name}] ".format(name=site.name)
         return prefix + force_text(subject)
 
@@ -78,7 +81,7 @@ class DefaultAccountAdapter(object):
                                    context)
         # remove superfluous line breaks
         subject = " ".join(subject.splitlines()).strip()
-        subject = self.format_email_subject(subject)
+        subject = self.format_email_subject(subject, context)
 
         bodies = {}
         for ext in ['html', 'txt']:


### PR DESCRIPTION
The email subject formatting tries to get current site if EMAIL_SUBJECT_PREFIX is not configured. And it use get_current_site() without passing request as parameter which brings "ImproperlyConfigured at ... You're using the Django "sites framework" without having set the SITE_ID setting." error in case SITE_ID is not set (which is okay in case we have sites configured in DB and use request to obtain the current site). But we already have current_site in context so I suggest to use this to fix the problem.