### PR TITLE
Force reauthentication by Google, not merely presentation of offline-access consent screen

### DIFF
--- a/allauth/socialaccount/providers/google/provider.py
+++ b/allauth/socialaccount/providers/google/provider.py
@@ -38,8 +38,7 @@ class GoogleProvider(OAuth2Provider):
         ret = super(GoogleProvider, self).get_auth_params(request,
                                                           action)
         if action == AuthAction.REAUTHENTICATE:
-            ret['prompt'] = 'consent'
-            ret['access_type'] = 'offline'
+            ret['prompt'] = 'select_account'
         return ret
 
     def extract_uid(self, data):


### PR DESCRIPTION
Setting prompt=consent during google authentication does not cause a reauthentication prompt to appear; instead, it presents an "allow offline access" consent form.  Furthermore, setting access_type=offline interferes with the provider configuration value google.AUTH_PARAMS.access_type

Setting prompt=select_account, however, will display a screen in which the user can actually select the user identity with which to log in (even if the user is not using multiple Google accounts, they are still presented with a selection).

While not as good as clearing the google auth cookie entirely, this at least is closer to the spirit of reauthentication, and more intuitive to the user.