### PR TITLE
Replace create_oauth2_tests with OAuth2TestsMixin

### DIFF
--- a/allauth/socialaccount/providers/amazon/tests.py
+++ b/allauth/socialaccount/providers/amazon/tests.py
@@ -1,11 +1,12 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import AmazonProvider
 
 
-class AmazonTests(create_oauth2_tests(registry.by_id(AmazonProvider.id))):
+class AmazonTests(OAuth2TestsMixin, TestCase):
+    provider_id = AmazonProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/baidu/tests.py
+++ b/allauth/socialaccount/providers/baidu/tests.py
@@ -1,9 +1,10 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import BaiduProvider
 
-class BaiduTests(create_oauth2_tests(registry.by_id(BaiduProvider.id))):
+class BaiduTests(OAuth2TestsMixin, TestCase):
+    provider_id = BaiduProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """{"portrait": "78c0e9839de59bbde7859ccf43", "uname": "\u90dd\u56fd\u715c", "uid": "3225892368"}""")

--- a/allauth/socialaccount/providers/basecamp/tests.py
+++ b/allauth/socialaccount/providers/basecamp/tests.py
@@ -1,11 +1,12 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import BasecampProvider
 
 
-class BasecampTests(create_oauth2_tests(registry.by_id(BasecampProvider.id))):
+class BasecampTests(OAuth2TestsMixin, TestCase):
+    provider_id = BasecampProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/bitbucket/tests.py
+++ b/allauth/socialaccount/providers/bitbucket/tests.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import BitbucketProvider
 
 
-class BitbucketTests(create_oauth_tests(registry.by_id(BitbucketProvider.id))):
+class BitbucketTests(OAuthTestsMixin, TestCase):
+    provider_id = BitbucketProvider.id
+
     def get_mocked_response(self):
         # FIXME: Replace with actual/complete Bitbucket response
         return [MockedResponse(200, r"""

--- a/allauth/socialaccount/providers/bitly/tests.py
+++ b/allauth/socialaccount/providers/bitly/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import BitlyProvider
 
-class BitlyTests(create_oauth2_tests(registry.by_id(BitlyProvider.id))):
+class BitlyTests(OAuth2TestsMixin, TestCase):
+    provider_id = BitlyProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """{
             "data": {

--- a/allauth/socialaccount/providers/coinbase/tests.py
+++ b/allauth/socialaccount/providers/coinbase/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import CoinbaseProvider
 
-class CoinbaseTests(create_oauth2_tests(registry.by_id(CoinbaseProvider.id))):
+class CoinbaseTests(OAuth2TestsMixin, TestCase):
+    provider_id = CoinbaseProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
 {

--- a/allauth/socialaccount/providers/douban/tests.py
+++ b/allauth/socialaccount/providers/douban/tests.py
@@ -1,11 +1,12 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import DoubanProvider
 
 
-class DoubanTests(create_oauth2_tests(registry.by_id(DoubanProvider.id))):
+class DoubanTests(OAuth2TestsMixin, TestCase):
+    provider_id = DoubanProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
             {"name": "guoqiao",

--- a/allauth/socialaccount/providers/dropbox/tests.py
+++ b/allauth/socialaccount/providers/dropbox/tests.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 from allauth.socialaccount.providers import registry
 
 from .provider import DropboxProvider
 
 
-class DropboxTests(create_oauth_tests(registry.by_id(DropboxProvider.id))):
+class DropboxTests(OAuthTestsMixin, TestCase):
+    provider_id = DropboxProvider.id
+
     def get_mocked_response(self):
         # FIXME: Replace with actual/complete Dropbox response
         return [MockedResponse(200, """

--- a/allauth/socialaccount/providers/dropbox_oauth2/tests.py
+++ b/allauth/socialaccount/providers/dropbox_oauth2/tests.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import DropboxOAuth2Provider
 
 
-class DropboxOAuth2Tests(create_oauth2_tests(registry.by_id(
-        DropboxOAuth2Provider.id))):
+class DropboxOAuth2Tests(OAuth2TestsMixin, TestCase):
+    provider_id = DropboxOAuth2Provider.id
+
     def get_mocked_response(self):
         return [MockedResponse(200, """{
             "display_name": "Björn Andersson",

--- a/allauth/socialaccount/providers/edmodo/tests.py
+++ b/allauth/socialaccount/providers/edmodo/tests.py
@@ -1,11 +1,12 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import EdmodoProvider
 
 
-class EdmodoTests(create_oauth2_tests(registry.by_id(EdmodoProvider.id))):
+class EdmodoTests(OAuth2TestsMixin, TestCase):
+    provider_id = EdmodoProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
 {

--- a/allauth/socialaccount/providers/evernote/tests.py
+++ b/allauth/socialaccount/providers/evernote/tests.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 from allauth.socialaccount.providers import registry
 
 from .provider import EvernoteProvider
 
 
-class EvernoteTests(create_oauth_tests(registry.by_id(EvernoteProvider.id))):
+class EvernoteTests(OAuthTestsMixin, TestCase):
+    provider_id = EvernoteProvider.id
 
     def get_mocked_response(self):
         return []

--- a/allauth/socialaccount/providers/facebook/tests.py
+++ b/allauth/socialaccount/providers/facebook/tests.py
@@ -4,11 +4,10 @@ from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from django.test.client import RequestFactory
 
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse, patch
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase, patch
 from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount import providers
-from allauth.socialaccount.providers import registry
 from allauth.account import app_settings as account_settings
 from allauth.account.models import EmailAddress
 from allauth.utils import get_user_model
@@ -26,7 +25,9 @@ from .provider import FacebookProvider
         'facebook': {
             'AUTH_PARAMS': {},
             'VERIFIED_EMAIL': False}})
-class FacebookTests(create_oauth2_tests(registry.by_id(FacebookProvider.id))):
+class FacebookTests(OAuth2TestsMixin, TestCase):
+    provider_id = FacebookProvider.id
+
     facebook_data = """
         {
            "id": "630595557",

--- a/allauth/socialaccount/providers/feedly/tests.py
+++ b/allauth/socialaccount/providers/feedly/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import FeedlyProvider
 
-class FeedlyTests(create_oauth2_tests(registry.by_id(FeedlyProvider.id))):
+class FeedlyTests(OAuth2TestsMixin, TestCase):
+    provider_id = FeedlyProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/flickr/tests.py
+++ b/allauth/socialaccount/providers/flickr/tests.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import FlickrProvider
 
 
-class FlickrTests(create_oauth_tests(registry.by_id(FlickrProvider.id))):
+class FlickrTests(OAuthTestsMixin, TestCase):
+    provider_id = FlickrProvider.id
+
     def get_mocked_response(self):
         #
         return [

--- a/allauth/socialaccount/providers/foursquare/tests.py
+++ b/allauth/socialaccount/providers/foursquare/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import FoursquareProvider
 
-class FoursquareTests(create_oauth2_tests(registry.by_id(FoursquareProvider.id))):
+class FoursquareTests(OAuth2TestsMixin, TestCase):
+    provider_id = FoursquareProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
                               {

--- a/allauth/socialaccount/providers/fxa/tests.py
+++ b/allauth/socialaccount/providers/fxa/tests.py
@@ -1,11 +1,12 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import FirefoxAccountsProvider
 
 
-class FirefoxAccountsTests(create_oauth2_tests(registry.by_id(FirefoxAccountsProvider.id))):
+class FirefoxAccountsTests(OAuth2TestsMixin, TestCase):
+    provider_id = FirefoxAccountsProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/github/tests.py
+++ b/allauth/socialaccount/providers/github/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import GitHubProvider
 
-class GitHubTests(create_oauth2_tests(registry.by_id(GitHubProvider.id))):
+class GitHubTests(OAuth2TestsMixin, TestCase):
+    provider_id = GitHubProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -14,12 +14,12 @@ try:
 except ImportError:
     from django.utils.importlib import import_module
 
-from allauth.socialaccount.tests import create_oauth2_tests
+from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.account import app_settings as account_settings
 from allauth.account.models import EmailConfirmation, EmailAddress
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.socialaccount.providers import registry
-from allauth.tests import MockedResponse, patch
+from allauth.tests import MockedResponse, TestCase, patch
 from allauth.account.signals import user_signed_up
 from allauth.account.adapter import get_adapter
 
@@ -33,7 +33,8 @@ from .provider import GoogleProvider
     ACCOUNT_SIGNUP_FORM_CLASS=None,
     ACCOUNT_EMAIL_VERIFICATION=account_settings
     .EmailVerificationMethod.MANDATORY)
-class GoogleTests(create_oauth2_tests(registry.by_id(GoogleProvider.id))):
+class GoogleTests(OAuth2TestsMixin, TestCase):
+    provider_id = GoogleProvider.id
 
     def get_mocked_response(self,
                             family_name='Penners',

--- a/allauth/socialaccount/providers/hubic/tests.py
+++ b/allauth/socialaccount/providers/hubic/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import HubicProvider
 
-class HubicTests(create_oauth2_tests(registry.by_id(HubicProvider.id))):
+class HubicTests(OAuth2TestsMixin, TestCase):
+    provider_id = HubicProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
 {

--- a/allauth/socialaccount/providers/instagram/tests.py
+++ b/allauth/socialaccount/providers/instagram/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import InstagramProvider
 
-class InstagramTests(create_oauth2_tests(registry.by_id(InstagramProvider.id))):
+class InstagramTests(OAuth2TestsMixin, TestCase):
+    provider_id = InstagramProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/linkedin/tests.py
+++ b/allauth/socialaccount/providers/linkedin/tests.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import LinkedInProvider
 
 
-class LinkedInTests(create_oauth_tests(registry.by_id(LinkedInProvider.id))):
+class LinkedInTests(OAuthTestsMixin, TestCase):
+    provider_id = LinkedInProvider.id
+
     def get_mocked_response(self):
         return [MockedResponse(200, """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <person>

--- a/allauth/socialaccount/providers/linkedin_oauth2/tests.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/tests.py
@@ -1,12 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import LinkedInOAuth2Provider
 
 
-class LinkedInOAuth2Tests(create_oauth2_tests(
-        registry.by_id(LinkedInOAuth2Provider.id))):
+class LinkedInOAuth2Tests(OAuth2TestsMixin, TestCase):
+    provider_id = LinkedInOAuth2Provider.id
 
     def get_mocked_response(self):
         return MockedResponse(200, """

--- a/allauth/socialaccount/providers/mailru/tests.py
+++ b/allauth/socialaccount/providers/mailru/tests.py
@@ -2,14 +2,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.socialaccount.providers import registry
-from allauth.tests import MockedResponse
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import MailRuProvider
 
 
-class MailRuTests(create_oauth2_tests(registry.by_id(MailRuProvider.id))):
+class MailRuTests(OAuth2TestsMixin, TestCase):
+    provider_id = MailRuProvider.id
 
     def get_mocked_response(self, verified_email=True):
         return MockedResponse(200, """

--- a/allauth/socialaccount/providers/odnoklassniki/tests.py
+++ b/allauth/socialaccount/providers/odnoklassniki/tests.py
@@ -2,15 +2,14 @@
 
 from __future__ import absolute_import
 
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.socialaccount.providers import registry
-from allauth.tests import MockedResponse
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import OdnoklassnikiProvider
 
 
-class OdnoklassnikiTests(
-        create_oauth2_tests(registry.by_id(OdnoklassnikiProvider.id))):
+class OdnoklassnikiTests(OAuth2TestsMixin, TestCase):
+    provider_id = OdnoklassnikiProvider.id
 
     def get_mocked_response(self, verified_email=True):
         return MockedResponse(200, """

--- a/allauth/socialaccount/providers/orcid/tests.py
+++ b/allauth/socialaccount/providers/orcid/tests.py
@@ -1,11 +1,12 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import OrcidProvider
 
 
-class OrcidTests(create_oauth2_tests(registry.by_id(OrcidProvider.id))):
+class OrcidTests(OAuth2TestsMixin, TestCase):
+    provider_id = OrcidProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/paypal/tests.py
+++ b/allauth/socialaccount/providers/paypal/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import PaypalProvider
 
-class PaypalTests(create_oauth2_tests(registry.by_id(PaypalProvider.id))):
+class PaypalTests(OAuth2TestsMixin, TestCase):
+    provider_id = PaypalProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/soundcloud/tests.py
+++ b/allauth/socialaccount/providers/soundcloud/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import SoundCloudProvider
 
-class SoundCloudTests(create_oauth2_tests(registry.by_id(SoundCloudProvider.id))):
+class SoundCloudTests(OAuth2TestsMixin, TestCase):
+    provider_id = SoundCloudProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/spotify/tests.py
+++ b/allauth/socialaccount/providers/spotify/tests.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import SpotifyOAuth2Provider
 
 
-class SpotifyOAuth2Tests(create_oauth2_tests(registry.by_id(
-        SpotifyOAuth2Provider.id))):
+class SpotifyOAuth2Tests(OAuth2TestsMixin, TestCase):
+    provider_id = SpotifyOAuth2Provider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """{
           "birthdate": "1937-06-01",

--- a/allauth/socialaccount/providers/stackexchange/tests.py
+++ b/allauth/socialaccount/providers/stackexchange/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import StackExchangeProvider
 
-class StackExchangeTests(create_oauth2_tests(registry.by_id(StackExchangeProvider.id))):
+class StackExchangeTests(OAuth2TestsMixin, TestCase):
+    provider_id = StackExchangeProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """
         {

--- a/allauth/socialaccount/providers/stripe/tests.py
+++ b/allauth/socialaccount/providers/stripe/tests.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import StripeProvider
 
 
-class StripeTests(create_oauth2_tests(registry.by_id(StripeProvider.id))):
+class StripeTests(OAuth2TestsMixin, TestCase):
+    provider_id = StripeProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """{
           "id": "acct_sometestid",

--- a/allauth/socialaccount/providers/tumblr/tests.py
+++ b/allauth/socialaccount/providers/tumblr/tests.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import TumblrProvider
 
 
-class TumblrTests(create_oauth_tests(registry.by_id(TumblrProvider.id))):
+class TumblrTests(OAuthTestsMixin, TestCase):
+    provider_id = TumblrProvider.id
+
     def get_mocked_response(self):
         return [MockedResponse(200, """
 {

--- a/allauth/socialaccount/providers/twitch/tests.py
+++ b/allauth/socialaccount/providers/twitch/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import TwitchProvider
 
-class TwitchTests(create_oauth2_tests(registry.by_id(TwitchProvider.id))):
+class TwitchTests(OAuth2TestsMixin, TestCase):
+    provider_id = TwitchProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """{"name":"test_user1","created_at":"2011-06-03T17:49:19Z","updated_at":"2012-06-18T17:19:57Z","_links":{"self":"https://api.twitch.tv/kraken/users/test_user1"},"logo":"http://static-cdn.jtvnw.net/jtv_user_pictures/test_user1-profile_image-62e8318af864d6d7-300x300.jpeg","_id":22761313,"display_name":"test_user1","email":"asdf@asdf.com","partnered":true}
 

--- a/allauth/socialaccount/providers/twitter/tests.py
+++ b/allauth/socialaccount/providers/twitter/tests.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import TwitterProvider
 
 
-class TwitterTests(create_oauth_tests(registry.by_id(TwitterProvider.id))):
+class TwitterTests(OAuthTestsMixin, TestCase):
+    provider_id = TwitterProvider.id
+
     def get_mocked_response(self):
         # FIXME: Replace with actual/complete Twitter response
         return [MockedResponse(200, r"""

--- a/allauth/socialaccount/providers/vimeo/tests.py
+++ b/allauth/socialaccount/providers/vimeo/tests.py
@@ -1,10 +1,13 @@
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+# -*- coding: utf-8 -*-
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import VimeoProvider
 
-class VimeoTests(create_oauth_tests(registry.by_id(VimeoProvider.id))):
+
+class VimeoTests(OAuthTestsMixin, TestCase):
+    provider_id = VimeoProvider.id
+
     def get_mocked_response(self):
         return [MockedResponse(200, """
 {"generated_in":"0.0137","stat":"ok","person":{"created_on":"2013-04-08 14:24:47","id":"17574504","is_contact":"0","is_plus":"0","is_pro":"0","is_staff":"0","is_subscribed_to":"0","username":"user17574504","display_name":"Raymond Penners","location":"","url":[""],"bio":"","number_of_contacts":"0","number_of_uploads":"0","number_of_likes":"0","number_of_videos":"0","number_of_videos_appears_in":"0","number_of_albums":"0","number_of_channels":"0","number_of_groups":"0","profileurl":"http:\\/\\/vimeo.com\\/user17574504","videosurl":"http:\\/\\/vimeo.com\\/user17574504\\/videos","portraits":{"portrait":[{"height":"30","width":"30","_content":"http:\\/\\/a.vimeocdn.com\\/images_v6\\/portraits\\/portrait_30_yellow.png"},{"height":"75","width":"75","_content":"http:\\/\\/a.vimeocdn.com\\/images_v6\\/portraits\\/portrait_75_yellow.png"},{"height":"100","width":"100","_content":"http:\\/\\/a.vimeocdn.com\\/images_v6\\/portraits\\/portrait_100_yellow.png"},{"height":"300","width":"300","_content":"http:\\/\\/a.vimeocdn.com\\/images_v6\\/portraits\\/portrait_300_yellow.png"}]}}}

--- a/allauth/socialaccount/providers/vk/tests.py
+++ b/allauth/socialaccount/providers/vk/tests.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.socialaccount.providers import registry
-from allauth.tests import MockedResponse
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import VKProvider
 
 
-class VKTests(create_oauth2_tests(registry.by_id(VKProvider.id))):
+class VKTests(OAuth2TestsMixin, TestCase):
+    provider_id = VKProvider.id
 
     def get_mocked_response(self, verified_email=True):
         return MockedResponse(200, """

--- a/allauth/socialaccount/providers/weibo/tests.py
+++ b/allauth/socialaccount/providers/weibo/tests.py
@@ -1,10 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import WeiboProvider
 
-class WeiboTests(create_oauth2_tests(registry.by_id(WeiboProvider.id))):
+class WeiboTests(OAuth2TestsMixin, TestCase):
+    provider_id = WeiboProvider.id
+
     def get_mocked_response(self):
         return MockedResponse(200, """{"bi_followers_count": 0, "domain": "", "avatar_large": "http://tp3.sinaimg.cn/3195025850/180/0/0", "block_word": 0, "star": 0, "id": 3195025850, "city": "1", "verified": false, "follow_me": false, "verified_reason": "", "followers_count": 6, "location": "\u5317\u4eac \u4e1c\u57ce\u533a", "mbtype": 0, "profile_url": "u/3195025850", "province": "11", "statuses_count": 0, "description": "", "friends_count": 0, "online_status": 0, "mbrank": 0, "idstr": "3195025850", "profile_image_url": "http://tp3.sinaimg.cn/3195025850/50/0/0", "allow_all_act_msg": false, "allow_all_comment": true, "geo_enabled": true, "name": "pennersr", "lang": "zh-cn", "weihao": "", "remark": "", "favourites_count": 0, "screen_name": "pennersr", "url": "", "gender": "f", "created_at": "Tue Feb 19 19:43:39 +0800 2013", "verified_type": -1, "following": false}
 

--- a/allauth/socialaccount/providers/windowslive/tests.py
+++ b/allauth/socialaccount/providers/windowslive/tests.py
@@ -1,12 +1,11 @@
-from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import WindowsLiveProvider
 
 
-class WindowsLiveTests(create_oauth2_tests(
-        registry.by_id(WindowsLiveProvider.id))):
+class WindowsLiveTests(OAuth2TestsMixin, TestCase):
+    provider_id = WindowsLiveProvider.id
 
     def get_mocked_response(self):
         return MockedResponse(200, """

--- a/allauth/socialaccount/providers/xing/tests.py
+++ b/allauth/socialaccount/providers/xing/tests.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from allauth.socialaccount.tests import create_oauth_tests
-from allauth.tests import MockedResponse
-from allauth.socialaccount.providers import registry
+from allauth.socialaccount.tests import OAuthTestsMixin
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import XingProvider
 
 
-class XingTests(create_oauth_tests(registry.by_id(XingProvider.id))):
+class XingTests(OAuthTestsMixin, TestCase):
+    provider_id = XingProvider.id
+
     def get_mocked_response(self):
         return [MockedResponse(200, """
 {"users":[{"id":"20493333_1cd028","active_email":"raymond.penners@gmail.com",


### PR DESCRIPTION
I tried to use `create_oauth2_tests` but hit the error:

```
  File "allauth/socialaccount/tests.py", line 226, in create_oauth2_tests
      Class = type(class_name, (TestCase,), impl)
TypeError: type() argument 1 must be string, not unicode
```

This happened because I'm using `unicode_literals` in my custom `provider.py`

I started to fix this by casting to `str` in `create_oauth2_tests` but then
I wondered why it's doing dynamic class creation in the first place, rather
than simply being a mixin. So here's `OAuthTestsMixin` and `OAuth2TestsMixin`
to replace `create_oauth_tests` and `create_oauth2_tests` respectively.

The function forms are still available for the sake of third-party providers
that call them.