### PR TITLE
Allow custom user agent for Reddit auth.

### DIFF
--- a/allauth/socialaccount/providers/reddit/views.py
+++ b/allauth/socialaccount/providers/reddit/views.py
@@ -1,5 +1,6 @@
 import requests
 
+from allauth.socialaccount import app_settings
 from allauth.socialaccount.providers.oauth2.views import (OAuth2Adapter,
                                                           OAuth2LoginView,
                                                           OAuth2CallbackView)
@@ -12,9 +13,12 @@ class RedditAdapter(OAuth2Adapter):
     authorize_url = 'https://www.reddit.com/api/v1/authorize'
     profile_url = 'https://oauth.reddit.com/api/v1/me'
     basic_auth = True
-    headers = {"User-Agent": "django-allauth-header"}
 
-    # After successfully logging in, use access token to retrieve user info
+    settings = app_settings.PROVIDERS.get(provider_id, {})
+    # Allow custom User Agent to comply with reddit API limits
+    headers = {
+        'User-Agent': settings.get('USER_AGENT', 'django-allauth-header')}
+
     def complete_login(self, request, app, token, **kwargs):
         headers = {
             "Authorization": "bearer " + token.token}

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -609,6 +609,35 @@ SCOPE
 For a full list of scope options, see https://developers.pinterest.com/docs/api/overview/#scopes
 
 
+Reddit
+-------
+
+App registration (get your key and secret here)
+    https://www.reddit.com/prefs/apps/
+
+Development callback URL
+    http://localhost:8000/accounts/reddit/login/callback/
+
+By default, access to Reddit is temporary. You can specify the `duration`
+auth parameter to make it `permanent`.
+
+You can optionally specify additional permissions to use. If no `SCOPE` value
+is set, the Reddit provider will use `identity` by default.
+
+In addition, you should override your user agent to comply with Reddit's API
+rules, and specify something in the format
+`<platform>:<app ID>:<version string> (by /u/<reddit username>)`. Otherwise,
+you will risk additional rate limiting in your application.::
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'reddit': {
+            'AUTH_PARAMS': { 'duration': 'permanent' },
+            'SCOPE': ['identity', 'submit'],
+            'USER_AGENT': 'django:myappid:1.0 (by /u/yourredditname)',
+        }
+    }
+
+
 Shopify
 -------
 


### PR DESCRIPTION
See the [Reddit API rules](https://github.com/reddit/reddit/wiki/API#rules)

> Change your client's User-Agent string to something unique and descriptive, including the target platform, a unique application identifier, a version string, and your username as contact information, in the following format: `<platform>:<app ID>:<version string> (by /u/<reddit username>)`
> - Example: `User-Agent: android:com.example.myredditapp:v1.2.3 (by /u/kemitche)`
> - Many default User-Agents (like "Python/urllib" or "Java") are drastically limited to encourage unique and descriptive user-agent strings.
> - Including the version number and updating it as you build your application allows us to safely block old buggy/broken versions of your app.
> - NEVER lie about your user-agent. This includes spoofing popular browsers and spoofing other bots. We will ban liars with extreme prejudice.