### PR TITLE
fix account signals

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -127,6 +127,8 @@ class EmailConfirmation(models.Model):
         self.sent = timezone.now()
         self.save()
         signals.email_confirmation_sent.send(sender=self.__class__,
+                                             request=request,
+                                             signup=signup,
                                              confirmation=self)
 
 
@@ -169,4 +171,6 @@ class EmailConfirmationHMAC:
     def send(self, request=None, signup=False):
         get_adapter(request).send_confirmation_mail(request, self, signup)
         signals.email_confirmation_sent.send(sender=self.__class__,
+                                             request=request,
+                                             signup=signup,
                                              confirmation=self)

--- a/allauth/account/signals.py
+++ b/allauth/account/signals.py
@@ -9,8 +9,9 @@ password_set = Signal(providing_args=["request", "user"])
 password_changed = Signal(providing_args=["request", "user"])
 password_reset = Signal(providing_args=["request", "user"])
 
-email_confirmed = Signal(providing_args=["email_address"])
-email_confirmation_sent = Signal(providing_args=["confirmation"])
+email_confirmed = Signal(providing_args=["request", "email_address"])
+email_confirmation_sent = Signal(providing_args=["request", "signup",
+                                                 "confirmation"])
 
 email_changed = Signal(
     providing_args=[

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -190,9 +190,12 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
         # By assigning the User to a property on the view, we allow subclasses
         # of SignupView to access the newly created User instance
         self.user = form.save(self.request)
-        return complete_signup(self.request, self.user,
+        try:
+            return complete_signup(self.request, self.user,
                                app_settings.EMAIL_VERIFICATION,
                                self.get_success_url())
+        except ImmediateHttpResponse as e:
+            return e.response
 
     def get_context_data(self, **kwargs):
         ret = super(SignupView, self).get_context_data(**kwargs)


### PR DESCRIPTION
Here are some details.

1. account/signals.py:    revise email_confirmed and email_confirmation_sent
2. account/models.py:   add request and signup parameters to email_confirmation_sent
3. account/views.py:      add the ImmediateHttpResponse exception for form_valid function in SignupView

Hi @pennersr, see if there is something missing or misunderstanding. Thanks.
