### PR TITLE
Make Slack provider work with only the 'identify' scope.

### DIFF
--- a/allauth/socialaccount/providers/slack/provider.py
+++ b/allauth/socialaccount/providers/slack/provider.py
@@ -29,8 +29,7 @@ class SlackProvider(OAuth2Provider):
                     email=data.get('user').get('email', None))
 
     def get_default_scope(self):
-        return ['identity.basic', 'identity.email',
-                'identity.avatar', 'identity.team']
+        return ['identify']
 
 
 providers.registry.register(SlackProvider)

--- a/allauth/socialaccount/providers/slack/tests.py
+++ b/allauth/socialaccount/providers/slack/tests.py
@@ -10,25 +10,9 @@ class SlackOAuth2Tests(OAuth2TestsMixin, TestCase):
     def get_mocked_response(self):
         return MockedResponse(200, """{
           "ok": true,
-          "user": {
-            "name": "Sonny Whether",
-            "id": "U0G9QF9C6",
-            "email": "sonny@captain-fabian.com",
-            "image_24":
-            "https://secure.gravatar.com/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg?s=24&d=https%3A%2F%2Fdev.slack.com%2Fimg%2Favatars%2Fava_0010-24.v1441146555.png",
-            "image_32":
-            "https://secure.gravatar.com/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg?s=32&d=https%3A%2F%2Fdev.slack.com%2Fimg%2Favatars%2Fava_0010-32.v1441146555.png",
-            "image_48":
-            "https://secure.gravatar.com/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg?s=48&d=https%3A%2F%2Fdev.slack.com%2Fimg%2Favatars%2Fava_0010-48.v1441146555.png",
-            "image_72":
-            "https://secure.gravatar.com/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg?s=72&d=https%3A%2F%2Fdev.slack.com%2Fimg%2Favatars%2Fava_0010-72.v1441146555.png",
-            "image_192":
-            "https://secure.gravatar.com/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg?s=192&d=https%3A%2F%2Fdev.slack.com%2Fimg%2Favatars%2Fava_0010-192.v1443724322.png",
-            "image_512":
-            "https://secure.gravatar.com/avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg?s=512&d=https%3A%2F%2Fdev.slack.com%2Fimg%2Favatars%2Fava_0010-512.v1443724322.png"
-          },
-          "team": {
-            "id": "T0G9PQBBK",
-            "name": "Captain Fabian's Naval Supply"
-          }
+          "url": "https:\/\/myteam.slack.com\/",
+          "team": "My Team",
+          "user": "cal",
+          "team_id": "T12345",
+          "user_id": "U12345"
         }""")  # noqa

--- a/allauth/socialaccount/providers/slack/views.py
+++ b/allauth/socialaccount/providers/slack/views.py
@@ -7,13 +7,12 @@ from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 
 from .provider import SlackProvider
 
-
 class SlackOAuth2Adapter(OAuth2Adapter):
     provider_id = SlackProvider.id
 
     access_token_url = 'https://slack.com/api/oauth.access'
     authorize_url = 'https://slack.com/oauth/authorize'
-    identity_url = 'https://slack.com/api/users.identity'
+    identity_url = 'https://slack.com/api/auth.test'
 
     def complete_login(self, request, app, token, **kwargs):
         extra_data = self.get_data(token.token)
@@ -33,8 +32,15 @@ class SlackOAuth2Adapter(OAuth2Adapter):
 
         # Fill in their generic info
         info = {
-            'user': resp.get('user'),
-            'team': resp.get('team')
+            'name': resp.get('user'),
+            'user': {
+                'name': resp.get('user'),
+                'id': resp.get('user_id')
+            },
+            'team': {
+                'name': resp.get('team'),
+                'id': resp.get('team_id')
+            }
         }
 
         return info


### PR DESCRIPTION
This change reduces the number of scopes which the Slack authentication provider depends on. It's important to do this because otherwise the authentication flow will not work if developers want to use any non-identity scopes, due to Slack's restrictions.