### PR TITLE
Use ORCID API v1.2 instead of v1.1

### DIFF
--- a/allauth/socialaccount/providers/orcid/views.py
+++ b/allauth/socialaccount/providers/orcid/views.py
@@ -24,7 +24,7 @@ class OrcidOAuth2Adapter(OAuth2Adapter):
 
     authorize_url = 'https://{0}/oauth/authorize'.format(base_domain)
     access_token_url = 'https://{0}/oauth/token'.format(api_domain)
-    profile_url = 'https://{0}/v1.1/%s/orcid-profile'.format(api_domain)
+    profile_url = 'https://{0}/v1.2/%s/orcid-profile'.format(api_domain)
 
     def complete_login(self, request, app, token, **kwargs):
         params = {}


### PR DESCRIPTION
API v1.1 is deprecated on sandbox.orcid.org, v1.2 has been released more than a year ago, and the changes between the two do not affect the behavior of the provider, so we definitely want to switch.

For the record, the changelog is here: https://members.orcid.org/api/news/xsd-12-update