### PR TITLE
Fixed Migration 0001_initial to work for new project migrations

### DIFF
--- a/allauth/socialaccount/migrations/0001_initial.py
+++ b/allauth/socialaccount/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('provider', models.CharField(max_length=30, verbose_name='provider', choices=registry.as_choices())),
-                ('uid', models.CharField(max_length=255, verbose_name='uid')),
+                ('uid', models.CharField(max_length=getattr(settings, 'SOCIALACCOUNT_UID_MAX_LENGTH', 191), verbose_name='uid')),
                 ('last_login', models.DateTimeField(auto_now=True, verbose_name='last login')),
                 ('date_joined', models.DateTimeField(auto_now_add=True, verbose_name='date joined')),
                 ('extra_data', allauth.socialaccount.fields.JSONField(default='{}', verbose_name='extra data')),


### PR DESCRIPTION
Hi,

I made a pull request to address the issue: #1539. The issue arises when adding allauth for the first time and running migrate on a new MySQL utf8mb4 schema. I had to manually fix the migration file to make the django `python manage.py migrate` command work. The fixed second migration you wrote did not fix the issue as the 0001_initial migration runs first and fails. This was tested on Django 1.10.3.

Thanks,

Arjun 