### PR TITLE
possibility to ignore username validation and to take hash instead

### DIFF
--- a/allauth/app_settings.py
+++ b/allauth/app_settings.py
@@ -5,3 +5,5 @@ SOCIALACCOUNT_ENABLED = 'allauth.socialaccount' in settings.INSTALLED_APPS
 LOGIN_REDIRECT_URL = getattr(settings, 'LOGIN_REDIRECT_URL', '/')
 
 USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
+USERNAME_AS_HASH = getattr(settings, 'USERNAME_AS_HASH', False)

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -61,6 +61,11 @@ def get_username_max_length():
 
 
 def generate_unique_username(txts, regex=None):
+    from . import app_settings
+    if app_settings.USERNAME_AS_HASH:
+        import os
+        return os.urandom(28).encode('hex')
+
     from .account.adapter import get_adapter
     adapter = get_adapter()
     username = _generate_unique_username_base(txts, regex)


### PR DESCRIPTION
added possibility to ignore username validation and to use random hash instead

in one of our projects, the username validation was the bottleneck in high traffic, I patched the generate_unique_username() to return os.urandom(28).encode('hex') back in time. In this pr, it is now possible to deactivate username validation via USERNAME_AS_HASH=True. 