### PR TITLE
Fix GitHub provider to_str on null field responses

### DIFF
--- a/allauth/socialaccount/providers/github/provider.py
+++ b/allauth/socialaccount/providers/github/provider.py
@@ -12,7 +12,15 @@ class GitHubAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(GitHubAccount, self).to_str()
-        return self.account.extra_data.get('name', dflt)
+        return next(
+            value
+            for value in (
+                self.account.extra_data.get('name', None),
+                self.account.extra_data.get('login', None),
+                dflt
+            )
+            if value is not None
+        )
 
 
 class GitHubProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/github/tests.py
+++ b/allauth/socialaccount/providers/github/tests.py
@@ -1,6 +1,7 @@
 from allauth.socialaccount.tests import create_oauth2_tests
 from allauth.tests import MockedResponse
 from allauth.socialaccount.providers import registry
+from allauth.socialaccount.models import SocialAccount
 
 from .provider import GitHubProvider
 
@@ -37,3 +38,18 @@ class GitHubTests(create_oauth2_tests(registry.by_id(GitHubProvider.id))):
             "events_url":"https://api.github.com/users/pennersr/events{/privacy}",
             "following_url":"https://api.github.com/users/pennersr/following"
         }""")
+
+    def test_account_name_null(self):
+        """String conversion when GitHub responds with empty name"""
+        data = """{
+            "type": "User",
+            "id": 201022,
+            "login": "pennersr",
+            "name": null
+        }"""
+        self.login(MockedResponse(200, data))
+        socialaccount = SocialAccount.objects.get(uid='201022')
+        self.assertIsNone(socialaccount.extra_data.get('name'))
+        account = socialaccount.get_provider_account()
+        self.assertIsNotNone(account.to_str())
+        self.assertEqual(account.to_str(), 'pennersr')


### PR DESCRIPTION
The GitHub provider will currently return `None` if coerced to a string, because
`to_str` returns `name` from the response data. GitHub may return `null` in this
field though, which ultimately results in exceptions coercing to Unicode.