### PR TITLE
Make Facebook login more flexible

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,6 +86,7 @@ Sam Solomon
 Seizan Shimazaki
 Serafeim Papastefanos
 Stuart Ross
+Sutrisno Efendi
 Terry Jones
 Tomas Babej
 Tomas Marcik


### PR DESCRIPTION
This PR make facebook login more flexible. If `Require App Secret` in our Facebook app is set to `Yes`, we need to set `REQUIRE_APP_SECRET` to `True` like this:
```python
SOCIALACCOUNT_PROVIDERS = {
    'facebook': {
        'REQUIRE_APP_SECRET': True,
        'VERSION': 'v2.4'
    }
}
```