### PR TITLE
Assorted improvements to the Battle.net backend

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -23,6 +23,8 @@ Note worthy changes
 - The OAuth2Adapter class has gained a ``get_callback_url`` method for when
   customizing the callback URL is desired.
 
+- The Battle.net login backend now accepts the ``region`` GET parameter.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -20,6 +20,9 @@ Note worthy changes
   username. For now, the default is set to ``True`` to maintain backwards
   compatibility.
 
+- The OAuth2Adapter class has gained a ``get_callback_url`` method for when
+  customizing the callback URL is desired.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -35,6 +35,13 @@ Backwards incompatible changes
   user model level. Alternatively, you can use the newly introduced
   ``ACCOUNT_USERNAME_VALIDATORS`` setting.
 
+- The Battle.net backend no longer overrides username regex validation. In
+  order to use battletags as usernames, you are expected to override either
+  the ``username`` field on your User model, or to pass a custom validator
+  which will accept the ``#`` character using the new
+  ``ACCOUNT_USERNAME_VALIDATORS`` setting. Such a validator is available in
+  ``socialaccount.providers.battlenet.validators.BattletagUsernameValidator``.
+
 
 0.29.0 (2016-11-21)
 *******************

--- a/allauth/socialaccount/providers/battlenet/provider.py
+++ b/allauth/socialaccount/providers/battlenet/provider.py
@@ -27,7 +27,11 @@ class BattleNetProvider(OAuth2Provider):
     account_class = BattleNetAccount
 
     def extract_uid(self, data):
-        return str(data["id"])
+        uid = str(data["id"])
+        if data.get("region") == "cn":
+            # China is on a different account system. UIDs can clash with US.
+            return uid + "-cn"
+        return uid
 
     def extract_common_fields(self, data):
         return {"battletag": data.get("battletag")}

--- a/allauth/socialaccount/providers/battlenet/provider.py
+++ b/allauth/socialaccount/providers/battlenet/provider.py
@@ -1,18 +1,6 @@
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
-from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-
-
-class BattleNetSocialAccountAdapter(DefaultSocialAccountAdapter):
-    def save_user(self, request, sociallogin, form=None):
-        user = super().save_user(request, sociallogin, form)
-
-        battletag = sociallogin.account.extra_data.get("battletag")
-        if battletag:
-            user.username = battletag
-            user.save()
-        return user
 
 
 class BattleNetAccount(ProviderAccount):

--- a/allauth/socialaccount/providers/battlenet/provider.py
+++ b/allauth/socialaccount/providers/battlenet/provider.py
@@ -34,7 +34,7 @@ class BattleNetProvider(OAuth2Provider):
         return uid
 
     def extract_common_fields(self, data):
-        return {"battletag": data.get("battletag")}
+        return {"username": data.get("battletag")}
 
     def get_default_scope(self):
         # Optional scopes: "sc2.profile", "wow.profile"

--- a/allauth/socialaccount/providers/battlenet/validators.py
+++ b/allauth/socialaccount/providers/battlenet/validators.py
@@ -1,0 +1,4 @@
+from django.core.validators import RegexValidator
+
+
+BattletagUsernameValidator = RegexValidator(r"^[\w.]+#\d+$")

--- a/allauth/socialaccount/providers/battlenet/views.py
+++ b/allauth/socialaccount/providers/battlenet/views.py
@@ -62,7 +62,7 @@ class BattleNetOAuth2Adapter(OAuth2Adapter):
     @property
     def battlenet_api_url(self):
         if self.battlenet_region == "cn":
-            return "https://www.battlenet.com.cn/api"
+            return "https://api.battlenet.com.cn"
         return "https://%s.api.battle.net" % (self.battlenet_region)
 
     @property

--- a/allauth/socialaccount/providers/battlenet/views.py
+++ b/allauth/socialaccount/providers/battlenet/views.py
@@ -51,6 +51,7 @@ class BattleNetOAuth2Adapter(OAuth2Adapter):
     """
     provider_id = BattleNetProvider.id
     battlenet_region = "us"
+    valid_regions = ("us", "eu", "kr", "sea", "tw", "cn")
 
     @property
     def battlenet_base_url(self):

--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -43,6 +43,11 @@ class OAuth2Adapter(object):
         """
         raise NotImplementedError
 
+    def get_callback_url(self, request, app):
+        callback_url = reverse(self.provider_id + "_callback")
+        protocol = self.redirect_uri_protocol
+        return build_absolute_uri(request, callback_url, protocol)
+
     def parse_token(self, data):
         token = SocialToken(token=data['access_token'])
         token.token_secret = data.get('refresh_token', '')
@@ -67,10 +72,7 @@ class OAuth2View(object):
         return view
 
     def get_client(self, request, app):
-        callback_url = reverse(self.adapter.provider_id + "_callback")
-        callback_url = build_absolute_uri(
-            request, callback_url,
-            protocol=self.adapter.redirect_uri_protocol)
+        callback_url = self.adapter.get_callback_url(request, app)
         provider = self.adapter.get_provider()
         scope = provider.get_scope(request)
         client = OAuth2Client(self.request, app.client_id, app.secret,

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -100,6 +100,13 @@ Register your app here (Mashery account required)
 Development callback URL
     https://localhost:8000/accounts/battlenet/login/callback/
 
+NOTE: In order to use battletags as usernames, you are expected to override either
+the ``username`` field on your User model, or to pass a custom validator which will
+accept the ``#`` character using the ``ACCOUNT_USERNAME_VALIDATORS`` setting
+Such a validator is available in
+``socialaccount.providers.battlenet.validators.BattletagUsernameValidator``.
+
+
 Bitbucket
 ---------
 
@@ -110,6 +117,7 @@ Make sure you select the Account:Read permission.
 
 Development callback URL
     http://127.0.0.1:8000/accounts/bitbucket_oauth2/login/callback/
+
 
 Doximity
 --------


### PR DESCRIPTION
Alrighty, now that 8dc2f2d5cc3ce0e5e1b999129ceaa57ed4e75390 has landed I can go ahead with this :)

The first commit starts addressing #1442. It doesn't outright *remove* the adapter but it makes it way less nasty. The current adapter *always* causes the "user", "user1"... mechanism because the battletag is never saved. Additionally, the current adapter always forces at least two sql writes (first the user, then re-saves the user's battletag).

So we first allow overriding the `username_regex` attribute. Rather than make it a setting, we allow specifying it in the adapter, which I believe to be a reasonable solution.
With that done, we can change the Battle.net adapter to use that and get the battletag as the username data.

The next commits address the china issue:

- `valid_region` is simply a list of the valid region inputs for `battlenet_region`
- Appending `-cn` to the UIDs matching `cn` region is required because the UIDs can clash between US and China; if we don't do that, an account in china can take over an account in the US if running both on the same server.
- Finally, the last commit allows overriding the region in `/account/battlenet/login/` by specifying, for example, `?region=cn`. I'm not sure if there is existing functionality for this but I think it's acceptable.