### PR TITLE
Update advanced.rst

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -142,6 +142,8 @@ If this does not suit your needs, you can hook up your own custom
 mechanism by overriding the `send_mail` method of the account adapter
 (`allauth.account.adapter.DefaultAccountAdapter`).
 
+HTML templates are sent in addition to the txt which shadow the defaults. No default html templates are included with the package.
+
 
 Custom Redirects
 ----------------


### PR DESCRIPTION
Found the documentation on default email behavior rather confusing. This change clarifies that the HTML email is sent in addition to txt but that there are no default HTML templates in account/email (as per site-packages).