### PR TITLE
battlenet: Add error checking in Battle.net output

### DIFF
--- a/allauth/socialaccount/providers/battlenet/tests.py
+++ b/allauth/socialaccount/providers/battlenet/tests.py
@@ -1,6 +1,8 @@
+from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
 from .provider import BattleNetProvider
+from .views import _check_errors
 
 
 class BattleNetTests(OAuth2TestsMixin, TestCase):
@@ -12,3 +14,13 @@ class BattleNetTests(OAuth2TestsMixin, TestCase):
             "battletag": "LuckyDragon#1953",
             "id": "123456789"
         }""")
+
+    def test_invalid_data(self):
+        with self.assertRaises(OAuth2Error):
+            # No id, raises
+            _check_errors({})
+
+        with self.assertRaises(OAuth2Error):
+            _check_errors({"error": "invalid_token"})
+
+        _check_errors({"id": 12345})  # Does not raise


### PR DESCRIPTION
This makes the provider more robust by ensuring `id` is present in the returned dictionary. It also properly handles API errors.