### PR TITLE
Fix Oauth2 breakage with django-rest-auth

### DIFF
--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -29,7 +29,7 @@ class OAuth2Adapter(object):
     basic_auth = False
     headers = None
 
-    def __init__(self, request):
+    def __init__(self, request=None):
         self.request = request
 
     def get_provider(self):

--- a/allauth/socialaccount/providers/shopify/views.py
+++ b/allauth/socialaccount/providers/shopify/views.py
@@ -44,6 +44,7 @@ class ShopifyOAuth2Adapter(OAuth2Adapter):
         return self._shop_url('/admin/shop.json')
 
     def complete_login(self, request, app, token, **kwargs):
+        self.request = request
         headers = {
             'X-Shopify-Access-Token': '{token}'.format(token=token.token)}
         response = requests.get(

--- a/allauth/socialaccount/providers/weixin/views.py
+++ b/allauth/socialaccount/providers/weixin/views.py
@@ -50,7 +50,7 @@ class WeixinOAuth2ClientMixin(object):
         provider = self.adapter.get_provider()
         scope = provider.get_scope(request)
         client = WeixinOAuth2Client(
-            self.request, app.client_id, app.secret,
+            request, app.client_id, app.secret,
             self.adapter.access_token_method,
             self.adapter.access_token_url,
             callback_url,


### PR DESCRIPTION
- django-rest-auth's SocialLoginSerializer instantiates login adapters
  without passing parameters
- OAuth2Adapter's `__init__` takes a request, but OAuth2Adapter doesn't
  actually use self.request anywhere
- Make request optional to match what is done in other adapters
- shopify and weixin were the only subclasses which used `self.request`,
  but in both cases there was a request instance availble elsewhere