### PR TITLE
Gitlab provider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Chris Beaven
 Chris Davis
 Christopher Grebs
 Daniel Eriksson
+Daniel Widerin
 David Evans
 David Friedman
 Eric Delord

--- a/allauth/socialaccount/providers/gitlab/models.py
+++ b/allauth/socialaccount/providers/gitlab/models.py
@@ -1,0 +1,1 @@
+# Create your models here.

--- a/allauth/socialaccount/providers/gitlab/provider.py
+++ b/allauth/socialaccount/providers/gitlab/provider.py
@@ -6,7 +6,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class GitLabAccount(ProviderAccount):
     def get_profile_url(self):
-        return self.account.extra_data.get('html_url')
+        return self.account.extra_data.get('web_url')
 
     def get_avatar_url(self):
         return self.account.extra_data.get('avatar_url')

--- a/allauth/socialaccount/providers/gitlab/provider.py
+++ b/allauth/socialaccount/providers/gitlab/provider.py
@@ -5,8 +5,9 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class GitLabAccount(ProviderAccount):
+
     def get_profile_url(self):
-        return self.account.extra_data.get('web_url')
+        return self.account.extra_data.get('html_url')
 
     def get_avatar_url(self):
         return self.account.extra_data.get('avatar_url')

--- a/allauth/socialaccount/providers/gitlab/provider.py
+++ b/allauth/socialaccount/providers/gitlab/provider.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class GitLabAccount(ProviderAccount):
+    def get_profile_url(self):
+        return self.account.extra_data.get('html_url')
+
+    def get_avatar_url(self):
+        return self.account.extra_data.get('avatar_url')
+
+    def to_str(self):
+        dflt = super(GitLabAccount, self).to_str()
+        return self.account.extra_data.get('name', dflt)
+
+
+class GitLabProvider(OAuth2Provider):
+    id = 'gitlab'
+    name = 'GitLab'
+    package = 'allauth.socialaccount.providers.gitlab'
+    account_class = GitLabAccount
+
+    def extract_uid(self, data):
+        return str(data['id'])
+
+    def extract_common_fields(self, data):
+        return dict(
+            email=data.get('email'),
+            username=data.get('username'),
+            name=data.get('name'),
+        )
+
+
+providers.registry.register(GitLabProvider)

--- a/allauth/socialaccount/providers/gitlab/tests.py
+++ b/allauth/socialaccount/providers/gitlab/tests.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse
+from allauth.tests import TestCase
+
+
+class GitLabTests(OAuth2TestsMixin, TestCase):
+    provider_id = GitLabProvider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(200, """
+            {
+                "avatar_url": "https://secure.gravatar.com/avatar/123",
+                "bio": "",
+                "can_create_group": "true",
+                "can_create_project": "true",
+                "color_scheme_id": 2,
+                "created_at": "2015-12-14T23:40:33+0100",
+                "current_sign_in_at": "2015-12-14T23:40:33+0100",
+                "email": "mr.bob@your.gitlab.server.tld",
+                "id": 2,
+                "identities": [],
+                "is_admin": "false",
+                "linkedin": "",
+                "name": "Mr Bob",
+                "private_token": "123",
+                "projects_limit": 10,
+                "skype": "mr.bob",
+                "state": "active",
+                "theme_id": 6,
+                "twitter": "mrbob",
+                "two_factor_enabled": "false",
+                "username": "mr.bob",
+                "web_url": "https://your.gitlab.server.tld/u/mr.bob",
+                "website_url": "http://mr.bob"
+            }
+        """)

--- a/allauth/socialaccount/providers/gitlab/urls.py
+++ b/allauth/socialaccount/providers/gitlab/urls.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
+from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
-from .provider import GitLabProvider
+
 
 urlpatterns = default_urlpatterns(GitLabProvider)

--- a/allauth/socialaccount/providers/gitlab/urls.py
+++ b/allauth/socialaccount/providers/gitlab/urls.py
@@ -1,0 +1,4 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+from .provider import GitLabProvider
+
+urlpatterns = default_urlpatterns(GitLabProvider)

--- a/allauth/socialaccount/providers/gitlab/views.py
+++ b/allauth/socialaccount/providers/gitlab/views.py
@@ -1,26 +1,25 @@
 # -*- coding: utf-8 -*-
+from allauth.socialaccount import app_settings
 from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
 from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
 from allauth.socialaccount.providers.oauth2.views import OAuth2CallbackView
 from allauth.socialaccount.providers.oauth2.views import OAuth2LoginView
-from django.conf import settings
 
 import requests
 
 
 class GitLabOAuth2Adapter(OAuth2Adapter):
     provider_id = GitLabProvider.id
+    provider_default_url = 'https://gitlab.com'
+    provider_api_version = 'v3'
 
-    access_token_url = getattr(
-        settings, 'GITLAB_ACCESS_TOKEN_URL', 'https://gitlab.com/oauth/token'
-    )
+    settings = app_settings.PROVIDERS.get(provider_id, {})
+    provider_base_url = settings.get('GITLAB_URL', provider_default_url)
 
