### PR TITLE
Include test settings and documentation in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include AUTHORS
 include LICENSE
 include README.rst
+include test_settings.py
 recursive-include allauth *.html *.txt *.xml *.po *.mo *.js
+recursive-include docs Makefile conf.py *.rst


### PR DESCRIPTION
I'd like to provide an official django-allauth package in the Debian archive.
Having the tests and documentation sources in the tarball would allow me to
utilize both during package build, running the tests and building the
documentation from source.