### PR TITLE
Fix for Instagram provider

### DIFF
--- a/allauth/socialaccount/providers/instagram/views.py
+++ b/allauth/socialaccount/providers/instagram/views.py
@@ -8,8 +8,8 @@ from .provider import InstagramProvider
 
 class InstagramOAuth2Adapter(OAuth2Adapter):
     provider_id = InstagramProvider.id
-    access_token_url = 'https://instagram.com/oauth/access_token'
-    authorize_url = 'https://instagram.com/oauth/authorize'
+    access_token_url = 'https://api.instagram.com/oauth/access_token'
+    authorize_url = 'https://api.instagram.com/oauth/authorize'
     profile_url = 'https://api.instagram.com/v1/users/self'
 
     def complete_login(self, request, app, token, **kwargs):

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -289,6 +289,16 @@ By default, `profile` scope is required, and optionally `email` scope
 depending on whether or not `SOCIALACCOUNT_QUERY_EMAIL` is enabled.
 
 
+Instagram
+---------
+
+App registration:
+    https://www.instagram.com/developer/clients/manage/
+
+Example valid redirect URI:
+    http://localhost:8000/accounts/instagram/login/callback/
+
+
 LinkedIn
 --------
 


### PR DESCRIPTION
According to the [API documentation](https://www.instagram.com/developer/authentication/), the URLs for oauth should be https://api.instagram.com

Also, added a touch of documentation for the provider.