### PR TITLE
[Docs] Add scope configuration details for GitHub

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -419,6 +419,21 @@ App registration (get your key and secret here)
 Development callback URL
     http://127.0.0.1:8000/accounts/github/login/callback/
 
+If you want more than just read-only access to public data specify the scope
+as follows. See https://developer.github.com/v3/oauth/#scopes for details.
+
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'github': {
+            'SCOPE': [
+                'user',
+                'repo',
+                'read:org',
+            ],
+        }
+    }
+
 Enterprise Support
 ******************
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -437,15 +437,14 @@ as follows. See https://developer.github.com/v3/oauth/#scopes for details.
 Enterprise Support
 ******************
 
-To use with GitHub Enterprise, add your server URL to your settings.py file.
-
-Example:
+If you use GitHub Enterprise add your server URL to your Django settings as
+follows:
 
 .. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
         'github': {
-            'GITHUB_URL': https://github.com,
+            'GITHUB_URL': 'https://your.github-server.domain',
         }
     }
 


### PR DESCRIPTION
Configuring the GitHub OAuth correctly in order to be allowed to do actual things via GitHub v3 API  [is obviously a challenge](http://stackoverflow.com/questions/6802516/github-api-create-repo/39727575). This addition to the docs should remediate this problem for django-allauth users.