### PR TITLE
Support overriding two templates with non-Django templates.

### DIFF
--- a/allauth/compat.py
+++ b/allauth/compat.py
@@ -5,6 +5,17 @@ if django.VERSION > (1, 8,):
 else:
     from django.utils.datastructures import SortedDict as OrderedDict  # noqa
 
+if django.VERSION > (1, 8,):
+    from django.template.loader import render_to_string
+else:
+    from django.template.loader import render_to_string as _render_to_string
+    from django.template import RequestContext
+
+    # Wire the Django >= 1.8 API to the Django < 1.7 implementation.
+    def render_to_string(template_name, context=None, request=None, using=None):
+        assert using is None, "Multiple template engines required Django >= 1.8"
+        return _render_to_string(template_name, context, RequestContext(request))
+
 try:
     from urllib.parse import parse_qsl, urlparse, urlunparse
 except ImportError:

--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -3,11 +3,10 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import get_token
-from django.template.loader import render_to_string
-from django.template import RequestContext
 from django.utils.html import mark_safe, escapejs
 from django.utils.crypto import get_random_string
 
+from allauth.compat import render_to_string
 from allauth.utils import import_callable
 from allauth.account.models import EmailAddress
 from allauth.socialaccount import providers
@@ -150,9 +149,8 @@ class FacebookProvider(OAuth2Provider):
             "csrfToken": get_token(request)
         }
         ctx = {'fb_data': mark_safe(json.dumps(fb_data))}
-        return render_to_string('facebook/fbconnect.html',
-                                ctx,
-                                RequestContext(request))
+        return render_to_string('facebook/fbconnect.html', ctx,
+                                request=request)
 
     def get_nonce(self, request, or_create=False, pop=False):
         if pop:

--- a/allauth/socialaccount/providers/persona/provider.py
+++ b/allauth/socialaccount/providers/persona/provider.py
@@ -1,9 +1,8 @@
 import json
 
-from django.template.loader import render_to_string
-from django.template import RequestContext
 from django.utils.html import escapejs
 
+from allauth.compat import render_to_string
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.base import ProviderAccount, Provider
 from allauth.account.models import EmailAddress
@@ -24,9 +23,7 @@ class PersonaProvider(Provider):
         settings = self.get_settings()
         request_parameters = settings.get('REQUEST_PARAMETERS', {})
         ctx = {'request_parameters': json.dumps(request_parameters)}
-        return render_to_string('persona/auth.html',
-                                ctx,
-                                RequestContext(request))
+        return render_to_string('persona/auth.html', ctx, request=request)
 
     def get_login_url(self, request, **kwargs):
         next_url = "'%s'" % escapejs(kwargs.get('next') or '')


### PR DESCRIPTION
These two modules were using a version of `render_to_string` that is
deprecated since Django 1.8.