### PR TITLE
Expand Firefox Accounts provider configuration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ James Thompson
 Jannis Leidel
 Jeff Triplett
 John Bazik
+John Whitlock
 Jonas Aule
 Josh Owen
 Josh Wright

--- a/allauth/socialaccount/providers/fxa/provider.py
+++ b/allauth/socialaccount/providers/fxa/provider.py
@@ -1,6 +1,17 @@
+from django.conf import settings
+
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+_FXA_SETTINGS = getattr(
+    settings, 'SOCIALACCOUNT_PROVIDERS', {}).get('fxa', {})
+FXA_OAUTH_ENDPOINT = _FXA_SETTINGS.get(
+    'OAUTH_ENDPOINT',
+    'https://oauth.accounts.firefox.com/v1')
+FXA_PROFILE_ENDPOINT = _FXA_SETTINGS.get(
+    'PROFILE_ENDPOINT',
+    'https://profile.accounts.firefox.com/v1')
 
 
 class FirefoxAccountsAccount(ProviderAccount):

--- a/allauth/socialaccount/providers/fxa/views.py
+++ b/allauth/socialaccount/providers/fxa/views.py
@@ -3,14 +3,16 @@ import requests
 from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
                                                           OAuth2LoginView,
                                                           OAuth2CallbackView)
-from .provider import FirefoxAccountsProvider
+from .provider import (FirefoxAccountsProvider,
+                       FXA_OAUTH_ENDPOINT,
+                       FXA_PROFILE_ENDPOINT)
 
 
 class FirefoxAccountsOAuth2Adapter(OAuth2Adapter):
     provider_id = FirefoxAccountsProvider.id
-    access_token_url = 'https://oauth.accounts.firefox.com/v1/token'
-    authorize_url = 'https://oauth.accounts.firefox.com/v1/authorization'
-    profile_url = 'https://profile.accounts.firefox.com/v1/profile'
+    access_token_url = FXA_OAUTH_ENDPOINT + '/token'
+    authorize_url = FXA_OAUTH_ENDPOINT + '/authorization'
+    profile_url = FXA_PROFILE_ENDPOINT + '/profile'
 
     def complete_login(self, request, app, token, **kwargs):
         headers = {'Authorization': 'Bearer {0}'.format(token.token)}

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -235,6 +235,29 @@ The provider is OAuth2 based. More info:
 
 Note: This is not the same as the Mozilla Persona provider below.
 
+The following Firefox Accounts settings are available::
+
+    SOCIALACCOUNT_PROVIDERS = \
+        {'fxa':
+            'SCOPE': ['profile'],
+            'OAUTH_ENDPOINT': 'https://oauth.accounts.firefox.com/v1',
+            'PROFILE_ENDPOINT': 'https://profile.accounts.firefox.com/v1'}}
+
+
+SCOPE:
+    Requested OAuth2 scope. Default is ['profile'], which will work for
+    applications on the Mozilla trusted whitelist. If your application is not
+    on the whitelist, then define SCOPE to be ['profile:email', 'profile:uid'].
+
+OAUTH_ENDPOINT:
+    Explicitly set the OAuth2 endpoint. Default is the production endpoint
+    "https://oauth.accounts.firefox.com/v1".
+
+OAUTH_ENDPOINT:
+    Explicitly set the profile endpoint. Default is the production endpoint
+    and is "https://profile.accounts.firefox.com/v1".
+
+
 Flickr
 ------
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -479,6 +479,10 @@ Development callback URL
 Persona
 -------
 
+Note: Mozilla Persona will be shut down on November 30th 2016. See
+`the announcement <https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers>`_
+for details.
+
 Mozilla Persona requires one setting, the "AUDIENCE" which needs to be the
 hardcoded hostname and port of your website. See https://developer.mozilla.org/en-US/Persona/Security_Considerations#Explicitly_specify_the_audience_parameter for more
 information why this needs to be set explicitly and can't be derived from


### PR DESCRIPTION
Add ``SOCIALACCOUNT_PROVIDERS`` configuration items so that [non-production Firefox Accounts deployments](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/Firefox_Accounts/Introduction#Firefox_Accounts_deployments) can easily be used. This formalizes the extended ``fxa`` provider used on the Mozilla projects [browsercompat](https://github.com/mdn/browsercompat/tree/master/bcauth/socialaccount/providers/fxa) and [push-dev-dashboard](https://github.com/mozilla-services/push-dev-dashboard/tree/master/dashboard/socialaccount/providers/fxa). 