### PR TITLE
Allow more dynamic email cleaning

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -299,7 +299,7 @@ class DefaultAccountAdapter(object):
         return password
 
     def validate_unique_email(self, email):
-        if email and email_address_exists(email):
+        if email_address_exists(email):
             raise forms.ValidationError(self.error_messages['email_taken'])
         return email
 

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -31,7 +31,7 @@ from ..compat import validate_password
 from ..utils import (build_absolute_uri, get_current_site,
                      generate_unique_username,
                      get_user_model, import_attribute,
-                     resolve_url)
+                     resolve_url, email_address_exists)
 
 from . import app_settings
 
@@ -50,7 +50,9 @@ class DefaultAccountAdapter(object):
         'username_taken':
         AbstractUser._meta.get_field('username').error_messages['unique'],
         'too_many_login_attempts':
-        _('Too many failed login attempts. Try again later.')
+        _('Too many failed login attempts. Try again later.'),
+        'email_taken':
+        AbstractUser._meta.get_field('email').error_messages['unique'],
     }
 
     def __init__(self, request=None):
@@ -282,6 +284,9 @@ class DefaultAccountAdapter(object):
         Validates an email value. You can hook into this if you want to
         (dynamically) restrict what email addresses can be chosen.
         """
+        if app_settings.UNIQUE_EMAIL:
+            if email and email_address_exists(email):
+                raise forms.ValidationError(self.error_messages['email_taken'])
         return email
 
     def clean_password(self, password, user=None):

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -284,9 +284,6 @@ class DefaultAccountAdapter(object):
         Validates an email value. You can hook into this if you want to
         (dynamically) restrict what email addresses can be chosen.
         """
-        if app_settings.UNIQUE_EMAIL:
-            if email and email_address_exists(email):
-                raise forms.ValidationError(self.error_messages['email_taken'])
         return email
 
     def clean_password(self, password, user=None):
@@ -300,6 +297,11 @@ class DefaultAccountAdapter(object):
                                           "characters.").format(min_length))
         validate_password(password, user)
         return password
+
+    def validate_unique_email(self, email):
+        if email and email_address_exists(email):
+            raise forms.ValidationError(self.error_messages['email_taken'])
+        return email
 
     def add_message(self, request, level, message_template,
                     message_context=None, extra_tags=''):

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -270,7 +270,7 @@ class BaseSignupForm(_base_signup_form_class()):
     def clean_email(self):
         value = self.cleaned_data["email"]
         value = get_adapter().clean_email(value)
-        if app_settings.UNIQUE_EMAIL:
+        if value and app_settings.UNIQUE_EMAIL:
             get_adapter().validate_unique_email(value)
         return value
 

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -270,6 +270,8 @@ class BaseSignupForm(_base_signup_form_class()):
     def clean_email(self):
         value = self.cleaned_data["email"]
         value = get_adapter().clean_email(value)
+        if app_settings.UNIQUE_EMAIL:
+            get_adapter().validate_unique_email(value)
         return value
 
     def custom_signup(self, request, user):
@@ -355,6 +357,7 @@ class AddEmailForm(UserForm):
 
     def clean_email(self):
         value = self.cleaned_data["email"]
+        value = get_adapter().clean_email(value)
         errors = {
             "this_account": _("This e-mail address is already associated"
                               " with this account."),
@@ -443,6 +446,7 @@ class ResetPasswordForm(forms.Form):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
+        email = get_adapter().clean_email(email)
         self.users = filter_users_by_email(email)
         if not self.users:
             raise forms.ValidationError(_("The e-mail address is not assigned"

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -271,7 +271,7 @@ class BaseSignupForm(_base_signup_form_class()):
         value = self.cleaned_data["email"]
         value = get_adapter().clean_email(value)
         if value and app_settings.UNIQUE_EMAIL:
-            get_adapter().validate_unique_email(value)
+            value = get_adapter().validate_unique_email(value)
         return value
 
     def custom_signup(self, request, user):

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -9,8 +9,7 @@ from django.utils.translation import pgettext, ugettext_lazy as _, ugettext
 from django.core import validators
 from django.contrib.auth.tokens import default_token_generator
 
-from ..utils import (email_address_exists,
-                     set_form_field_order,
+from ..utils import (set_form_field_order,
                      build_absolute_uri,
                      get_username_max_length,
                      get_current_site)
@@ -271,14 +270,7 @@ class BaseSignupForm(_base_signup_form_class()):
     def clean_email(self):
         value = self.cleaned_data["email"]
         value = get_adapter().clean_email(value)
-        if app_settings.UNIQUE_EMAIL:
-            if value and email_address_exists(value):
-                self.raise_duplicate_email_error()
         return value
-
-    def raise_duplicate_email_error(self):
-        raise forms.ValidationError(_("A user is already registered"
-                                      " with this e-mail address."))
 
     def custom_signup(self, request, user):
         custom_form = super(BaseSignupForm, self)
@@ -363,7 +355,6 @@ class AddEmailForm(UserForm):
 
     def clean_email(self):
         value = self.cleaned_data["email"]
-        value = get_adapter().clean_email(value)
         errors = {
             "this_account": _("This e-mail address is already associated"
                               " with this account."),
@@ -452,7 +443,6 @@ class ResetPasswordForm(forms.Form):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
-        email = get_adapter().clean_email(email)
         self.users = filter_users_by_email(email)
         if not self.users:
             raise forms.ValidationError(_("The e-mail address is not assigned"


### PR DESCRIPTION
I've been forking django-allauth for a couple years mainly for these changes, and I think this makes the clean_email function a lot more dynamic and fits its purpose better.

Moving the app_settings.UNIQUE_EMAIL check to the adapter seems to make more sense, while removing the hook from the password reset and add email forms, because the password reset form shouldn't share a validating hook with the signup form, and the add email form already does all the necessary checks it needs to do before allowing it.

My use case for this is I allow "newsletter only" user accounts, which is essentially a User without a username and password set, and have it subscribe to a mailing list. When that same person decides to create a normal user account (normal signup), it need to check if the email exists, and if it does, it checks if it's a "newsletter only" user account to see if it needs to raise an "email taken" validation error or convert a newsletter only account into a normal one. Moving the UNIQUE_EMAIL validation check to a more customizable function allows this beautifully.