### PR TITLE
Keep inactive user response logic in adapter

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -4,17 +4,18 @@ import re
 import warnings
 import json
 
-from django.core.urlresolvers import reverse
-from django.conf import settings
-from django.http import HttpResponse
-from django.template.loader import render_to_string
-from django.template import TemplateDoesNotExist
-from django.core.mail import EmailMultiAlternatives, EmailMessage
-from django.utils.translation import ugettext_lazy as _
 from django import forms
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login as django_login
 from django.contrib.auth import logout as django_logout
+from django.core.mail import EmailMultiAlternatives, EmailMessage
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
+from django.http import HttpResponseRedirect
+from django.template.loader import render_to_string
+from django.template import TemplateDoesNotExist
+from django.utils.translation import ugettext_lazy as _
 
 try:
     from django.utils.encoding import force_text
@@ -370,6 +371,22 @@ class DefaultAccountAdapter(object):
         self.send_mail(email_template,
                        emailconfirmation.email_address.email,
                        ctx)
+
+    def get_user_inactive_redirect_url(self):
+        return reverse('account_inactive')
+
+    def get_user_inactive_response(self):
+        return HttpResponseRedirect(
+            self.get_user_inactive_redirect_url()
+        )
+
+    def get_email_verification_sent_redirect_url(self):
+        return reverse('account_email_verification_sent')
+
+    def get_email_verification_sent_response(self):
+        return HttpResponseRedirect(
+            self.get_email_verification_sent_redirect_url()
+        )
 
 
 def get_adapter():

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -6,7 +6,6 @@ except ImportError:
     now = datetime.now
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.db import models
 from django.conf import settings
 from django.http import HttpResponseRedirect
@@ -129,7 +128,7 @@ def perform_login(request, user, email_verification,
     # `user_signed_up` signal. Furthermore, social users should be
     # stopped anyway.
     if not user.is_active:
-        return HttpResponseRedirect(reverse('account_inactive'))
+        return get_adapter().get_user_inactive_response()
 
     from .models import EmailAddress
     has_verified_email = EmailAddress.objects.filter(user=user,
@@ -143,8 +142,7 @@ def perform_login(request, user, email_verification,
     elif email_verification == EmailVerificationMethod.MANDATORY:
         if not has_verified_email:
             send_email_confirmation(request, user, signup=signup)
-            return HttpResponseRedirect(
-                reverse('account_email_verification_sent'))
+            return get_adapter().get_email_verification_sent_response()
     try:
         get_adapter().login(request, user)
         response = HttpResponseRedirect(


### PR DESCRIPTION
I'm using allauth to power a traditional webui as well as an API. I've had to subclass the hell out of the adapters to get the exact behaviour I want, but this is what they're intended to allow. Allauth has been a fantastic help. Particularly on the API front however, I have consistently run into inflexibility in allauth due to the utils.py and helpers.py style of logic containment.

This PR is patching yet another single instance of this inflexibility, but I'd also like to underscore how problematic logic not being in the adapters has been for me when trying to subclass and sensibly customize allauth for usage in an API. That's all :)