### PR TITLE
ORCID: endpoint can be changed from the settings

### DIFF
--- a/allauth/socialaccount/providers/orcid/views.py
+++ b/allauth/socialaccount/providers/orcid/views.py
@@ -1,5 +1,6 @@
 import requests
 
+from allauth.socialaccount import app_settings
 from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
                                                           OAuth2LoginView,
                                                           OAuth2CallbackView)
@@ -10,13 +11,28 @@ class OrcidOAuth2Adapter(OAuth2Adapter):
     provider_id = OrcidProvider.id
     # http://support.orcid.org/knowledgebase/articles/335483-the-public-
     # client-orcid-api
-    authorize_url = 'https://orcid.org/oauth/authorize'
-    access_token_url = 'https://pub.orcid.org/oauth/token'
-    profile_url = 'https://pub.orcid.org/v1.1/%s/orcid-profile'
+    
+    member_api_default = False
+    base_domain_default = 'orcid.org'
+
+    settings = app_settings.PROVIDERS.get(provider_id, {})
+
+    base_domain = settings.get('BASE_DOMAIN', base_domain_default)
+    member_api = settings.get('MEMBER_API', member_api_default)
+
+    api_domain = '{0}.{1}'.format('api' if member_api else 'pub', base_domain)
+
+    authorize_url = 'https://{0}/oauth/authorize'.format(base_domain)
+    access_token_url = 'https://{0}/oauth/token'.format(api_domain)
+    profile_url = 'https://{0}/v1.1/%s/orcid-profile'.format(api_domain)
 
     def complete_login(self, request, app, token, **kwargs):
+        params = {}
+        if self.member_api:
+            params['access_token'] = token.token
+
         resp = requests.get(self.profile_url % kwargs['response']['orcid'],
-                            params={'access_token': token.token},
+                            params=params,
                             headers={'accept': 'application/orcid+json'})
         extra_data = resp.json()
         return self.get_provider().sociallogin_from_response(request,

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -436,17 +436,18 @@ following template tag::
 ORCID
 ------
 
-The ORCID provider should work out of the box provided that you are using the Production ORCID registry and the member api. If you are in development and are using the Sandbox registry, then you will need to change the urls to::
+The ORCID provider should work out of the box provided that you are using the Production ORCID registry and the public API. In other settings, you will need to define the API you are using
+in your site's settings, as follows::
 
-    authorize_url = 'https://sandbox.orcid.org/oauth/authorize'
-    access_token_url = 'https://api.sandbox.orcid.org/oauth/token'
-    profile_url = 'http://pub.sandbox.orcid.org/v1.2/%s/orcid-profile'
-
-If you find issues with the complete_login method (allauth/socialaccount/providers/orcid/views.py) when using the public api, try removing:
-
-    params={'access_token': token.token},
-
-since the access token is only required in the member api and its presence causes an error when using the public api.
+    SOCIALACCOUNT_PROVIDERS = \
+        {'orcid':
+           {
+             # Base domain of the API. Default value: 'orcid.org', for the production API
+            'BASE_DOMAIN':'sandbox.orcid.org', # for the sandbox API
+             # Member API or Public API? Default: False (for the public API)
+             'MEMBER_API': True, # for the member API
+           }
+        }
 
 
 Paypal


### PR DESCRIPTION
This closes #1083 by introducing two parameters in the settings. This also fixes the bug mentioned in the documentation. The documentation has been updated to reflect this.

The default behavior of the provider is kept the same.