### PR TITLE
Add Bitbucket OAuth2 provider

### DIFF
--- a/allauth/socialaccount/providers/bitbucket_oauth2/models.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/models.py
@@ -1,0 +1,1 @@
+# Create your models here.

--- a/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
@@ -1,0 +1,22 @@
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class BitbucketOAuth2Account(ProviderAccount):
+    pass
+
+
+class BitbucketOAuth2Provider(OAuth2Provider):
+    id = 'bitbucket_oauth2'
+    name = 'Bitbucket'
+    package = 'allauth.socialaccount.providers.bitbucket_oauth2'
+    account_class = BitbucketOAuth2Account
+
+    def extract_uid(self, data):
+        return data['username']
+
+    def extract_common_fields(self, data):
+        return dict(name=data.get('display_name'))
+
+providers.registry.register(BitbucketOAuth2Provider)

--- a/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
@@ -4,7 +4,21 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class BitbucketOAuth2Account(ProviderAccount):
-    pass
+    def get_profile_url(self):
+        return (self.account.extra_data
+                .get('links', {})
+                .get('html', {})
+                .get('href'))
+
+    def get_avatar_url(self):
+        return (self.account.extra_data
+                .get('links', {})
+                .get('avatar', {})
+                .get('href'))
+
+    def to_str(self):
+        dflt = super(BitbucketOAuth2Account, self).to_str()
+        return self.account.extra_data.get('display_name', dflt)
 
 
 class BitbucketOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
@@ -17,6 +17,8 @@ class BitbucketOAuth2Provider(OAuth2Provider):
         return data['username']
 
     def extract_common_fields(self, data):
-        return dict(name=data.get('display_name'))
+        return dict(name=data.get('display_name'),
+                    email=data.get('email'))
+
 
 providers.registry.register(BitbucketOAuth2Provider)

--- a/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from allauth.socialaccount.tests import create_oauth2_tests
+from allauth.tests import MockedResponse
+from allauth.socialaccount.providers import registry
+
+from .provider import BitbucketOAuth2Provider
+
+
+class BitbucketOAuth2Tests(create_oauth2_tests(registry.by_id(
+        BitbucketOAuth2Provider.id))):
+    def get_mocked_response(self):
+        return [MockedResponse(200, """
+            {
+                "created_on": "2011-12-20T16:34:07.132459+00:00",
+                "display_name": "tutorials account",
+                "links": {
+                    "avatar": {
+                        "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Nov/25/tutorials-avatar-1563784409-6_avatar.png"
+                    },
+                    "followers": {
+                        "href": "https://api.bitbucket.org/2.0/users/tutorials/followers"
+                    },
+                    "following": {
+                        "href": "https://api.bitbucket.org/2.0/users/tutorials/following"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/tutorials"
+                    },
+                    "repositories": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/tutorials"
+                    },
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/users/tutorials"
+                    }
+                },
+                "location": "Santa Monica, CA",
+                "type": "user",
+                "username": "tutorials",
+                "uuid": "{c788b2da-b7a2-404c-9e26-d3f077557007}",
+                "website": "https://tutorials.bitbucket.org/"
+            }
+        """)]

