### PR TITLE
remove hopper.pw from list of examples

### DIFF
--- a/docs/showcase.rst
+++ b/docs/showcase.rst
@@ -15,7 +15,6 @@ Here are some sites that have `django-allauth` up and running:
 - http://www.burufly.com
 - http://eatwith.com
 - http://en.globalquiz.org
-- http://hopper.pw
 - http://decommentariis.net
 - http://www.heapsortjobs.com
 - http://demo.organice.io


### PR DESCRIPTION
I shut down hopper.pw a while ago, so it should be removed from this list.