### PR TITLE
Don't access username field if USER_MODEL_USERNAME_FIELD is None.

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -315,8 +315,11 @@ class AppSettings(object):
                 raise ImproperlyConfigured(
                     'ACCOUNT_USERNAME_VALIDATORS is expected to be a list')
         else:
-            ret = get_user_model()._meta.get_field(
-                self.USER_MODEL_USERNAME_FIELD).validators
+            if self.USER_MODEL_USERNAME_FIELD is not None:
+                ret = get_user_model()._meta.get_field(
+                    self.USER_MODEL_USERNAME_FIELD).validators
+            else:
+                ret = []
         return ret
 
 


### PR DESCRIPTION
This is important for things that walk public properties (freezegun in my case)