### PR TITLE
Made COOLDOWN_PERIOD a public setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ virtualenv
 *.prefs
 *.mo
 /.stfolder
+
+# venv installation
+venv

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -40,6 +40,15 @@ class AppSettings(object):
         return getter(self.prefix + name, dflt)
 
     @property
+    def ACCOUNT_EMAIL_COOLDOWN_PERIOD(self):
+        """
+        A timedelta object representing how long to wait between sending
+        verification emails to an email address.
+        """
+        from datetime import timedelta
+        return self._setting("ACCOUNT_EMAIL_COOLDOWN_PERIOD", timedelta(minutes=3))
+
+    @property
     def DEFAULT_HTTP_PROTOCOL(self):
         return self._setting("DEFAULT_HTTP_PROTOCOL", "http").lower()
 

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -46,7 +46,8 @@ class AppSettings(object):
         verification emails to an email address.
         """
         from datetime import timedelta
-        return self._setting("ACCOUNT_EMAIL_COOLDOWN_PERIOD", timedelta(minutes=3))
+        return self._setting("ACCOUNT_EMAIL_COOLDOWN_PERIOD",
+                             timedelta(minutes=3))
 
     @property
     def DEFAULT_HTTP_PROTOCOL(self):

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -16,6 +16,8 @@ from django.core.exceptions import ValidationError
 
 from allauth.compat import OrderedDict
 
+from . import app_settings
+
 try:
     from django.contrib.auth import update_session_auth_hash
 except ImportError:
@@ -293,7 +295,7 @@ def send_email_confirmation(request, user, signup=False):
     """
     from .models import EmailAddress, EmailConfirmation
 
-    COOLDOWN_PERIOD = timedelta(minutes=3)
+    COOLDOWN_PERIOD = app_settings.ACCOUNT_EMAIL_COOLDOWN_PERIOD
     email = user_email(user)
     if email:
         try:

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 try:
     from django.utils.timezone import now
 except ImportError:
@@ -15,8 +14,6 @@ from django.utils.http import int_to_base36, base36_to_int
 from django.core.exceptions import ValidationError
 
 from allauth.compat import OrderedDict
-
-from . import app_settings
 
 try:
     from django.contrib.auth import update_session_auth_hash

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,6 +46,10 @@ ACCOUNT_EMAIL_CONFIRMATION_HMAC (=True)
   track of these keys. Current versions use HMAC based keys that do not
   require server side state.
 
+ACCOUNT_EMAIL_COOLDOWN_PERIOD (=timedelta(minutes=3))
+  Determines the amount of time to wait between sending out verification e-mail
+  to user that login in with an unverified e-mail.
+
 ACCOUNT_EMAIL_REQUIRED (=False)
   The user is required to hand over an e-mail address when signing up.
 


### PR DESCRIPTION
As suggested in: #1008 I have made COOLDOWN_PERIOD public through ACCOUNT_EMAIL_COOLDOWN_PERIOD and added documentation for the new setting.