### PR TITLE
Adding default scope of user:email to requests with QUERY_EMAIL as true

### DIFF
--- a/allauth/socialaccount/providers/github/provider.py
+++ b/allauth/socialaccount/providers/github/provider.py
@@ -1,6 +1,7 @@
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from allauth.socialaccount.app_settings import QUERY_EMAIL
 
 
 class GitHubAccount(ProviderAccount):
@@ -27,6 +28,13 @@ class GitHubProvider(OAuth2Provider):
     id = 'github'
     name = 'GitHub'
     account_class = GitHubAccount
+
+    def get_default_scope(self):
+        scope = []
+        if QUERY_EMAIL:
+            scope.append('user:email')
+
+        return scope
 
     def extract_uid(self, data):
         return str(data['id'])


### PR DESCRIPTION
If the github user fetched does not have a public email and ACCOUNT_EMAIL_REQUIRED is true the view calls [get_email](https://github.com/pennersr/django-allauth/blob/2f433118ca344b837772601ac743768b2e974c66/allauth/socialaccount/providers/github/views.py#L26).  The method then tries to retrieve the email via the email endpoint which will 404 unless either user or user:email is added to the scope.  The code then throws a `KeyError` when attempting to [access the expected data](https://github.com/pennersr/django-allauth/blob/2f433118ca344b837772601ac743768b2e974c66/allauth/socialaccount/providers/github/views.py#L32).

This change simply adds the "user:email" scope to the OAUTH2 request to ensure the email is returned.