### PR TITLE
Added support for requesting extra_data from OpenId servers

### DIFF
--- a/allauth/socialaccount/providers/openid/provider.py
+++ b/allauth/socialaccount/providers/openid/provider.py
@@ -67,8 +67,9 @@ class OpenIDProvider(Provider):
         server_settings = \
             self.get_server_settings(response.endpoint.server_url)
         extra_attributes = server_settings.get('extra_attributes', [])
-        for id, name, _ in extra_attributes:
-            extra_data[id] = get_value_from_response(response, ax_names=[name])
+        for attribute_id, name, _ in extra_attributes:
+            extra_data[attribute_id] \
+                = get_value_from_response(response, ax_names=[name])
         return extra_data
 
     def extract_uid(self, response):

--- a/allauth/socialaccount/providers/openid/provider.py
+++ b/allauth/socialaccount/providers/openid/provider.py
@@ -55,8 +55,21 @@ class OpenIDProvider(Provider):
                                 openid_url='http://hyves.nl')]
         return self.get_settings().get('SERVERS', default_servers)
 
-    def extract_extra_data(self, response):
+    def get_server_settings(self, endpoint):
+        servers = self.get_settings().get('SERVERS', [])
+        for server in servers:
+            if endpoint == server.get('openid_url'):
+                return server
         return {}
+
+    def extract_extra_data(self, response):
+        extra_data = {}
+        server_settings = \
+            self.get_server_settings(response.endpoint.server_url)
+        extra_attributes = server_settings.get('extra_attributes', [])
+        for id, name, _ in extra_attributes:
+            extra_data[id] = get_value_from_response(response, ax_names=[name])
+        return extra_data
 
     def extract_uid(self, response):
         return response.identity_url

--- a/allauth/socialaccount/providers/openid/tests.py
+++ b/allauth/socialaccount/providers/openid/tests.py
@@ -1,8 +1,11 @@
 from openid.consumer import consumer
+from django.test import override_settings
 
 from allauth.compat import reverse
 from allauth.utils import get_user_model
 from allauth.tests import TestCase, Mock, patch
+
+from allauth.socialaccount.models import SocialAccount
 
 from . import views
 from .utils import AXAttribute
@@ -51,3 +54,53 @@ class OpenIDTests(TestCase):
                         'http://testserver/accounts/profile/',
                         fetch_redirect_response=False)
                     get_user_model().objects.get(first_name='raymond')
+
+    @override_settings(SOCIALACCOUNT_PROVIDERS={'openid': {'SERVERS': [
+        dict(id='yahoo',
+             name='Yahoo',
+             openid_url='http://me.yahoo.com',
+             extra_attributes=[
+                 ('phone', 'http://axschema.org/contact/phone/default', True,)
+             ])]}})
+    def test_login_with_extra_attributes(self):
+        with patch('allauth.socialaccount.providers.openid.views.QUERY_EMAIL',
+                   True):
+            resp = self.client.post(reverse(views.login),
+                                    dict(openid='http://me.yahoo.com'))
+        assert 'login.yahooapis' in resp['location']
+        with patch('allauth.socialaccount.providers'
+                   '.openid.views._openid_consumer') as consumer_mock:
+            client = Mock()
+            complete = Mock()
+            endpoint = Mock()
+            consumer_mock.return_value = client
+            client.complete = complete
+            complete_response = Mock()
+            complete.return_value = complete_response
+            complete_response.endpoint = endpoint
+            complete_response.endpoint.server_url = 'http://me.yahoo.com'
+            complete_response.status = consumer.SUCCESS
+            complete_response.identity_url = 'http://dummy/john/'
+            with patch('allauth.socialaccount.providers'
+                       '.openid.utils.SRegResponse') as sr_mock:
+                with patch('allauth.socialaccount.providers'
+                           '.openid.utils.FetchResponse') as fr_mock:
+                    sreg_mock = Mock()
+                    ax_mock = Mock()
+                    sr_mock.fromSuccessResponse = sreg_mock
+                    fr_mock.fromSuccessResponse = ax_mock
+                    sreg_mock.return_value = {}
+                    ax_mock.return_value = {
+                        AXAttribute.CONTACT_EMAIL: ['raymond@example.com'],
+                        AXAttribute.PERSON_FIRST_NAME: ['raymond'],
+                        'http://axschema.org/contact/phone/default':
+                            ['123456789']}
+                    resp = self.client.post(reverse('openid_callback'))
+                    self.assertRedirects(
+                        resp,
+                        'http://testserver/accounts/profile/',
+                        fetch_redirect_response=False)
+                    socialaccount = \
+                        SocialAccount.objects.get(user__first_name='raymond')
+                    self.assertEqual(
+                        socialaccount.extra_data.get('phone'), '123456789')

--- a/allauth/socialaccount/providers/openid/views.py
+++ b/allauth/socialaccount/providers/openid/views.py
@@ -46,6 +46,14 @@ def login(request):
                     for name in AXAttributes:
                         ax.add(AttrInfo(name,
                                         required=True))
+                    provider = OpenIDProvider(request)
+                    server_settings = \
+                        provider.get_server_settings(request.GET.get('openid'))
+                    extra_attributes = \
+                        server_settings.get('extra_attributes', [])
+                    for _, name, required in extra_attributes:
+                        ax.add(AttrInfo(name,
+                                        required=required))
                     auth_request.addExtension(ax)
                 callback_url = reverse(callback)
                 SocialLogin.stash_state(request)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -550,6 +550,22 @@ follows::
                       openid_url='https://www.google.com/accounts/o8/id')]}}
 
 
+You can manually specify extra_data you want to request from server as follows::
+
+    SOCIALACCOUNT_PROVIDERS = \
+        { 'openid':
+            { 'SERVERS':
+                 [ dict(id='mojeid',
+                      name='MojeId',
+                      openid_url='https://mojeid.cz/endpoint/',
+                      extra_attributes = [
+                          ('phone', 'http://axschema.org/contact/phone/default', False),
+                          ('birth_date', 'http://axschema.org/birthDate', False,),
+                      ])]}}
+
+Attributes are in form (id, name, required) where id is key in extra_data field of socialaccount,
+name is identifier of requested attribute and required specifies whether attribute is required.
+
 If you want to manually include login links yourself, you can use the
 following template tag::
 


### PR DESCRIPTION
This commit adds possibility to specify data you want to request from openid provider. The returned data will be stored in extra_data attribute of socialaccount.