### PR TITLE
Add get_extra_context_data in ResetPasswordForm

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -469,6 +469,9 @@ class ResetPasswordForm(forms.Form):
             })
         )
 
+    def get_extra_context_data(self):
+        return {}
+
     def clean_email(self):
         email = self.cleaned_data["email"]
         email = get_adapter().clean_email(email)
@@ -509,6 +512,7 @@ class ResetPasswordForm(forms.Form):
                        "user": user,
                        "password_reset_url": url,
                        "request": request}
+            context.update(self.get_extra_context_data())
 
             if app_settings.AUTHENTICATION_METHOD \
                     != AuthenticationMethod.EMAIL:


### PR DESCRIPTION
This method is needed to avoid to override the whole save method
when you want extra context data into the email template.