### PR TITLE
Django 1.10 deprecation warning cleanups

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
-from ..compat import reverse, validate_password
+from ..compat import is_authenticated, reverse, validate_password
 from ..utils import (build_absolute_uri, get_current_site,
                      generate_unique_username,
                      get_user_model, import_attribute,
@@ -145,7 +145,7 @@ class DefaultAccountAdapter(object):
         that URLs passed explicitly (e.g. by passing along a `next`
         GET parameter) take precedence over the value returned here.
         """
-        assert request.user.is_authenticated()
+        assert is_authenticated(request.user)
         url = getattr(settings, "LOGIN_REDIRECT_URLNAME", None)
         if url:
             warnings.warn("LOGIN_REDIRECT_URLNAME is deprecated, simply"
@@ -168,7 +168,7 @@ class DefaultAccountAdapter(object):
         """
         The URL to return to after successful e-mail confirmation.
         """
-        if request.user.is_authenticated():
+        if is_authenticated(request.user):
             if app_settings.EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL:
                 return  \
                     app_settings.EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -14,7 +14,6 @@ from django.contrib.auth import logout as django_logout, authenticate
 from django.contrib.auth.models import AbstractUser
 from django.core.cache import cache
 from django.core.mail import EmailMultiAlternatives, EmailMessage
-from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.template.loader import render_to_string
@@ -27,7 +26,7 @@ try:
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
 
-from ..compat import validate_password
+from ..compat import reverse, validate_password
 from ..utils import (build_absolute_uri, get_current_site,
                      generate_unique_username,
                      get_user_model, import_attribute,

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import
 import warnings
 
 from django import forms
-from django.core.urlresolvers import reverse
 from django.core import exceptions
 from django.utils.translation import pgettext, ugettext_lazy as _, ugettext
 from django.core import validators
 from django.contrib.auth.tokens import default_token_generator
 
+from ..compat import reverse
 from ..utils import (set_form_field_order,
                      build_absolute_uri,
                      get_username_max_length,

--- a/allauth/account/migrations/0001_initial.py
+++ b/allauth/account/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('email', models.EmailField(unique=UNIQUE_EMAIL, max_length=75, verbose_name='e-mail address')),
                 ('verified', models.BooleanField(default=False, verbose_name='verified')),
                 ('primary', models.BooleanField(default=False, verbose_name='primary')),
-                ('user', models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(verbose_name='user', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'email address',
@@ -37,7 +37,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(default=django.utils.timezone.now, verbose_name='created')),
                 ('sent', models.DateTimeField(null=True, verbose_name='sent')),
                 ('key', models.CharField(unique=True, max_length=64, verbose_name='key')),
-                ('email_address', models.ForeignKey(verbose_name='e-mail address', to='account.EmailAddress')),
+                ('email_address', models.ForeignKey(verbose_name='e-mail address', to='account.EmailAddress', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'email confirmation',

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -23,7 +23,8 @@ from .adapter import get_adapter
 class EmailAddress(models.Model):
 
     user = models.ForeignKey(allauth_app_settings.USER_MODEL,
-                             verbose_name=_('user'))
+                             verbose_name=_('user'),
+                             on_delete=models.CASCADE)
     email = models.EmailField(unique=app_settings.UNIQUE_EMAIL,
                               max_length=app_settings.EMAIL_MAX_LENGTH,
                               verbose_name=_('e-mail address'))
@@ -85,7 +86,8 @@ class EmailAddress(models.Model):
 class EmailConfirmation(models.Model):
 
     email_address = models.ForeignKey(EmailAddress,
-                                      verbose_name=_('e-mail address'))
+                                      verbose_name=_('e-mail address'),
+                                      on_delete=models.CASCADE)
     created = models.DateTimeField(verbose_name=_('created'),
                                    default=timezone.now)
     sent = models.DateTimeField(verbose_name=_('sent'), null=True)

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -27,7 +27,7 @@ from allauth.utils import (
     get_user_model,
     get_username_max_length)
 
-from ..compat import reverse
+from ..compat import is_authenticated, reverse
 
 from . import app_settings
 
@@ -321,7 +321,7 @@ class AccountTests(TestCase):
             url,
             {'password1': 'newpass123',
              'password2': 'newpass123'})
-        self.assertTrue(user.is_authenticated())
+        self.assertTrue(is_authenticated(user))
         # EmailVerificationMethod.MANDATORY sends us to the confirm-email page
         self.assertRedirects(resp, '/confirm-email/')
 

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -7,7 +7,6 @@ import django
 from django.utils.timezone import now
 from django.test.utils import override_settings
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.test.client import Client
 from django.core import mail
 from django.test.client import RequestFactory
@@ -27,6 +26,8 @@ from allauth.utils import (
     get_current_site,
     get_user_model,
     get_username_max_length)
+
+from ..compat import reverse
 
 from . import app_settings
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import redirect
 from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.decorators import method_decorator
 
-from ..compat import reverse, reverse_lazy
+from ..compat import is_anonymous, reverse, reverse_lazy
 from ..exceptions import ImmediateHttpResponse
 from ..utils import get_form_class, get_request_param, get_current_site
 
@@ -288,7 +288,7 @@ class ConfirmEmailView(TemplateResponseMixin, View):
         if user_pk_str:
             user_pk = url_str_to_user_pk(user_pk_str)
         user = confirmation.email_address.user
-        if user_pk == user.pk and self.request.user.is_anonymous():
+        if user_pk == user.pk and is_anonymous(self.request.user):
             return perform_login(self.request,
                                  user,
                                  app_settings.EmailVerificationMethod.NONE,

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -1,4 +1,3 @@
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.http import (HttpResponseRedirect, Http404,
                          HttpResponsePermanentRedirect)
 from django.views.generic.base import TemplateResponseMixin, View, TemplateView
@@ -10,6 +9,7 @@ from django.shortcuts import redirect
 from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.decorators import method_decorator
 
+from ..compat import reverse, reverse_lazy
 from ..exceptions import ImmediateHttpResponse
 from ..utils import get_form_class, get_request_param, get_current_site
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import redirect
 from django.views.decorators.debug import sensitive_post_parameters
 from django.utils.decorators import method_decorator
 
-from ..compat import is_anonymous, reverse, reverse_lazy
+from ..compat import is_anonymous, is_authenticated, reverse, reverse_lazy
 from ..exceptions import ImmediateHttpResponse
 from ..utils import get_form_class, get_request_param, get_current_site
 
@@ -54,7 +54,7 @@ class RedirectAuthenticatedUserMixin(object):
         # WORKAROUND: https://code.djangoproject.com/ticket/19316
         self.request = request
         # (end WORKAROUND)
-        if request.user.is_authenticated() and \
+        if is_authenticated(request.user) and \
                 app_settings.AUTHENTICATED_LOGIN_REDIRECTS:
             redirect_to = self.get_authenticated_redirect_url()
             response = HttpResponseRedirect(redirect_to)
@@ -673,14 +673,14 @@ class LogoutView(TemplateResponseMixin, View):
     def get(self, *args, **kwargs):
         if app_settings.LOGOUT_ON_GET:
             return self.post(*args, **kwargs)
-        if not self.request.user.is_authenticated():
+        if not is_authenticated(self.request.user):
             return redirect(self.get_redirect_url())
         ctx = self.get_context_data()
         return self.render_to_response(ctx)
 
     def post(self, *args, **kwargs):
         url = self.get_redirect_url()
-        if self.request.user.is_authenticated():
+        if is_authenticated(self.request.user):
             self.logout()
         return redirect(url)
 

--- a/allauth/compat.py
+++ b/allauth/compat.py
@@ -1,5 +1,10 @@
 import django
 
+if django.VERSION > (1, 10,):
+    from django.urls import NoReverseMatch, reverse, reverse_lazy
+else:
+    from django.core.urlresolvers import NoReverseMatch, reverse, reverse_lazy  # noqa
+
 if django.VERSION > (1, 8,):
     from collections import OrderedDict
 else:

--- a/allauth/compat.py
+++ b/allauth/compat.py
@@ -54,3 +54,10 @@ def is_anonymous(user):
         return user.is_anonymous
     else:
         return user.is_anonymous()
+
+
+def is_authenticated(user):
+    if django.VERSION > (1, 10,):
+        return user.is_authenticated
+    else:
+        return user.is_authenticated()

--- a/allauth/compat.py
+++ b/allauth/compat.py
@@ -47,3 +47,10 @@ def template_context_value(context, key):
     except KeyError:
         value = getattr(context, key)
     return value
+
+
+def is_anonymous(user):
+    if django.VERSION > (1, 10,):
+        return user.is_anonymous
+    else:
+        return user.is_anonymous()

--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -13,7 +13,7 @@ from ..account.models import EmailAddress
 from ..account.adapter import get_adapter as get_account_adapter
 from ..account import app_settings as account_settings
 from ..account.app_settings import EmailVerificationMethod
-from ..compat import reverse
+from ..compat import is_authenticated, reverse
 
 from . import app_settings
 
@@ -115,7 +115,7 @@ class DefaultSocialAccountAdapter(object):
         Returns the default URL to redirect to after successfully
         connecting a social account.
         """
-        assert request.user.is_authenticated()
+        assert is_authenticated(request.user)
         url = reverse('socialaccount_connections')
         return url
 

--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from django.utils.translation import ugettext_lazy as _
-from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 
 from ..utils import (import_attribute,
@@ -14,6 +13,7 @@ from ..account.models import EmailAddress
 from ..account.adapter import get_adapter as get_account_adapter
 from ..account import app_settings as account_settings
 from ..account.app_settings import EmailVerificationMethod
+from ..compat import reverse
 
 from . import app_settings
 

--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -2,7 +2,6 @@ from django.contrib import messages
 from django.shortcuts import render
 from django.http import HttpResponseRedirect
 from django.forms import ValidationError
-from django.core.urlresolvers import reverse
 
 from allauth.account.utils import (perform_login, complete_signup,
                                    user_username)
@@ -10,6 +9,8 @@ from allauth.account import app_settings as account_settings
 from allauth.account.adapter import get_adapter as get_account_adapter
 from allauth.exceptions import ImmediateHttpResponse
 from .providers.base import AuthProcess, AuthError
+
+from ..compat import reverse
 
 from .models import SocialLogin
 

--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -10,7 +10,7 @@ from allauth.account.adapter import get_adapter as get_account_adapter
 from allauth.exceptions import ImmediateHttpResponse
 from .providers.base import AuthProcess, AuthError
 
-from ..compat import is_anonymous, reverse
+from ..compat import is_anonymous, is_authenticated, reverse
 
 from .models import SocialLogin
 
@@ -159,7 +159,7 @@ def _social_login_redirect(request, sociallogin):
 
 
 def _complete_social_login(request, sociallogin):
-    if request.user.is_authenticated():
+    if is_authenticated(request.user):
         get_account_adapter().logout(request)
     if sociallogin.is_existing:
         # Login existing user

--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -10,7 +10,7 @@ from allauth.account.adapter import get_adapter as get_account_adapter
 from allauth.exceptions import ImmediateHttpResponse
 from .providers.base import AuthProcess, AuthError
 
-from ..compat import reverse
+from ..compat import is_anonymous, reverse
 
 from .models import SocialLogin
 
@@ -98,7 +98,7 @@ def render_authentication_error(request,
 
 
 def _add_social_account(request, sociallogin):
-    if request.user.is_anonymous():
+    if is_anonymous(request.user):
         # This should not happen. Simply redirect to the connections
         # view (which has a login required)
         return HttpResponseRedirect(reverse('socialaccount_connections'))

--- a/allauth/socialaccount/migrations/0001_initial.py
+++ b/allauth/socialaccount/migrations/0001_initial.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                 ('last_login', models.DateTimeField(auto_now=True, verbose_name='last login')),
                 ('date_joined', models.DateTimeField(auto_now_add=True, verbose_name='date joined')),
                 ('extra_data', allauth.socialaccount.fields.JSONField(default='{}', verbose_name='extra data')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'social account',
@@ -56,8 +56,8 @@ class Migration(migrations.Migration):
                 ('token', models.TextField(help_text='"oauth_token" (OAuth1) or access token (OAuth2)', verbose_name='token')),
                 ('token_secret', models.TextField(help_text='"oauth_token_secret" (OAuth1) or refresh token (OAuth2)', verbose_name='token secret', blank=True)),
                 ('expires_at', models.DateTimeField(null=True, verbose_name='expires at', blank=True)),
-                ('account', models.ForeignKey(to='socialaccount.SocialAccount')),
-                ('app', models.ForeignKey(to='socialaccount.SocialApp')),
+                ('account', models.ForeignKey(to='socialaccount.SocialAccount', on_delete=models.CASCADE)),
+                ('app', models.ForeignKey(to='socialaccount.SocialApp', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'social application token',

--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -76,7 +76,8 @@ class SocialApp(models.Model):
 
 @python_2_unicode_compatible
 class SocialAccount(models.Model):
-    user = models.ForeignKey(allauth.app_settings.USER_MODEL)
+    user = models.ForeignKey(allauth.app_settings.USER_MODEL,
+                             on_delete=models.CASCADE)
     provider = models.CharField(verbose_name=_('provider'),
                                 max_length=30,
                                 choices=providers.registry.as_choices())
@@ -130,8 +131,8 @@ class SocialAccount(models.Model):
 
 @python_2_unicode_compatible
 class SocialToken(models.Model):
-    app = models.ForeignKey(SocialApp)
-    account = models.ForeignKey(SocialAccount)
+    app = models.ForeignKey(SocialApp, on_delete=models.CASCADE)
+    account = models.ForeignKey(SocialAccount, on_delete=models.CASCADE)
     token = models.TextField(
         verbose_name=_('token'),
         help_text=_(

--- a/allauth/socialaccount/providers/draugiem/provider.py
+++ b/allauth/socialaccount/providers/draugiem/provider.py
@@ -1,8 +1,9 @@
-from django.core.urlresolvers import reverse
 from django.utils.http import urlencode
 
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.base import Provider, ProviderAccount
+
+from allauth.compat import reverse
 
 
 class DraugiemAccount(ProviderAccount):

--- a/allauth/socialaccount/providers/draugiem/tests.py
+++ b/allauth/socialaccount/providers/draugiem/tests.py
@@ -1,9 +1,9 @@
 from hashlib import md5
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
 from django.utils.http import urlencode
 
+from allauth.compat import reverse
 from allauth.socialaccount import providers
 from allauth.socialaccount.models import SocialToken, SocialApp
 from allauth.utils import get_current_site

--- a/allauth/socialaccount/providers/draugiem/views.py
+++ b/allauth/socialaccount/providers/draugiem/views.py
@@ -1,11 +1,11 @@
 from hashlib import md5
 import requests
 
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.http import urlencode
 from django.views.decorators.csrf import csrf_exempt
 
+from allauth.compat import reverse
 from allauth.socialaccount import providers
 from allauth.socialaccount.models import SocialLogin, SocialToken
 from allauth.socialaccount.helpers import complete_social_login

--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -1,13 +1,12 @@
 import json
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import get_token
 from django.utils.html import mark_safe, escapejs
 from django.utils.http import urlquote
 from django.utils.crypto import get_random_string
 
-from allauth.compat import render_to_string
+from allauth.compat import render_to_string, reverse
 from allauth.utils import import_callable
 from allauth.account.models import EmailAddress
 from allauth.socialaccount import providers

--- a/allauth/socialaccount/providers/facebook/tests.py
+++ b/allauth/socialaccount/providers/facebook/tests.py
@@ -1,9 +1,9 @@
 import json
 
-from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from django.test.client import RequestFactory
 
+from allauth.compat import reverse
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase, patch
 from allauth.socialaccount.models import SocialAccount

--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -7,13 +7,13 @@ from django.contrib.auth.models import User
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.core import mail
-from django.core.urlresolvers import reverse
 
 try:
     from importlib import import_module
 except ImportError:
     from django.utils.importlib import import_module
 
+from allauth.compat import reverse
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.account import app_settings as account_settings
 from allauth.account.models import EmailConfirmation, EmailAddress

--- a/allauth/socialaccount/providers/oauth/provider.py
+++ b/allauth/socialaccount/providers/oauth/provider.py
@@ -3,9 +3,9 @@ try:
 except ImportError:
     from urlparse import parse_qsl
 
-from django.core.urlresolvers import reverse
 from django.utils.http import urlencode
 
+from allauth.compat import reverse
 from allauth.socialaccount.providers.base import Provider
 
 

--- a/allauth/socialaccount/providers/oauth/views.py
+++ b/allauth/socialaccount/providers/oauth/views.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
-
+from allauth.compat import reverse
 from allauth.socialaccount.helpers import render_authentication_error
 from allauth.socialaccount.providers.oauth.client import (OAuthClient,
                                                           OAuthError)

--- a/allauth/socialaccount/providers/oauth2/provider.py
+++ b/allauth/socialaccount/providers/oauth2/provider.py
@@ -3,9 +3,9 @@ try:
 except ImportError:
     from urlparse import parse_qsl
 
-from django.core.urlresolvers import reverse
 from django.utils.http import urlencode
 
+from allauth.compat import reverse
 from allauth.socialaccount.providers.base import Provider
 
 

--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import
 from datetime import timedelta
 
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 
+from allauth.compat import reverse
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.utils import build_absolute_uri
 from allauth.socialaccount.helpers import render_authentication_error

--- a/allauth/socialaccount/providers/openid/provider.py
+++ b/allauth/socialaccount/providers/openid/provider.py
@@ -2,9 +2,9 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
-from django.core.urlresolvers import reverse
 from django.utils.http import urlencode
 
+from allauth.compat import reverse
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.base import Provider, ProviderAccount
 

--- a/allauth/socialaccount/providers/openid/tests.py
+++ b/allauth/socialaccount/providers/openid/tests.py
@@ -1,7 +1,6 @@
 from openid.consumer import consumer
 
-from django.core.urlresolvers import reverse
-
+from allauth.compat import reverse
 from allauth.utils import get_user_model
 from allauth.tests import TestCase, Mock, patch
 

--- a/allauth/socialaccount/providers/openid/views.py
+++ b/allauth/socialaccount/providers/openid/views.py
@@ -1,5 +1,4 @@
 from django.shortcuts import render
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
 
@@ -8,6 +7,7 @@ from openid.consumer import consumer
 from openid.extensions.sreg import SRegRequest
 from openid.extensions.ax import FetchRequest, AttrInfo
 
+from allauth.compat import reverse
 from allauth.socialaccount.app_settings import QUERY_EMAIL
 from allauth.socialaccount.models import SocialLogin
 from allauth.socialaccount.helpers import render_authentication_error

--- a/allauth/socialaccount/providers/persona/tests.py
+++ b/allauth/socialaccount/providers/persona/tests.py
@@ -1,6 +1,6 @@
 from django.test.utils import override_settings
-from django.core.urlresolvers import reverse
 
+from allauth.compat import reverse
 from allauth.utils import get_user_model
 from allauth.tests import TestCase, patch
 

--- a/allauth/socialaccount/providers/shopify/tests.py
+++ b/allauth/socialaccount/providers/shopify/tests.py
@@ -1,5 +1,4 @@
-from django.core.urlresolvers import reverse
-
+from allauth.compat import reverse
 from allauth.socialaccount.tests import create_oauth2_tests
 from allauth.tests import MockedResponse, mocked_response
 from allauth.socialaccount.providers import registry

--- a/allauth/socialaccount/providers/untappd/provider.py
+++ b/allauth/socialaccount/providers/untappd/provider.py
@@ -1,5 +1,4 @@
-from django.core.urlresolvers import reverse
-
+from allauth.compat import reverse
 from allauth.account.models import EmailAddress
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.base import ProviderAccount

--- a/allauth/socialaccount/providers/weixin/views.py
+++ b/allauth/socialaccount/providers/weixin/views.py
@@ -1,7 +1,6 @@
 import requests
 
-from django.core.urlresolvers import reverse
-
+from allauth.compat import reverse
 from allauth.utils import build_absolute_uri
 from allauth.account import app_settings
 from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,

--- a/allauth/socialaccount/tests.py
+++ b/allauth/socialaccount/tests.py
@@ -7,7 +7,6 @@ import warnings
 import json
 
 from django.test.utils import override_settings
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -15,6 +14,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.sites.models import Site
 from django.conf import settings
 
+from ..compat import reverse
 from ..tests import MockedResponse, mocked_response, TestCase
 from ..account import app_settings as account_settings
 from ..account.models import EmailAddress

--- a/allauth/socialaccount/views.py
+++ b/allauth/socialaccount/views.py
@@ -1,10 +1,10 @@
 from django.contrib import messages
 from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.contrib.auth.decorators import login_required
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 
+from ..compat import reverse, reverse_lazy
 from ..account import app_settings as account_settings
 from ..account.views import (AjaxCapableProcessFormViewMixin,
                              CloseableSignupMixin,

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.validators import validate_email, ValidationError
-from django.core import urlresolvers
 from django.contrib.sites.models import Site
 from django.db.models import FieldDoesNotExist, FileField
 from django.db.models.fields import (DateTimeField, DateField,
@@ -20,7 +19,7 @@ try:
     from django.utils.encoding import force_text, force_bytes
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
-from allauth.compat import importlib
+from allauth.compat import importlib, reverse, NoReverseMatch
 
 
 def _generate_unique_username_base(txts, regex=None):
@@ -165,8 +164,8 @@ def resolve_url(to):
     Subset of django.shortcuts.resolve_url (that one is 1.5+)
     """
     try:
-        return urlresolvers.reverse(to)
-    except urlresolvers.NoReverseMatch:
+        return reverse(to)
+    except NoReverseMatch:
         # If this doesn't "feel" like a URL, re-raise.
         if '/' not in to and '.' not in to:
             raise


### PR DESCRIPTION
* is_anonymous and is_authorized and now properties - added a compatibility function
* urlresolver has moved - import used functions into the compatibility module
* on_delete - is explicit in Django 1.10, so use models.CASCADE, the current implicit method in all models and migrations.