### PR TITLE
Adds prompt=consent for Google provider per (newer) docs for refresh token

### DIFF
--- a/allauth/socialaccount/providers/google/provider.py
+++ b/allauth/socialaccount/providers/google/provider.py
@@ -39,7 +39,8 @@ class GoogleProvider(OAuth2Provider):
         ret = super(GoogleProvider, self).get_auth_params(request,
                                                           action)
         if action == AuthAction.REAUTHENTICATE:
-            ret['approval_prompt'] = 'force'
+            ret['prompt'] = 'consent'
+            ret['access_type'] = 'offline'
         return ret
 
     def extract_uid(self, data):


### PR DESCRIPTION
This pull request provides new magical incantation to 1) force consent screen prompt and 2) request refresh token.

The current `approval_prompt=force` argument will prompt for consent screen/reauthentication. However, this was previously (through 2015?) also the recommended way to request refresh token. Google apparently no longer provides refresh token unless you also explicitly pass `access_type=offline`.

* Refresh token doc: https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens
* Consent screen prompt doc: https://developers.google.com/identity/protocols/OpenIDConnect#re-consent

I believe most people will still find old issues suggesting to pass `action=reauthenticate` when they want refresh token -- which will not work but for this new pull request / updated Google API call.

---

Put another way, right now there is no good way for `allauth` to capture `token_secret` from Google provider.

With this P/R you just need to pass `action=reauthenticate` `GET` parameter to the provider login view.