### PR TITLE
Add Eve Online provider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,5 +94,6 @@ Udi Oron
 Vuong Nguyen
 Volodymyr Yatsyk
 Wendy Edwards
+Will Ross
 Yuri Kriachko
 Yaroslav Muravsky

--- a/allauth/socialaccount/providers/eveonline/models.py
+++ b/allauth/socialaccount/providers/eveonline/models.py
@@ -1,0 +1,1 @@
+# Create your models here.

--- a/allauth/socialaccount/providers/eveonline/provider.py
+++ b/allauth/socialaccount/providers/eveonline/provider.py
@@ -38,4 +38,4 @@ class EveOnlineProvider(OAuth2Provider):
                     username=data.get('CharacterID'))
 
 
-providers.registry.register(GitHubProvider)
+providers.registry.register(EveOnlineProvider)

--- a/allauth/socialaccount/providers/eveonline/provider.py
+++ b/allauth/socialaccount/providers/eveonline/provider.py
@@ -41,8 +41,7 @@ class EveOnlineProvider(OAuth2Provider):
         return str(data['CharacterOwnerHash'])
 
     def extract_common_fields(self, data):
-        return dict(name=data.get('CharacterName'),
-                    username=data.get('CharacterID'))
+        return dict(name=data.get('CharacterName'))
 
 
 providers.registry.register(EveOnlineProvider)

--- a/allauth/socialaccount/providers/eveonline/provider.py
+++ b/allauth/socialaccount/providers/eveonline/provider.py
@@ -1,6 +1,7 @@
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from allauth.socialaccount.app_settings import STORE_TOKENS
 
 
 class EveOnlineAccount(ProviderAccount):
@@ -29,6 +30,12 @@ class EveOnlineProvider(OAuth2Provider):
     id = 'eveonline'
     name = 'EVE Online'
     account_class = EveOnlineAccount
+
+    def get_default_scope(self):
+        scopes = []
+        if STORE_TOKENS:
+            scopes.append('publicData')
+        return scopes
 
     def extract_uid(self, data):
         return str(data['CharacterOwnerHash'])

--- a/allauth/socialaccount/providers/eveonline/provider.py
+++ b/allauth/socialaccount/providers/eveonline/provider.py
@@ -10,7 +10,8 @@ class EveOnlineAccount(ProviderAccount):
                 char_name=self.account.extra_data.get('CharacterName'))
 
     def get_avatar_url(self):
-        return 'https://image.eveonline.com/Character/{char_id}_128.jpg'.format(
+        return ('https://image.eveonline.com/Character/'
+                '{char_id}_128.jpg').format(
                 char_id=self.account.extra_data.get('CharacterID', 1))
 
     def to_str(self):

--- a/allauth/socialaccount/providers/eveonline/provider.py
+++ b/allauth/socialaccount/providers/eveonline/provider.py
@@ -1,0 +1,41 @@
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class EveOnlineAccount(ProviderAccount):
+    def get_profile_url(self):
+        return 'https://gate.eveonline.com/Profile/{char_name}'.format(
+                char_name=self.account.extra_data.get('CharacterName'))
+
+    def get_avatar_url(self):
+        return 'https://image.eveonline.com/Character/{char_id}_128.jpg'.format(
+                char_id=self.account.extra_data.get('CharacterID', 1))
+
+    def to_str(self):
+        dflt = super(EveOnlineAccount, self).to_str()
+        return next(
+            value
+            for value in (
+                self.account.extra_data.get('CharacterName', None),
+                self.account.extra_data.get('CharacterID', None),
+                dflt
+            )
+            if value is not None
+        )
+
+
+class EveOnlineProvider(OAuth2Provider):
+    id = 'eveonline'
+    name = 'EVE Online'
+    account_class = EveOnlineAccount
+
+    def extract_uid(self, data):
+        return str(data['CharacterOwnerHash'])
+
+    def extract_common_fields(self, data):
+        return dict(name=data.get('CharacterName'),
+                    username=data.get('CharacterID'))
+
+
+providers.registry.register(GitHubProvider)

--- a/allauth/socialaccount/providers/eveonline/tests.py
+++ b/allauth/socialaccount/providers/eveonline/tests.py
@@ -1,0 +1,20 @@
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
+from allauth.socialaccount.models import SocialAccount
+
+from .provider import EveOnlineProvider
+
+
+class EveOnlineTests(OAuth2TestsMixin, TestCase):
+    provider_id = EveOnlineProvider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(200, """
+        {
+            "CharacterID": 273042051,
+            "CharacterName": "CCP illurkall",
+            "ExpiresOn": "2014-05-23T15:01:15.182864Z",
+            "Scopes": " ",
+            "TokenType": "Character",
+            "CharacterOwnerHash": "XM4D...FoY="
+        }""")

--- a/allauth/socialaccount/providers/eveonline/tests.py
+++ b/allauth/socialaccount/providers/eveonline/tests.py
@@ -1,6 +1,5 @@
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
-from allauth.socialaccount.models import SocialAccount
 
 from .provider import EveOnlineProvider
 

--- a/allauth/socialaccount/providers/eveonline/urls.py
+++ b/allauth/socialaccount/providers/eveonline/urls.py
@@ -1,0 +1,4 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+from .provider import EveOnlineProvider
+
+urlpatterns = default_urlpatterns(EveOnlineProvider)

--- a/allauth/socialaccount/providers/eveonline/views.py
+++ b/allauth/socialaccount/providers/eveonline/views.py
@@ -4,7 +4,6 @@ from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
                                                           OAuth2LoginView,
                                                           OAuth2CallbackView)
 from .provider import EveOnlineProvider
