### PR TITLE
Add ACCOUNT_TEMPLATE_EXTENSION option and view mixin for allowing other template engine extensions

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -238,6 +238,13 @@ class AppSettings(object):
         return self._setting('SESSION_REMEMBER', None)
 
     @property
+    def TEMPLATE_EXTENSION(self):
+        """
+        A string defining the template extension to use, defaults to `html`.
+        """
+        return self._setting('TEMPLATE_EXTENSION', 'html')
+
+    @property
     def FORMS(self):
         return self._setting('FORMS', {})
 

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -30,6 +30,7 @@ import uuid
 
 
 @override_settings(
+    ACCOUNT_TEMPLATE_EXTENSION='html',
     ACCOUNT_DEFAULT_HTTP_PROTOCOL='https',
     ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod.MANDATORY,
     ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod.USERNAME,
@@ -198,7 +199,8 @@ class AccountTests(TestCase):
         # Extract URL for `password_reset_from_key` view and access it
         url = body[body.find('/password/reset/'):].split()[0]
         resp = self.client.get(url)
-        self.assertTemplateUsed(resp, 'account/password_reset_from_key.html')
+        self.assertTemplateUsed(
+            resp, 'account/password_reset_from_key.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
         self.assertFalse('token_fail' in resp.context_data)
 
         # Reset the password
@@ -217,13 +219,14 @@ class AccountTests(TestCase):
         resp = self.client.post(url,
                                 {'password1': 'newpass123',
                                  'password2': 'newpass123'})
-        self.assertTemplateUsed(resp, 'account/password_reset_from_key.html')
+        self.assertTemplateUsed(
+            resp, 'account/password_reset_from_key.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
         self.assertTrue(resp.context_data['token_fail'])
 
         # Same should happen when accessing the page directly
         response = self.client.get(url)
-        self.assertTemplateUsed(response,
-                                'account/password_reset_from_key.html')
+        self.assertTemplateUsed(
+            response, 'account/password_reset_from_key.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
         self.assertTrue(response.context_data['token_fail'])
 
         # When in XHR views, it should respond with a 400 bad request
@@ -265,7 +268,7 @@ class AccountTests(TestCase):
         self.assertGreater(mail.outbox[0].body.find('https://'), 0)
         self.assertEqual(len(mail.outbox), 1)
         self.assertTemplateUsed(resp,
-                                'account/verification_sent.html')
+                                'account/verification_sent.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
         # Attempt to login, unverified
         for attempt in [1, 2]:
             resp = c.post(reverse('account_login'),
@@ -279,7 +282,7 @@ class AccountTests(TestCase):
                 username='johndoe', is_active=True).exists())
 
             self.assertTemplateUsed(resp,
-                                    'account/verification_sent.html')
+                                    'account/verification_sent.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
             # Attempt 1: no mail is sent due to cool-down ,
             # but there was already a mail in the outbox.
             self.assertEqual(len(mail.outbox), attempt)
@@ -297,7 +300,7 @@ class AccountTests(TestCase):
             .get()
         resp = c.get(reverse('account_confirm_email',
                              args=[confirmation.key]))
-        self.assertTemplateUsed(resp, 'account/email_confirm.html')
+        self.assertTemplateUsed(resp, 'account/email_confirm.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
         c.post(reverse('account_confirm_email',
                        args=[confirmation.key]))
         resp = c.post(reverse('account_login'),
@@ -432,7 +435,7 @@ class AccountTests(TestCase):
     @override_settings(ACCOUNT_LOGOUT_ON_GET=False)
     def test_logout_view_on_post(self):
         c, resp = self._logout_view('get')
-        self.assertTemplateUsed(resp, 'account/logout.html')
+        self.assertTemplateUsed(resp, 'account/logout.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
         resp = c.post(reverse('account_logout'))
         self.assertTemplateUsed(resp, 'account/messages/logged_out.txt')
 

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -30,7 +30,6 @@ import uuid
 
 
 @override_settings(
-    ACCOUNT_TEMPLATE_EXTENSION='html',
     ACCOUNT_DEFAULT_HTTP_PROTOCOL='https',
     ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod.MANDATORY,
     ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod.USERNAME,
@@ -200,7 +199,7 @@ class AccountTests(TestCase):
         url = body[body.find('/password/reset/'):].split()[0]
         resp = self.client.get(url)
         self.assertTemplateUsed(
-            resp, 'account/password_reset_from_key.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
+            resp, 'account/password_reset_from_key.%s' % app_settings.TEMPLATE_EXTENSION)
         self.assertFalse('token_fail' in resp.context_data)
 
         # Reset the password
@@ -220,13 +219,13 @@ class AccountTests(TestCase):
                                 {'password1': 'newpass123',
                                  'password2': 'newpass123'})
         self.assertTemplateUsed(
-            resp, 'account/password_reset_from_key.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
+            resp, 'account/password_reset_from_key.%s' % app_settings.TEMPLATE_EXTENSION)
         self.assertTrue(resp.context_data['token_fail'])
 
         # Same should happen when accessing the page directly
         response = self.client.get(url)
         self.assertTemplateUsed(
-            response, 'account/password_reset_from_key.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
+            response, 'account/password_reset_from_key.%s' % app_settings.TEMPLATE_EXTENSION)
         self.assertTrue(response.context_data['token_fail'])
 
         # When in XHR views, it should respond with a 400 bad request
@@ -268,7 +267,7 @@ class AccountTests(TestCase):
         self.assertGreater(mail.outbox[0].body.find('https://'), 0)
         self.assertEqual(len(mail.outbox), 1)
         self.assertTemplateUsed(resp,
-                                'account/verification_sent.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
+                                'account/verification_sent.%s' % app_settings.TEMPLATE_EXTENSION)
         # Attempt to login, unverified
         for attempt in [1, 2]:
             resp = c.post(reverse('account_login'),
@@ -281,8 +280,8 @@ class AccountTests(TestCase):
             self.assertTrue(get_user_model().objects.filter(
                 username='johndoe', is_active=True).exists())
 
-            self.assertTemplateUsed(resp,
-                                    'account/verification_sent.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
+            self.assertTemplateUsed(
+                resp, 'account/verification_sent.%s' % app_settings.TEMPLATE_EXTENSION)
             # Attempt 1: no mail is sent due to cool-down ,
             # but there was already a mail in the outbox.
             self.assertEqual(len(mail.outbox), attempt)
@@ -300,7 +299,7 @@ class AccountTests(TestCase):
             .get()
         resp = c.get(reverse('account_confirm_email',
                              args=[confirmation.key]))
-        self.assertTemplateUsed(resp, 'account/email_confirm.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
+        self.assertTemplateUsed(resp, 'account/email_confirm.%s' % app_settings.TEMPLATE_EXTENSION)
         c.post(reverse('account_confirm_email',
                        args=[confirmation.key]))
         resp = c.post(reverse('account_login'),
@@ -435,7 +434,7 @@ class AccountTests(TestCase):
     @override_settings(ACCOUNT_LOGOUT_ON_GET=False)
     def test_logout_view_on_post(self):
         c, resp = self._logout_view('get')
-        self.assertTemplateUsed(resp, 'account/logout.%s' % settings.ACCOUNT_TEMPLATE_EXTENSION)
+        self.assertTemplateUsed(resp, 'account/logout.%s' % app_settings.TEMPLATE_EXTENSION)
         resp = c.post(reverse('account_logout'))
         self.assertTemplateUsed(resp, 'account/messages/logged_out.txt')
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -87,7 +87,7 @@ class AjaxCapableProcessFormViewMixin(object):
 class DynamicTemplateExtensionMixin(object):
 
     def get_template_names(self):
-        return ['%s.%s' % (self.kwargs['template'],
+        return ['%s.%s' % (self.template_name.split('.')[0],
                 getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html'))]
 
 
@@ -571,7 +571,7 @@ class PasswordResetDoneView(DynamicTemplateExtensionMixin, TemplateView):
 password_reset_done = PasswordResetDoneView.as_view()
 
 
-class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, 
+class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin,
                                FormView):
     template_name = "account/password_reset_from_key.html"
     form_class = ResetPasswordKeyForm

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -84,19 +84,11 @@ class AjaxCapableProcessFormViewMixin(object):
         return _ajax_response(self.request, response, form=form)
 
 
-class DynamicTemplateExtensionMixin(object):
-
-    def get_template_names(self):
-        return ['%s.%s' % (self.template_name.split('.')[0],
-                getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html'))]
-
-
 class LoginView(RedirectAuthenticatedUserMixin,
                 AjaxCapableProcessFormViewMixin,
-                DynamicTemplateExtensionMixin,
                 FormView):
     form_class = LoginForm
-    template_name = "account/login.html"
+    template_name = "account/login.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     success_url = None
     redirect_field_name = "next"
 
@@ -140,7 +132,7 @@ login = LoginView.as_view()
 
 
 class CloseableSignupMixin(object):
-    template_name_signup_closed = "account/signup_closed.html"
+    template_name_signup_closed = "account/signup_closed.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
     def dispatch(self, request, *args, **kwargs):
         # WORKAROUND: https://code.djangoproject.com/ticket/19316
@@ -167,8 +159,8 @@ class CloseableSignupMixin(object):
 
 
 class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
-                 AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
-    template_name = "account/signup.html"
+                 AjaxCapableProcessFormViewMixin, FormView):
+    template_name = "account/signup.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     form_class = SignupForm
     redirect_field_name = "next"
     success_url = None
@@ -212,9 +204,9 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
 signup = SignupView.as_view()
 
 
-class ConfirmEmailView(TemplateResponseMixin, DynamicTemplateExtensionMixin, View):
+class ConfirmEmailView(TemplateResponseMixin, View):
 
-    template_name = "account/email_confirm.html"
+    template_name = "account/email_confirm.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
     def get(self, *args, **kwargs):
         try:
@@ -311,8 +303,8 @@ class ConfirmEmailView(TemplateResponseMixin, DynamicTemplateExtensionMixin, Vie
 confirm_email = ConfirmEmailView.as_view()
 
 
-class EmailView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
-    template_name = "account/email.html"
+class EmailView(AjaxCapableProcessFormViewMixin, FormView):
+    template_name = "account/email.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     form_class = AddEmailForm
     success_url = reverse_lazy('account_email')
 
@@ -457,8 +449,8 @@ class EmailView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, 
 email = login_required(EmailView.as_view())
 
 
-class PasswordChangeView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
-    template_name = "account/password_change.html"
+class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
+    template_name = "account/password_change.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     form_class = ChangePasswordForm
     success_url = reverse_lazy("account_change_password")
 
@@ -500,8 +492,8 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensi
 password_change = login_required(PasswordChangeView.as_view())
 
 
-class PasswordSetView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
-    template_name = "account/password_set.html"
+class PasswordSetView(AjaxCapableProcessFormViewMixin, FormView):
+    template_name = "account/password_set.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     form_class = SetPasswordForm
     success_url = reverse_lazy("account_set_password")
 
@@ -541,8 +533,8 @@ class PasswordSetView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionM
 password_set = login_required(PasswordSetView.as_view())
 
 
-class PasswordResetView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
-    template_name = "account/password_reset.html"
+class PasswordResetView(AjaxCapableProcessFormViewMixin, FormView):
+    template_name = "account/password_reset.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     form_class = ResetPasswordForm
     success_url = reverse_lazy("account_reset_password_done")
 
@@ -565,15 +557,14 @@ class PasswordResetView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensio
 password_reset = PasswordResetView.as_view()
 
 
-class PasswordResetDoneView(DynamicTemplateExtensionMixin, TemplateView):
-    template_name = "account/password_reset_done.html"
+class PasswordResetDoneView(TemplateView):
+    template_name = "account/password_reset_done.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
 password_reset_done = PasswordResetDoneView.as_view()
 
 
-class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin,
-                               FormView):
-    template_name = "account/password_reset_from_key.html"
+class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
+    template_name = "account/password_reset_from_key.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     form_class = ResetPasswordKeyForm
     success_url = reverse_lazy("account_reset_password_from_key_done")
 
@@ -625,15 +616,15 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, DynamicTemplateE
 password_reset_from_key = PasswordResetFromKeyView.as_view()
 
 
-class PasswordResetFromKeyDoneView(DynamicTemplateExtensionMixin, TemplateView):
-    template_name = "account/password_reset_from_key_done.html"
+class PasswordResetFromKeyDoneView(TemplateView):
+    template_name = "account/password_reset_from_key_done.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
 password_reset_from_key_done = PasswordResetFromKeyDoneView.as_view()
 
 
-class LogoutView(TemplateResponseMixin, DynamicTemplateExtensionMixin, View):
+class LogoutView(TemplateResponseMixin, View):
 
-    template_name = "account/logout.html"
+    template_name = "account/logout.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     redirect_field_name = "next"
 
     def get(self, *args, **kwargs):
@@ -673,13 +664,13 @@ class LogoutView(TemplateResponseMixin, DynamicTemplateExtensionMixin, View):
 logout = LogoutView.as_view()
 
 
-class AccountInactiveView(DynamicTemplateExtensionMixin, TemplateView):
-    template_name = 'account/account_inactive.html'
+class AccountInactiveView(TemplateView):
+    template_name = 'account/account_inactive.%s' % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
 account_inactive = AccountInactiveView.as_view()
 
 
-class EmailVerificationSentView(DynamicTemplateExtensionMixin, TemplateView):
-    template_name = 'account/verification_sent.html'
+class EmailVerificationSentView(TemplateView):
+    template_name = 'account/verification_sent.%s' % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
 email_verification_sent = EmailVerificationSentView.as_view()

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -212,7 +212,7 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
 signup = SignupView.as_view()
 
 
-class ConfirmEmailView(TemplateResponseMixin, View):
+class ConfirmEmailView(TemplateResponseMixin, DynamicTemplateExtensionMixin, View):
 
     template_name = "account/email_confirm.html"
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth import logout as auth_logout
 from django.shortcuts import redirect
 from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.decorators import method_decorator
+from django.conf import settings
 
 from ..exceptions import ImmediateHttpResponse
 from ..utils import get_form_class, get_request_param, get_current_site
@@ -83,8 +84,16 @@ class AjaxCapableProcessFormViewMixin(object):
         return _ajax_response(self.request, response, form=form)
 
 
+class DynamicTemplateExtensionMixin(object):
+
+    def get_template_names(self):
+        return ['%s.%s' % (self.kwargs['template'],
+                getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html'))]
+
+
 class LoginView(RedirectAuthenticatedUserMixin,
                 AjaxCapableProcessFormViewMixin,
+                DynamicTemplateExtensionMixin,
                 FormView):
     form_class = LoginForm
     template_name = "account/login.html"
@@ -158,7 +167,7 @@ class CloseableSignupMixin(object):
 
 
 class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
-                 AjaxCapableProcessFormViewMixin, FormView):
+                 AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
     template_name = "account/signup.html"
     form_class = SignupForm
     redirect_field_name = "next"
@@ -302,7 +311,7 @@ class ConfirmEmailView(TemplateResponseMixin, View):
 confirm_email = ConfirmEmailView.as_view()
 
 
-class EmailView(AjaxCapableProcessFormViewMixin, FormView):
+class EmailView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
     template_name = "account/email.html"
     form_class = AddEmailForm
     success_url = reverse_lazy('account_email')
@@ -448,7 +457,7 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 email = login_required(EmailView.as_view())
 
 
-class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
+class PasswordChangeView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
     template_name = "account/password_change.html"
     form_class = ChangePasswordForm
     success_url = reverse_lazy("account_change_password")
@@ -491,7 +500,7 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
 password_change = login_required(PasswordChangeView.as_view())
 
 
-class PasswordSetView(AjaxCapableProcessFormViewMixin, FormView):
+class PasswordSetView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
     template_name = "account/password_set.html"
     form_class = SetPasswordForm
     success_url = reverse_lazy("account_set_password")
@@ -532,7 +541,7 @@ class PasswordSetView(AjaxCapableProcessFormViewMixin, FormView):
 password_set = login_required(PasswordSetView.as_view())
 
 
-class PasswordResetView(AjaxCapableProcessFormViewMixin, FormView):
+class PasswordResetView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, FormView):
     template_name = "account/password_reset.html"
     form_class = ResetPasswordForm
     success_url = reverse_lazy("account_reset_password_done")
@@ -556,13 +565,14 @@ class PasswordResetView(AjaxCapableProcessFormViewMixin, FormView):
 password_reset = PasswordResetView.as_view()
 
 
-class PasswordResetDoneView(TemplateView):
+class PasswordResetDoneView(DynamicTemplateExtensionMixin, TemplateView):
     template_name = "account/password_reset_done.html"
 
 password_reset_done = PasswordResetDoneView.as_view()
 
 
-class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
+class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, DynamicTemplateExtensionMixin, 
+                               FormView):
     template_name = "account/password_reset_from_key.html"
     form_class = ResetPasswordKeyForm
     success_url = reverse_lazy("account_reset_password_from_key_done")
@@ -615,13 +625,13 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
 password_reset_from_key = PasswordResetFromKeyView.as_view()
 
 
-class PasswordResetFromKeyDoneView(TemplateView):
+class PasswordResetFromKeyDoneView(DynamicTemplateExtensionMixin, TemplateView):
     template_name = "account/password_reset_from_key_done.html"
 
 password_reset_from_key_done = PasswordResetFromKeyDoneView.as_view()
 
 
-class LogoutView(TemplateResponseMixin, View):
+class LogoutView(TemplateResponseMixin, DynamicTemplateExtensionMixin, View):
 
     template_name = "account/logout.html"
     redirect_field_name = "next"
@@ -663,13 +673,13 @@ class LogoutView(TemplateResponseMixin, View):
 logout = LogoutView.as_view()
 
 
-class AccountInactiveView(TemplateView):
+class AccountInactiveView(DynamicTemplateExtensionMixin, TemplateView):
     template_name = 'account/account_inactive.html'
 
 account_inactive = AccountInactiveView.as_view()
 
 
-class EmailVerificationSentView(TemplateView):
+class EmailVerificationSentView(DynamicTemplateExtensionMixin, TemplateView):
     template_name = 'account/verification_sent.html'
 
 email_verification_sent = EmailVerificationSentView.as_view()

--- a/allauth/socialaccount/tests.py
+++ b/allauth/socialaccount/tests.py
@@ -12,6 +12,7 @@ from django.test.client import RequestFactory
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.contrib.auth.models import AnonymousUser
+from django.conf import settings
 
 from ..tests import MockedResponse, mocked_response, TestCase
 from ..account import app_settings as account_settings
@@ -104,7 +105,7 @@ class OAuthTestsMixin(object):
     def test_authentication_error(self):
         resp = self.client.get(reverse(self.provider.id + '_callback'))
         self.assertTemplateUsed(resp,
-                                'socialaccount/authentication_error.html')
+                                'socialaccount/authentication_error.%s' % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html'))
 
 
 # For backward-compatibility with third-party provider tests that call
@@ -215,8 +216,9 @@ class OAuth2TestsMixin(object):
 
     def test_authentication_error(self):
         resp = self.client.get(reverse(self.provider.id + '_callback'))
-        self.assertTemplateUsed(resp,
-                                'socialaccount/authentication_error.html')
+        self.assertTemplateUsed(
+            resp,
+            'socialaccount/authentication_error.%s' % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html'))
 
 
 # For backward-compatibility with third-party provider tests that call

--- a/allauth/socialaccount/views.py
+++ b/allauth/socialaccount/views.py
@@ -4,6 +4,7 @@ from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.auth.decorators import login_required
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
+from django.conf import settings
 
 from ..account.views import (AjaxCapableProcessFormViewMixin,
                              CloseableSignupMixin,
@@ -21,7 +22,7 @@ from . import app_settings
 class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
                  AjaxCapableProcessFormViewMixin, FormView):
     form_class = SignupForm
-    template_name = 'socialaccount/signup.html'
+    template_name = 'socialaccount/signup.%s' % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
     def get_form_class(self):
         return get_form_class(app_settings.FORMS,
@@ -64,20 +65,20 @@ signup = SignupView.as_view()
 
 
 class LoginCancelledView(TemplateView):
-    template_name = "socialaccount/login_cancelled.html"
+    template_name = "socialaccount/login_cancelled.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
 login_cancelled = LoginCancelledView.as_view()
 
 
 class LoginErrorView(TemplateView):
-    template_name = "socialaccount/authentication_error.html"
+    template_name = "socialaccount/authentication_error.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
 
 
 login_error = LoginErrorView.as_view()
 
 
 class ConnectionsView(AjaxCapableProcessFormViewMixin, FormView):
-    template_name = "socialaccount/connections.html"
+    template_name = "socialaccount/connections.%s" % getattr(settings, 'ACCOUNT_TEMPLATE_EXTENSION', 'html')
     form_class = DisconnectForm
     success_url = reverse_lazy("socialaccount_connections")
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -140,6 +140,9 @@ ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS( (=True)
   By changing this setting to `False`, logged in users will not be redirected when
   they access login/signup pages.
 
+ACCOUNT_TEMPLATE_EXTENSION (="html")
+  A string defining the template extension to use, defaults to `html`.
+
 SOCIALACCOUNT_ADAPTER (="allauth.socialaccount.adapter.DefaultSocialAccountAdapter")
   Specifies the adapter class to use, allowing you to alter certain
   default behaviour.


### PR DESCRIPTION
I've recently begun using the Jade template language with my Django projects using pyjade. I also use django-allauth in all my projects. The problem I was facing was that the allauth account views use the `.html` extension, but I need to use the `.jade` extension. My first workaround was to import the allauth views, set the `template_name` attribute to my desired template, then call the as_view() method and add my views to my urls.py. However, this solution is proving unwieldy when moving it across many different projects.

I have since edited the views.py of django-allauth to include a `DynamicTemplateExtensionMixin` class and an `ACCOUNT_TEMPLATE_EXTENSION` configuration setting. This way I can easily override the allauth account templates as I did to prior to using Jade and merely have to change the template extensions and set a single configuration option.