### PR TITLE
add extra initial fields to socialaccont SignupForm

### DIFF
--- a/allauth/socialaccount/app_settings.py
+++ b/allauth/socialaccount/app_settings.py
@@ -71,6 +71,11 @@ class AppSettings(object):
     def UID_MAX_LENGTH(self):
         return 191
 
+    @property
+    def EXTERA_INITIAL_FEILDS(self):
+        return self._setting("EXTERA_INITIAL_FEILDS",
+            ['first_name', 'last_name'])
+
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/socialaccount/app_settings.py
+++ b/allauth/socialaccount/app_settings.py
@@ -74,7 +74,7 @@ class AppSettings(object):
     @property
     def EXTERA_INITIAL_FEILDS(self):
         return self._setting("EXTERA_INITIAL_FEILDS",
-            ['first_name', 'last_name'])
+                             ['first_name', 'last_name'])
 
 
 # Ugly? Guido recommends this himself ...

--- a/allauth/socialaccount/forms.py
+++ b/allauth/socialaccount/forms.py
@@ -18,12 +18,14 @@ class SignupForm(BaseSignupForm):
     def __init__(self, *args, **kwargs):
         self.sociallogin = kwargs.pop('sociallogin')
         user = self.sociallogin.user
-        # TODO: Should become more generic, not listing
-        # a few fixed properties.
+
         initial = {'email': user_email(user) or '',
-                   'username': user_username(user) or '',
-                   'first_name': user_field(user, 'first_name') or '',
-                   'last_name': user_field(user, 'last_name') or ''}
+                   'username': user_username(user) or ''}
+
+        if app_settings.EXTERA_INITIAL_FEILDS:
+            for field in app_settings.EXTERA_INITIAL_FEILDS:
+                initial.update({field: user_field(user, field) or ''})
+
         kwargs.update({
             'initial': initial,
             'email_required': kwargs.get('email_required',


### PR DESCRIPTION
The initial fields for socialaccont SignupForm are specific and not customizable, I add new settings variable [list] that make me able to add custom initial fields

Example:   
`SOCIALACCOUNT_EXTERA_INITIAL_FEILDS = ['full_name', 'birthdate', 'gender']`

also set to `SOCIALACCOUNT_EXTERA_INITIAL_FEILDS`  default value ('first_name', 'last_name') to  avoid any issues may appear in old settings 