### PR TITLE
Add an optional ACCOUNT_EMAIL_CONFIRMATION_URL configuration

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -340,14 +340,19 @@ class DefaultAccountAdapter(object):
         confirmations are sent outside of the request context `request`
         can be `None` here.
         """
-        url = reverse(
-            "account_confirm_email",
-            args=[emailconfirmation.key])
-        ret = build_absolute_uri(
-            request,
-            url,
-            protocol=app_settings.DEFAULT_HTTP_PROTOCOL)
-        return ret
+        url = getattr(settings, "ACCOUNT_EMAIL_CONFIRMATION_URL", None)
+
+        if url is not None:
+            return url.format(emailconfirmation.key)
+        else:
+            url = reverse(
+                "account_confirm_email",
+                args=[emailconfirmation.key])
+            ret = build_absolute_uri(
+                request,
+                url,
+                protocol=app_settings.DEFAULT_HTTP_PROTOCOL)
+            return ret
 
     def send_confirmation_mail(self, request, emailconfirmation, signup):
         current_site = get_current_site(request)

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -47,6 +47,23 @@ class AccountTests(TestCase):
                                           provider='facebook')
             sa.sites.add(get_current_site())
 
+
+    @override_settings(
+        ACCOUNT_EMAIL_CONFIRMATION_URL='http://example.com/confirm/{}')
+    def test_confirmation_url_conf(self):
+        c = Client()
+        # Signup
+        resp = c.post(reverse('account_signup'),
+                      {'username': 'johndoe',
+                       'email': 'john@doe.com',
+                       'password1': 'johndoe',
+                       'password2': 'johndoe'},
+                      follow=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mail.outbox[0].to, ['john@doe.com'])
+        self.assertGreater(mail.outbox[0].body.find('http://example.com/confirm/'), 0)
+        self.assertEqual(len(mail.outbox), 1)
+
     @override_settings(
         ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod
         .USERNAME_EMAIL)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,6 +25,12 @@ ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL (=None)
   case of an authenticated user. Set to `None` to use
   `settings.LOGIN_REDIRECT_URL`.
 
+ACCOUNT_EMAIL_CONFIRMATION_URL (="optional")
+  The url to send in the 'confirm your password' email. This is useful in
+  cases where this module is being used inside a rest API and you need to send the
+  confirmation to your frontend.
+  The url should conform to `http://example.com/confirm/{}`, since the key will be added to this url
+
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS (=3)
   Determines the expiration date of email confirmation mails (# of days).
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.8.7
+django>=1.6
 mock>=1.0.1
 # There is no OpenID lib that support both Python 2 and 3 from a single-source base.
 # So we have to choose between:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=1.6
+django==1.8.7
 mock>=1.0.1
 # There is no OpenID lib that support both Python 2 and 3 from a single-source base.
 # So we have to choose between:


### PR DESCRIPTION
Hi, i've been using django-allauth for a rest api, it works very good but i found that this use case has a problem: the email being sent contains an url to the api itself instead of the front end. 
This was solvable via subclassing, of course, but i thought it would be nice to have it supported inside the module. 

