### PR TITLE
Check status code of Github emails response

### DIFF
--- a/allauth/socialaccount/providers/github/views.py
+++ b/allauth/socialaccount/providers/github/views.py
@@ -28,7 +28,7 @@ class GitHubOAuth2Adapter(OAuth2Adapter):
         resp = requests.get(self.emails_url,
                             params={'access_token': token.token})
         emails = resp.json()
-        if emails:
+        if resp.status_code == 200 and emails:
             email = emails[0]
             primary_emails = [
                 e for e in emails


### PR DESCRIPTION
If the Github email request fails the `emails` variable will be a dictionary containing error info. This dictionary has content and is thus considered as `True`, but it does not actually contain an email at index 0. 

This happens for instance with a 404, when no emails can be read. This fixes https://github.com/pennersr/django-allauth/issues/1234 when the scope is not set up to read private emails.