### PR TITLE
Use friendlier name for RedditAccount to_str method

### DIFF
--- a/allauth/socialaccount/providers/reddit/provider.py
+++ b/allauth/socialaccount/providers/reddit/provider.py
@@ -4,7 +4,10 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class RedditAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        dflt = super(RedditAccount, self).to_str()
+        name = self.account.extra_data.get('name', dflt)
+        return name
 
 
 class RedditProvider(OAuth2Provider):


### PR DESCRIPTION
On `/accounts/social/connections/`, it changes from saying "Reddit Reddit" to "Reddit yourusername"