### PR TITLE
Add exception handling for oauth error case for ceratin cases

### DIFF
--- a/allauth/socialaccount/providers/oauth/client.py
+++ b/allauth/socialaccount/providers/oauth/client.py
@@ -14,6 +14,7 @@ from allauth.compat import parse_qsl, urlparse
 
 import requests
 from requests_oauthlib import OAuth1
+from requests.exceptions import ConnectionError, HTTPError
 
 
 def get_token_prefix(url):
@@ -31,6 +32,12 @@ def get_token_prefix(url):
 
 
 class OAuthError(Exception):
+    pass
+
+class OAuthConnectionError(ConnectionError):
+    pass
+
+class OAuthHTTPError(HTTPError):
     pass
 
 

--- a/allauth/socialaccount/providers/oauth/views.py
+++ b/allauth/socialaccount/providers/oauth/views.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 from allauth.compat import reverse
 from allauth.socialaccount.helpers import render_authentication_error
 from allauth.socialaccount.providers.oauth.client import (OAuthClient,
-                                                          OAuthError)
+                                                          OAuthError,
+                                                          OAuthConnectionError)
 from allauth.socialaccount.helpers import complete_social_login
 from allauth.socialaccount import providers
 from allauth.socialaccount.models import SocialToken, SocialLogin
@@ -103,7 +104,7 @@ class OAuthCallbackView(OAuthView):
             login.token = token
             login.state = SocialLogin.unstash_state(request)
             return complete_social_login(request, login)
-        except OAuthError as e:
+        except (OAuthError, OAuthConnectionError) as e:
             return render_authentication_error(
                 request,
                 self.adapter.provider_id,

--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -12,7 +12,8 @@ from allauth.utils import build_absolute_uri
 from allauth.socialaccount.helpers import render_authentication_error
 from allauth.socialaccount import providers
 from allauth.socialaccount.providers.oauth2.client import (OAuth2Client,
-                                                           OAuth2Error)
+                                                           OAuth2Error,
+                                                           OAuthHTTPError)
 from allauth.socialaccount.helpers import complete_social_login
 from allauth.socialaccount.models import SocialToken, SocialLogin
 from allauth.utils import get_request_param
@@ -133,7 +134,7 @@ class OAuth2CallbackView(OAuth2View):
             else:
                 login.state = SocialLogin.unstash_state(request)
             return complete_social_login(request, login)
-        except (PermissionDenied, OAuth2Error) as e:
+        except (PermissionDenied, OAuth2Error, OAuthHTTPError, KeyError) as e:
             return render_authentication_error(
                 request,
                 self.adapter.provider_id,


### PR DESCRIPTION
I know it is not perfect solution, 
can you at least refer to this suggestion and make exception handling fix?

Thank you.


refer to issue #1375 
----

Following view class only catches PermissionDenied, OAuth2Error
* OAuthCallbackView
* OAuth2CallbackView
However we get following error on production level when there are swarming request or undistinguishable api return from providers. 

```
HTTPError at /accounts/facebook/login/callback/

500 Server Error: Internal Server Error
```

```
HTTPError at /accounts/google/login/callback/

500 Server Error: Internal Server Error
```

```
ConnectionError at /accounts/twitter/login/callback/

HTTPSConnectionPool(host='api.twitter.com', port=443): Max retries exceeded with url: /1.1/account/verify_credentials.json?include_email=true (Caused by <class 'socket.error'>: [Errno 110] Connection timed out)

```

```
TypeError at /accounts/facebook/login/callback/

'NoneType' object has no attribute '__getitem__'
```

```
KeyError at /accounts/vk/login/callback/

'response'
Request Method:	GET
Request URL:	***/accounts/vk/login/callback/?code=f3e4cd7478618ee313&state=DIsBbTeTQwuQ
Django Version:	1.7.1
Exception Type:	KeyError
Exception Value:	
```

