### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Mailinglist
   http://groups.google.com/group/django-allauth
 
 Documentation
-  http://django-allauth.readthedocs.org/en/latest/
+  https://django-allauth.readthedocs.io/en/latest/
 
 Stack Overflow
   http://stackoverflow.com/questions/tagged/django-allauth


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.