### PR TITLE
Adds a setting to control internal messaes

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -309,6 +309,9 @@ class DefaultAccountAdapter(object):
         Wrapper of `django.contrib.messages.add_message`, that reads
         the message text from a template.
         """
+        if not app_settings.ALLOW_INTERNAL_MESSAGES:
+            return
+
         if 'django.contrib.messages' in settings.INSTALLED_APPS:
             try:
                 if message_context is None:

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -275,6 +275,14 @@ class AppSettings(object):
     def SALT(self):
         return self._setting('SALT', 'account')
 
+    @property
+    def ALLOW_INTERNAL_MESSAGES(self):
+        """
+        Enable/disable sending messages to users via
+        django.contrib.messages
+        """
+        return self._setting('ALLOW_INTERNAL_MESSAGES',True)
+
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html
 import sys  # noqa

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -281,7 +281,7 @@ class AppSettings(object):
         Enable/disable sending messages to users via
         django.contrib.messages
         """
-        return self._setting('ALLOW_INTERNAL_MESSAGES',True)
+        return self._setting('ALLOW_INTERNAL_MESSAGES', True)
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -165,6 +165,9 @@ ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS( (=True)
 ACCOUNT_TEMPLATE_EXTENSION (="html")
   A string defining the template extension to use, defaults to `html`.
 
+ACCOUNT_ALLOW_INTERNAL_MESSAGES (=True)
+  Enable/disable automatically sending messages using the `django.contrib.messages`.
+
 SOCIALACCOUNT_ADAPTER (="allauth.socialaccount.adapter.DefaultSocialAccountAdapter")
   Specifies the adapter class to use, allowing you to alter certain
   default behaviour.


### PR DESCRIPTION
This setting allows users of this app to have control over the sending of messages through django.contrib.messages.