### PR TITLE
Change extra_data default from '{}' to dict. Fixes #1272

### DIFF
--- a/allauth/socialaccount/migrations/0003_extra_data_default_dict.py
+++ b/allauth/socialaccount/migrations/0003_extra_data_default_dict.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import allauth.socialaccount.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('socialaccount', '0002_token_max_lengths'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='socialaccount',
+            name='extra_data',
+            field=allauth.socialaccount.fields.JSONField(default=dict, verbose_name='extra data'),
+            preserve_default=True,
+        ),
+    ]

--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -93,7 +93,7 @@ class SocialAccount(models.Model):
                                       auto_now=True)
     date_joined = models.DateTimeField(verbose_name=_('date joined'),
                                        auto_now_add=True)
-    extra_data = JSONField(verbose_name=_('extra data'), default='{}')
+    extra_data = JSONField(verbose_name=_('extra data'), default=dict)
 
     class Meta:
         unique_together = ('provider', 'uid')


### PR DESCRIPTION
This adds a Django migration but not a South migration, since the former
recognizes the change to the model but the latter doesn't.