--- a/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
@@ -125,6 +125,16 @@ class BitbucketOAuth2Tests(create_oauth2_tests(registry.by_id(
         socialaccount = SocialAccount.objects.get(uid='tutorials')
         self.assertEqual(socialaccount.user.username, 'tutorials')
         self.assertEqual(socialaccount.user.email, 'tutorials@bitbucket.org')
+        account = socialaccount.get_provider_account()
+        self.assertEqual(account.to_str(), 'tutorials account')
+        self.assertEqual(
+            account.get_profile_url(),
+            'https://bitbucket.org/tutorials'
+        )
+        self.assertEqual(
+            account.get_avatar_url(),
+            'https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Nov/25/tutorials-avatar-1563784409-6_avatar.png'
+        )
         self.patches['requests'].get.assert_has_calls([
             mock.call('https://api.bitbucket.org/2.0/user', params=mock.ANY),
             mock.call('https://api.bitbucket.org/2.0/user/emails', params=mock.ANY),

--- a/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
@@ -1,44 +1,131 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import mock
+
+from django.test.utils import override_settings
 from allauth.socialaccount.tests import create_oauth2_tests
-from allauth.tests import MockedResponse
+from allauth.tests import MockedResponse, patch
 from allauth.socialaccount.providers import registry
+from allauth.socialaccount.models import SocialAccount
 
 from .provider import BitbucketOAuth2Provider
 
 
+@override_settings(SOCIALACCOUNT_QUERY_EMAIL=True)
 class BitbucketOAuth2Tests(create_oauth2_tests(registry.by_id(
         BitbucketOAuth2Provider.id))):
-    def get_mocked_response(self):
-        return [MockedResponse(200, """
-            {
-                "created_on": "2011-12-20T16:34:07.132459+00:00",
-                "display_name": "tutorials account",
-                "links": {
-                    "avatar": {
-                        "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Nov/25/tutorials-avatar-1563784409-6_avatar.png"
-                    },
-                    "followers": {
-                        "href": "https://api.bitbucket.org/2.0/users/tutorials/followers"
-                    },
-                    "following": {
-                        "href": "https://api.bitbucket.org/2.0/users/tutorials/following"
-                    },
-                    "html": {
-                        "href": "https://bitbucket.org/tutorials"
-                    },
-                    "repositories": {
-                        "href": "https://api.bitbucket.org/2.0/repositories/tutorials"
-                    },
-                    "self": {
-                        "href": "https://api.bitbucket.org/2.0/users/tutorials"
-                    }
+
+    response_data = """
+        {
+            "created_on": "2011-12-20T16:34:07.132459+00:00",
+            "display_name": "tutorials account",
+            "links": {
+                "avatar": {
+                    "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Nov/25/tutorials-avatar-1563784409-6_avatar.png"
                 },
-                "location": "Santa Monica, CA",
-                "type": "user",
-                "username": "tutorials",
-                "uuid": "{c788b2da-b7a2-404c-9e26-d3f077557007}",
-                "website": "https://tutorials.bitbucket.org/"
-            }
-        """)]
+                "followers": {
+                    "href": "https://api.bitbucket.org/2.0/users/tutorials/followers"
+                },
+                "following": {
+                    "href": "https://api.bitbucket.org/2.0/users/tutorials/following"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/tutorials"
+                },
+                "repositories": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/tutorials"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/tutorials"
+                }
+            },
+            "location": "Santa Monica, CA",
+            "type": "user",
+            "username": "tutorials",
+            "uuid": "{c788b2da-b7a2-404c-9e26-d3f077557007}",
+            "website": "https://tutorials.bitbucket.org/"
+        }
+    """
+
+    email_response_data = """
+        {
+            "page": 1,
+            "pagelen": 10,
+            "size": 1,
+            "values": [
+                {
+                    "email": "tutorials@bitbucket.org",
+                    "is_confirmed": true,
+                    "is_primary": true,
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/user/emails/tutorials@bitbucket.org"
+                        }
+                    },
+                    "type": "email"
+                },
+                {
+                    "email": "tutorials+secondary@bitbucket.org",
+                    "is_confirmed": true,
+                    "is_primary": true,
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/user/emails/tutorials+secondary@bitbucket.org"
+                        }
+                    },
+                    "type": "email"
+                }
+            ]
+        }
+    """
+
+    def setUp(self):
+        super(BitbucketOAuth2Tests, self).setUp()
+        self.mocks = {
+            'requests': patch('allauth.socialaccount.providers'
+                              '.bitbucket_oauth2.views.requests')
+        }
+        self.patches = dict((name, mocked.start())
+                            for (name, mocked) in self.mocks.items())
+        self.patches['requests'].get.side_effect = [
+            MockedResponse(200, self.response_data),
+            MockedResponse(200, self.email_response_data),
+        ]
+
+    def tearDown(self):
+        for (_, mocked) in self.mocks.items():
+            mocked.stop()
+
+    def get_mocked_response(self):
+        return [MockedResponse(200, self.response_data)]
+
+    def test_account_tokens(self, multiple_login=False):
+        if multiple_login:
+            self.patches['requests'].get.side_effect = [
+                MockedResponse(200, self.response_data),
+                MockedResponse(200, self.email_response_data),
+                MockedResponse(200, self.response_data),
+                MockedResponse(200, self.email_response_data),
+            ]
+        super(BitbucketOAuth2Tests, self).test_account_tokens(multiple_login)
+        calls = [
+            mock.call('https://api.bitbucket.org/2.0/user', params=mock.ANY),
+            mock.call('https://api.bitbucket.org/2.0/user/emails', params=mock.ANY),
+        ]
+        if multiple_login:
+            calls.extend([
+                mock.call('https://api.bitbucket.org/2.0/user', params=mock.ANY),
+                mock.call('https://api.bitbucket.org/2.0/user/emails', params=mock.ANY),
+            ])
+        self.patches['requests'].get.assert_has_calls(calls)
+
+    def test_provider_account(self):
+        self.login(self.get_mocked_response())
+        socialaccount = SocialAccount.objects.get(uid='tutorials')
+        self.assertEqual(socialaccount.user.username, 'tutorials')
+        self.assertEqual(socialaccount.user.email, 'tutorials@bitbucket.org')
+        self.patches['requests'].get.assert_has_calls([
+            mock.call('https://api.bitbucket.org/2.0/user', params=mock.ANY),
+            mock.call('https://api.bitbucket.org/2.0/user/emails', params=mock.ANY),
+        ])

--- a/allauth/socialaccount/providers/bitbucket_oauth2/urls.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/urls.py
@@ -1,0 +1,5 @@
+from allauth.socialaccount.providers.oauth.urls import default_urlpatterns
+
+from .provider import BitbucketOAuth2Provider
+
+urlpatterns = default_urlpatterns(BitbucketOAuth2Provider)

--- a/allauth/socialaccount/providers/bitbucket_oauth2/views.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/views.py
@@ -4,28 +4,39 @@ from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
 import requests
 
 from .provider import BitbucketOAuth2Provider
+from allauth.socialaccount import app_settings
 
 
 class BitbucketOAuth2Adapter(OAuth2Adapter):
     provider_id = BitbucketOAuth2Provider.id
     access_token_url = 'https://bitbucket.org/site/oauth2/access_token'
     authorize_url = 'https://bitbucket.org/site/oauth2/authorize'
-    profile_url = 'https://bitbucket.org/api/1.0/user'
-    redirect_uri_protocol = 'https'
+    profile_url = 'https://api.bitbucket.org/2.0/user'
+    emails_url = 'https://api.bitbucket.org/2.0/user/emails'
 
     def complete_login(self, request, app, token, **kwargs):
-        extra_data = requests.get(self.profile_url, params={
-            'access_token': token.token
-        })
+        resp = requests.get(self.profile_url,
+                            params={'access_token': token.token})
+        extra_data = resp.json()
+        if app_settings.QUERY_EMAIL and not extra_data.get('email'):
+            extra_data['email'] = self.get_email(token)
+        return self.get_provider().sociallogin_from_response(request,
+                                                             extra_data)
 
-        # This only here because of weird response from the test suite
-        if isinstance(extra_data, list):
-            extra_data = extra_data[0]
-
-        return self.get_provider().sociallogin_from_response(
-            request,
-            extra_data.json()
-        )
+    def get_email(self, token):
+        """Fetches email address from email API endpoint"""
+        resp = requests.get(self.emails_url,
+                            params={'access_token': token.token})
+        emails = resp.json().get('values', [])
+        email = ''
+        try:
+            email = emails[0].get('email')
+            primary_emails = [e for e in emails if e.get('is_primary', False)]
+            email = primary_emails[0].get('email')
+        except (IndexError, TypeError, KeyError):
+            return ''
+        finally:
+            return email
 
 
 oauth_login = OAuth2LoginView.adapter_view(BitbucketOAuth2Adapter)

--- a/allauth/socialaccount/providers/bitbucket_oauth2/views.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/views.py
@@ -1,0 +1,32 @@
+from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
+                                                          OAuth2LoginView,
+                                                          OAuth2CallbackView)
+import requests
+
+from .provider import BitbucketOAuth2Provider
+
+
+class BitbucketOAuth2Adapter(OAuth2Adapter):
+    provider_id = BitbucketOAuth2Provider.id
+    access_token_url = 'https://bitbucket.org/site/oauth2/access_token'
+    authorize_url = 'https://bitbucket.org/site/oauth2/authorize'
+    profile_url = 'https://bitbucket.org/api/1.0/user'
+    redirect_uri_protocol = 'https'
+
+    def complete_login(self, request, app, token, **kwargs):
+        extra_data = requests.get(self.profile_url, params={
+            'access_token': token.token
+        })
+
+        # This only here because of weird response from the test suite
+        if isinstance(extra_data, list):
+            extra_data = extra_data[0]
+
+        return self.get_provider().sociallogin_from_response(
+            request,
+            extra_data.json()
+        )
+
+
+oauth_login = OAuth2LoginView.adapter_view(BitbucketOAuth2Adapter)
+oauth_callback = OAuth2CallbackView.adapter_view(BitbucketOAuth2Adapter)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -58,6 +58,7 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
         'allauth.socialaccount.providers.amazon',
         'allauth.socialaccount.providers.angellist',
         'allauth.socialaccount.providers.bitbucket',
+        'allauth.socialaccount.providers.bitbucket_oauth2',
         'allauth.socialaccount.providers.bitly',
         'allauth.socialaccount.providers.coinbase',
         'allauth.socialaccount.providers.dropbox',

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -37,7 +37,7 @@ Supported Providers
 
 - AngelList (OAuth2)
 
-- Bitbucket (OAuth)
+- Bitbucket (OAuth, OAuth2)
 
 - Bitly (OAuth2)
 


### PR DESCRIPTION
Basing most of this on another OAuth2 provider, this adds Bitbucket OAuth2 support. The only hang up I hit while implementing this was fetching the user email from a secondary API endpoint, so some focus there in this review would be a good thing.

Refs #1131 