-    authorize_url = getattr(
-        settings, 'GITLAB_USER_AUTHORIZATION_URL', 'https://gitlab.com/oauth/authorize'  # noqa
-    )
-
-    profile_url = getattr(
-        settings, 'GITLAB_USER_INFO_URL', 'https://gitlab.com/api/v3/user'
+    access_token_url = '{0}/oauth/token'.format(provider_base_url)
+    authorize_url = '{0}/oauth/authorize'.format(provider_base_url)
+    profile_url = '{0}/api/{1}/user'.format(
+        provider_base_url, provider_api_version
     )
 
     def complete_login(self, request, app, token, response):

--- a/allauth/socialaccount/providers/gitlab/views.py
+++ b/allauth/socialaccount/providers/gitlab/views.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
+from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
+from allauth.socialaccount.providers.oauth2.views import OAuth2CallbackView
+from allauth.socialaccount.providers.oauth2.views import OAuth2LoginView
+from django.conf import settings
+
+import requests
+
+
+class GitLabOAuth2Adapter(OAuth2Adapter):
+    provider_id = GitLabProvider.id
+
+    access_token_url = getattr(
+        settings, 'GITLAB_ACCESS_TOKEN_URL', 'https://gitlab.com/oauth/token'
+    )
+
+    authorize_url = getattr(
+        settings, 'GITLAB_USER_AUTHORIZATION_URL', 'https://gitlab.com/oauth/authorize'  # noqa
+    )
+
+    profile_url = getattr(
+        settings, 'GITLAB_USER_INFO_URL', 'https://gitlab.com/api/v3/user'
+    )
+
+    def complete_login(self, request, app, token, response):
+        extra_data = requests.get(self.profile_url, params={
+            'access_token': token.token
+        })
+
+        return self.get_provider().sociallogin_from_response(
+            request,
+            extra_data.json()
+        )
+
+oauth2_login = OAuth2LoginView.adapter_view(GitLabOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(GitLabOAuth2Adapter)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -255,25 +255,14 @@ authentication provider as described in GitLab docs here:
 
     http://doc.gitlab.com/ce/integration/oauth_provider.html
 
-Following GitLab settings are available:
+Following GitLab settings are available, it unset https://gitlab.com will
+be used.
 
-GITLAB_USER_AUTHORIZATION_URL:
-    Override authorize endpoint to request an authorization token. For your
+GITLAB_URL:
+    Override endpoint to request an authorization and access token. For your
     private GitLab server you use:
 
-        https://your.gitlab.server.tld/oauth/authorize
-
-GITLAB_ACCESS_TOKEN_URL:
-    To request the access token from your private GitLab server you have to
-    override access token endpoint:
-
-        https://your.gitlab.server.tld/oauth/token
-
-GITLAB_USER_INFO_URL:
-    Endpoint to retrieve your user information from. For your private GitLab
-    server you use:
-
-        https://your.gitlab.server.tld/api/v3/user
+        https://your.gitlab.server.tld
 
 
 Google

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -246,6 +246,36 @@ App registration
     https://github.com/settings/applications/new
 
 
+GitLab
+------
+
+The GitLab provider works by default with https://gitlab.com. It allows you
+to connect to your private GitLab server and use GitLab as an OAuth2
+authentication provider as described in GitLab docs here:
+
+    http://doc.gitlab.com/ce/integration/oauth_provider.html
+
+Following GitLab settings are available:
+
+GITLAB_USER_AUTHORIZATION_URL:
+    Override authorize endpoint to request an authorization token. For your
+    private GitLab server you use:
+
+        https://your.gitlab.server.tld/oauth/authorize
+
+GITLAB_ACCESS_TOKEN_URL:
+    To request the access token from your private GitLab server you have to
+    override access token endpoint:
+
+        https://your.gitlab.server.tld/oauth/token
+
+GITLAB_USER_INFO_URL:
+    Endpoint to retrieve your user information from. For your private GitLab
+    server you use:
+
+        https://your.gitlab.server.tld/api/v3/user
+
+
 Google
 ------
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.foursquare',
     'allauth.socialaccount.providers.google',
     'allauth.socialaccount.providers.github',
+    'allauth.socialaccount.providers.gitlab',
     'allauth.socialaccount.providers.hubic',
     'allauth.socialaccount.providers.instagram',
     'allauth.socialaccount.providers.linkedin',


### PR DESCRIPTION
This GitLab provider enables OAuth2 authentication against GitLab. Use following settings in your `DJANGO_SETTINGS_MODULE ` to use your private GitLab server as an OAuth2 provider. 

    # Personal GitLab server
    GITLAB_USER_AUTHORIZATION_URL = 'https://your.gitlab.server.tld/oauth/authorize'
    GITLAB_ACCESS_TOKEN_URL = 'https://your.gitlab.server.tld/oauth/token'
    GITLAB_USER_INFO_URL = 'https://your.gitlab.server.tld/api/v3/user'