### PR TITLE
Avoid overwrite email on signup

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -198,7 +198,8 @@ class DefaultAccountAdapter(object):
         email = data.get('email')
         username = data.get('username')
         user_email(user, email)
-        user_username(user, username)
+        if username:
+            user_username(user, username)
         if first_name:
             user_field(user, 'first_name', first_name)
         if last_name:


### PR DESCRIPTION
When using a custom User model with `email `only (no `username` field) and `ACCOUNT_USER_MODEL_USERNAME_FIELD` is set to 'email', default signup adapter will overwrite `User.email` ith an auto generated `username`.