### PR TITLE
battlenet: Make the Battle.net region available in `extra_data`

### DIFF
--- a/allauth/socialaccount/providers/battlenet/tests.py
+++ b/allauth/socialaccount/providers/battlenet/tests.py
@@ -1,3 +1,5 @@
+import json
+from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
@@ -7,13 +9,12 @@ from .views import _check_errors
 
 class BattleNetTests(OAuth2TestsMixin, TestCase):
     provider_id = BattleNetProvider.id
+    _uid = 123456789
+    _battletag = "LuckyDragon#1953"
 
     def get_mocked_response(self):
-        return MockedResponse(200, """
-        {
-            "battletag": "LuckyDragon#1953",
-            "id": "123456789"
-        }""")
+        data = {"battletag": self._battletag, "id": self._uid}
+        return MockedResponse(200, json.dumps(data))
 
     def test_invalid_data(self):
         with self.assertRaises(OAuth2Error):
@@ -24,3 +25,10 @@ class BattleNetTests(OAuth2TestsMixin, TestCase):
             _check_errors({"error": "invalid_token"})
 
         _check_errors({"id": 12345})  # Does not raise
+
+    def test_extra_data(self):
+        self.login(self.get_mocked_response())
+        account = SocialAccount.objects.get(uid=str(self._uid))
+        self.assertEqual(account.extra_data["battletag"], self._battletag)
+        self.assertEqual(account.extra_data["id"], self._uid)
+        self.assertEqual(account.extra_data["region"], "us")

--- a/allauth/socialaccount/providers/battlenet/views.py
+++ b/allauth/socialaccount/providers/battlenet/views.py
@@ -50,7 +50,6 @@ class BattleNetOAuth2Adapter(OAuth2Adapter):
     Can be any of eu, us, kr, sea, tw or cn
     """
     provider_id = BattleNetProvider.id
-    supports_state = True
     battlenet_region = "us"
 
     @property

--- a/allauth/socialaccount/providers/battlenet/views.py
+++ b/allauth/socialaccount/providers/battlenet/views.py
@@ -83,6 +83,10 @@ class BattleNetOAuth2Adapter(OAuth2Adapter):
         response = requests.get(self.profile_url, params=params)
         data = response.json()
         _check_errors(data)
+
+        # Add the region to the data so that we can have it in `extra_data`.
+        data["region"] = self.battlenet_region
+
         return self.get_provider().sociallogin_from_response(request, data)
 
 oauth2_login = OAuth2LoginView.adapter_view(BattleNetOAuth2Adapter)

--- a/allauth/socialaccount/providers/slack/views.py
+++ b/allauth/socialaccount/providers/slack/views.py
@@ -15,8 +15,6 @@ class SlackOAuth2Adapter(OAuth2Adapter):
     authorize_url = 'https://slack.com/oauth/authorize'
     identity_url = 'https://slack.com/api/users.identity'
 
-    supports_state = True
-
     def complete_login(self, request, app, token, **kwargs):
         extra_data = self.get_data(token.token)
         return self.get_provider().sociallogin_from_response(request,


### PR DESCRIPTION
Because the China region uses a different user database, it is critical
to store the API region that was used for the user's creation.

--

This is a commit made in preparation for concurrent multi-region support in the Battle.net API.

Here is the problem: There are two installations of the Battle.net API: one on battle.net and another on battlenet.com.cn. As you can see from the adapter, the URLs are different depending on the API used.

However, I *could not confirm* whether the UIDs we are currently extracting (the `id` field from the data returned) are unique worldwide or per-installation. Same for the Battletag (username). I strongly suspect they are not, which means the UID extraction cannot currently non-china + china at the same time.

*However*, we cannot simply append the region to the UID or some such, because `us12345` is the *same instance* as `eu12345`. It's *only china* that is (likely) problematic.

In any case, the provider's region needs to be made available to the model. So this commit solves that and I'll try some stuff locally to figure out if they are indeed different.