### PR TITLE
Update views.py

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -558,8 +558,12 @@ class PasswordResetView(AjaxCapableProcessFormViewMixin, FormView):
 
     def get_context_data(self, **kwargs):
         ret = super(PasswordResetView, self).get_context_data(**kwargs)
+        login_url = passthrough_next_redirect_url(self.request,
+                                                  reverse("account_login"),
+                                                  self.redirect_field_name)
         # NOTE: For backwards compatibility
         ret['password_reset_form'] = ret.get('form')
+        ret.update({"login_url": login_url})
         # (end NOTE)
         return ret
 


### PR DESCRIPTION
add login_url to the context variables of the password reset form. It is always handy to give users the ability to sign in quickly when the suddenly remember their password.