### PR TITLE
Update Python requirements to reflect Travis testing

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -4,7 +4,7 @@ Overview
 Requirements
 ------------
 
-- Python 2.6, 2.7 or 3.3
+- Python 2.7, 3.2, 3.3, 3.4, or 3.5
 
 - Django (1.4.3+)
 


### PR DESCRIPTION
Travis currently tests 2.7, 3.2, 3.3, 3.4, 3.5; the documentation should reflect this.