### PR TITLE
In my work environments the server has no internet access, so is necessary to access external urls with proxy.

### DIFF
--- a/allauth/socialaccount/app_settings.py
+++ b/allauth/socialaccount/app_settings.py
@@ -71,6 +71,10 @@ class AppSettings(object):
     def UID_MAX_LENGTH(self):
         return 191
 
+    @property
+    def PROXY_URL(self):
+        return self._setting('PROXY_URL', None)
+
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/socialaccount/providers/oauth2/client.py
+++ b/allauth/socialaccount/providers/oauth2/client.py
@@ -4,7 +4,7 @@ except ImportError:
     from urllib import urlencode
     from urlparse import parse_qsl
 import requests
-
+from allauth.socialaccount.app_settings import PROXY_URL
 
 class OAuth2Error(Exception):
     pass
@@ -65,13 +65,25 @@ class OAuth2Client(object):
             params = data
             data = None
         # TODO: Proper exception handling
-        resp = requests.request(
-            self.access_token_method,
-            url,
-            params=params,
-            data=data,
-            headers=self.headers,
-            auth=auth)
+
+        if PROXY_URL:
+            proxy = "https://" + PROXY_URL
+            resp = requests.request(
+                self.access_token_method,
+                url,
+                params=params,
+                data=data,
+                headers=self.headers,
+                auth=auth,
+                proxies={'https': proxy})
+        else:
+            resp = requests.request(
+                self.access_token_method,
+                url,
+                params=params,
+                data=data,
+                headers=self.headers,
+                auth=auth)
 
         access_token = None
         if resp.status_code == 200:


### PR DESCRIPTION
In my work environments the server has no internet access, so is necessary to access external urls with proxy.

To use proxy in those requests, just included the property SOCIALACCOUNT_PROXY_URL on settings with the proxy url and port. 
Ex: SOCIALACCOUNT_PROXY_URL = "proxy.test.com:3128"