### PR TITLE
Don't log user out when setting the password.

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -18,6 +18,11 @@ from django.core.exceptions import ValidationError
 from allauth.compat import OrderedDict
 
 try:
+    from django.contrib.auth import update_session_auth_hash
+except ImportError:
+    update_session_auth_hash = None
+
+try:
     from django.utils.encoding import force_text
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
@@ -57,6 +62,15 @@ def get_login_redirect_url(request, url=None, redirect_field_name="next"):
     return redirect_url
 
 _user_display_callable = None
+
+
+def logout_on_password_change(request, user):
+    # Since it is the default behavior of Django to invalidate all sessions on
+    # password change, this function actually has to preserve the session when
+    # logout isn't desired.
+    if (update_session_auth_hash is not None and
+            not app_settings.LOGOUT_ON_PASSWORD_CHANGE):
+        update_session_auth_hash(request, user)
 
 
 def default_user_display(user):

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -28,11 +28,6 @@ from . import app_settings
 
 from .adapter import get_adapter
 
-try:
-    from django.contrib.auth import update_session_auth_hash
-except ImportError:
-    update_session_auth_hash = None
-
 
 sensitive_post_parameters_m = method_decorator(
     sensitive_post_parameters('password', 'password1', 'password2'))
@@ -481,9 +476,7 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
 
     def form_valid(self, form):
         form.save()
-        if (update_session_auth_hash is not None and
-                not app_settings.LOGOUT_ON_PASSWORD_CHANGE):
-            update_session_auth_hash(self.request, form.user)
+        logout_on_password_change(self.request, form.user)
         get_adapter().add_message(self.request,
                                   messages.SUCCESS,
                                   'account/messages/password_changed.txt')
@@ -525,6 +518,7 @@ class PasswordSetView(AjaxCapableProcessFormViewMixin, FormView):
 
     def form_valid(self, form):
         form.save()
+        logout_on_password_change(self.request, form.user)
         get_adapter().add_message(self.request,
                                   messages.SUCCESS,
                                   'account/messages/password_set.txt')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,13 @@ Changelog
 
 This chapter contains notes on upgrading.
 
+From 0.24.0
+***********
+
+- Setting a password after logging in with a social account no longer logs out
+  the user by default on Django 1.7+. Setting an initial password and changing
+  the password both respect `settings.ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE`.
+
 From 0.23.0
 ***********
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -60,7 +60,7 @@ ACCOUNT_LOGOUT_ON_GET (=False)
 
 ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE (=False)
   Determines whether or not the user is automatically logged out after
-  changing the password. See documentation for `Django's session invalidation on password change <https://docs.djangoproject.com/en/1.8/topics/auth/default/#session-invalidation-on-password-change>`_. (Django 1.7+)
+  changing or setting their password. See documentation for `Django's session invalidation on password change <https://docs.djangoproject.com/en/1.8/topics/auth/default/#session-invalidation-on-password-change>`_. (Django 1.7+)
 
 ACCOUNT_LOGOUT_REDIRECT_URL (="/")
   The URL (or URL name) to return to after the user logs out. This is


### PR DESCRIPTION
This makes "setting the password" and "changing the password" behave
identically with regards to settings.ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE.

Fix #1262.