-from allauth.socialaccount import app_settings
 
 
 class EveOnlineOAuth2Adapter(OAuth2Adapter):

--- a/allauth/socialaccount/providers/eveonline/views.py
+++ b/allauth/socialaccount/providers/eveonline/views.py
@@ -1,0 +1,25 @@
+import requests
+
+from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
+                                                          OAuth2LoginView,
+                                                          OAuth2CallbackView)
+from .provider import EveOnlineProvider
+from allauth.socialaccount import app_settings
+
+
+class EveOnlineOAuth2Adapter(OAuth2Adapter):
+    provider_id = EveOnlineProvider.id
+    access_token_url = 'https://login.eveonline.com/oauth/token'
+    authorize_url = 'https://login.eveonline.com/oauth/authorize'
+    profile_url = 'https://login.eveonline.com/oauth/verify'
+
+    def complete_login(self, request, app, token, **kwargs):
+        resp = requests.get(self.profile_url,
+                            headers={'Authorization': 'Bearer ' + token.token})
+        extra_data = resp.json()
+        return self.get_provider().sociallogin_from_response(request,
+                                                             extra_data)
+
+
+oauth2_login = OAuth2LoginView.adapter_view(EveOnlineOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(EveOnlineOAuth2Adapter)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,6 +70,7 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
         'allauth.socialaccount.providers.dropbox',
         'allauth.socialaccount.providers.dropbox_oauth2',
         'allauth.socialaccount.providers.edmodo',
+        'allauth.socialaccount.providers.eveonline',
         'allauth.socialaccount.providers.evernote',
         'allauth.socialaccount.providers.facebook',
         'allauth.socialaccount.providers.feedly',

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -53,6 +53,8 @@ Supported Providers
 
 - Edmodo (OAuth2)
 
+- Eve Online (OAuth2)
+
 - Evernote (OAuth)
 
 - Facebook (both OAuth2 and JS SDK)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -100,6 +100,16 @@ is set, the Edmodo provider will use `basic` by default.::
     }
 
 
+Eve Online
+----------
+
+Register your application at `https://developers.eveonline.com/applications/create`.
+Note that if you have `STORE_TOKENS` enabled (the default), you will need to
+set up you application to be able to request an OAuth scope. This means you
+will need to set it as having "CREST Access". The least obtrusive scope is
+"publicData".
+
+
 Evernote
 ----------
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -80,6 +80,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.dropbox',
     'allauth.socialaccount.providers.dropbox_oauth2',
     'allauth.socialaccount.providers.edmodo',
+    'allauth.socialaccount.providers.eveonline',
     'allauth.socialaccount.providers.evernote',
     'allauth.socialaccount.providers.feedly',
     'allauth.socialaccount.providers.facebook',


### PR DESCRIPTION
Not even sure if this is the sort of provider you'd want included, but I added an [Eve Online](http://www.eveonline.com) provider using their [SSO API](https://eveonline-third-party-documentation.readthedocs.org/en/latest/sso/index.html). This API is a little different from most of the other providers in that a single person can authenticate with multiple identities (any of their characters in-game)[0]. The biggest difference that most users of django-allauth might encounter is that there is not a way to get an email address for a user.

The biggest area I'm looking for review is how I'm mapping a character's information to a user in `providers.py`. Is there other information I should be extracting? The only information I can easily get is a character's name, an ID number for that character (which will not change if a character is transferred to another account) and a "[CharacterOwnerHash](https://eveonline-third-party-documentation.readthedocs.org/en/latest/sso/obtaincharacterid.html)" (which *will* change if the character is transferred to a new account). Right now I'm mapping the UID to this hash, and a user's name (the `name` attribute, not `username`) to the character's name. Should I map the `username` to the character's ID?

0: The most recent release expanded the OAuth API so that it's technically possible to log in as an account, but there isn't an identifier associated with this, only a set of the characters on an account. Players commonly have multiple game accounts with multiple characters, and can add or remove characters on those accounts at will.