### PR TITLE
Added email to Twitter provider. Closes #1342

### DIFF
--- a/allauth/socialaccount/providers/twitter/provider.py
+++ b/allauth/socialaccount/providers/twitter/provider.py
@@ -46,7 +46,8 @@ class TwitterProvider(OAuthProvider):
 
     def extract_common_fields(self, data):
         return dict(username=data.get('screen_name'),
-                    name=data.get('name'))
+                    name=data.get('name'),
+                    email=data.get('email'),)
 
 
 providers.registry.register(TwitterProvider)

--- a/allauth/socialaccount/providers/twitter/views.py
+++ b/allauth/socialaccount/providers/twitter/views.py
@@ -1,5 +1,6 @@
 import json
 
+from allauth.socialaccount.app_settings import QUERY_EMAIL
 from allauth.socialaccount.providers.oauth.client import OAuth
 from allauth.socialaccount.providers.oauth.views import (OAuthAdapter,
                                                          OAuthLoginView,
@@ -12,7 +13,8 @@ class TwitterAPI(OAuth):
     """
     Verifying twitter credentials
     """
-    url = 'https://api.twitter.com/1.1/account/verify_credentials.json'
+    _base_url = 'https://api.twitter.com/1.1/account/verify_credentials.json'
+    url = _base_url + '?include_email=true' if QUERY_EMAIL else _base_url
 
     def get_user_info(self):
         user = json.loads(self.query(self.url))


### PR DESCRIPTION
If QUERY_EMAIL is set, append `?include_email=true` to twitter user profile url
To make this work, you need to have email access in your twitter app. See https://dev.twitter.com/rest/reference/get/account/verify_credentials.

NOTE: If user doesn't have an email address in Twitter, email field in response will be a blank string `""` (not None!). I'm not sure how this is typically handled in allauth, seems it will just ask the user to input an email after social auth. Let me know if this needs to be better handled.

Do you need me to add tests for this?