### PR TITLE
Repair tests on python-3.4 with django-1.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
    - DJANGO="Django<1.7"
    - DJANGO="Django<1.8"
    - DJANGO="Django<1.9"
-   - DJANGO="Django==1.9b1"
+   - DJANGO="Django<1.10"
 cache:
   directories:
     - $HOME/.cache/pip
@@ -27,9 +27,9 @@ matrix:
       env: DJANGO="Django<1.8"
     # Django 1.9+ no longer supports python 3.2/3.3
     - python: "3.2"
-      env: DJANGO="Django==1.9b1"
+      env: DJANGO="Django<1.10"
     - python: "3.3"
-      env: DJANGO="Django==1.9b1"
+      env: DJANGO="Django<1.10"
 branches:
  only:
   - master

--- a/allauth/socialaccount/tests.py
+++ b/allauth/socialaccount/tests.py
@@ -69,8 +69,8 @@ def create_oauth_tests(provider):
                           % self.provider.id)
             return
         resp = self.login(resp_mocks)
-        self.assertEqual('http://testserver/accounts/profile/',
-                         resp['location'])
+        self.assertRedirects(resp, 'http://testserver/accounts/profile/',
+                             fetch_redirect_response=False)
         self.assertFalse(resp.context['user'].has_usable_password())
 
     def login(self, resp_mocks, process='login'):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,32,33,34,35}-django{16,17,18},
+envlist = py{27,32,33,34,35}-django{16,17,18,19}
 
 [testenv]
 deps =
@@ -8,6 +8,7 @@ deps =
     django16: Django < 1.7
     django17: Django < 1.8
     django18: Django < 1.9
+    django19: Django < 1.10
 commands =
     coverage run manage.py test allauth
     coverage report


### PR DESCRIPTION
This failed in Travis on another PR, see
https://github.com/pennersr/django-allauth/pull/1214 and
https://travis-ci.org/pennersr/django-allauth/jobs/94960086

It has nothing to do with that PR but here's the fix, so that one won't appear
to be failing.

Note I thought that Django upstream had decided on 2.0 after 1.9, but then found this which says the next version will be 1.10 https://www.djangoproject.com/weblog/2015/jun/25/roadmap/