### PR TITLE
Order of fields in SignupForm

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -59,8 +59,8 @@ instances are created, and populated with data
 - `allauth.account.adapter.DefaultAccountAdapter`:
 
   - `is_open_for_signup(self, request)`: The default function
-  returns `True`. You can override this method by returning `False`
-  if you want to disable account signup.
+    returns `True`. You can override this method by returning `False`
+    if you want to disable account signup.
 
   - `new_user(self, request)`: Instantiates a new, empty `User`.
 
@@ -81,9 +81,9 @@ instances are created, and populated with data
 - `allauth.socialaccount.adapter.DefaultSocialAccountAdapter`:
 
   - `is_open_for_signup(self, request)`: The default function
-  returns that is the same as `ACCOUNT_ADAPTER` in `settings.py`.
-  You can override this method by returning `True`/`False`
-  if you want to enable/disable socialaccount signup.
+    returns that is the same as `ACCOUNT_ADAPTER` in `settings.py`.
+    You can override this method by returning `True`/`False`
+    if you want to enable/disable socialaccount signup.
 
   - `new_user(self, request, sociallogin)`: Instantiates a new, empty
     `User`.

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1,8 +1,8 @@
 Providers
 =========
 
-Most providers require you to sign up for a so called API client or
-app, containing a client ID and API secret. You must add a `SocialApp`
+Most providers require you to sign up for a so called API client or app,
+containing a client ID and API secret. You must add a ``SocialApp``
 record per provider via the Django admin containing these app
 credentials.
 
@@ -35,7 +35,7 @@ Development callback URL
 
 
 500px
--------
+-----
 
 App registration (get your key and secret here)
     https://500px.com/settings/applications
@@ -47,7 +47,7 @@ Development callback URL
 Amazon
 ------
 
-Amazon requires secure OAuth callback URLs (`redirect_uri`), please
+Amazon requires secure OAuth callback URLs (``redirect_uri``), please
 see the section on HTTPS about how this is handled.
 
 App registration (get your key and secret here)
@@ -100,10 +100,10 @@ Register your app here (Mashery account required)
 Development callback URL
     https://localhost:8000/accounts/battlenet/login/callback/
 
-NOTE: In order to use battletags as usernames, you are expected to override either
-the ``username`` field on your User model, or to pass a custom validator which will
-accept the ``#`` character using the ``ACCOUNT_USERNAME_VALIDATORS`` setting
-Such a validator is available in
+Note that in order to use battletags as usernames, you are expected to override
+either the ``username`` field on your User model, or to pass a custom validator
+which will accept the ``#`` character using the ``ACCOUNT_USERNAME_VALIDATORS``
+setting. Such a validator is available in
 ``socialaccount.providers.battlenet.validators.BattletagUsernameValidator``.
 
 
@@ -117,6 +117,9 @@ Make sure you select the Account:Read permission.
 
 Development callback URL
     http://127.0.0.1:8000/accounts/bitbucket_oauth2/login/callback/
+
+Note that Bitbucket calls the ``client_id`` *Key* in their user interface.
+Don't get confused by that; use the *Key* value for your ``client_id`` field.
 
 
 Discord
@@ -176,14 +179,21 @@ Edmodo
 Edmodo OAuth2 documentation
     https://developers.edmodo.com/edmodo-connect/edmodo-connect-overview-getting-started/
 
-You can optionally specify additional permissions to use. If no `SCOPE` value
-is set, the Edmodo provider will use `basic` by default::
+You can optionally specify additional permissions to use. If no ``SCOPE``
+value is set, the Edmodo provider will use ``basic`` by default:
+
+.. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
         'edmodo': {
-            'SCOPE': ['basic', 'read_groups', 'read_connections',
-                      'read_user_email', 'create_messages',
-                      'write_library_items']
+            'SCOPE': [
+                'basic',
+                'read_groups',
+                'read_connections',
+                'read_user_email',
+                'create_messages',
+                'write_library_items',
+            ]
         }
     }
 
@@ -192,7 +202,7 @@ Eve Online
 ----------
 
 Register your application at `https://developers.eveonline.com/applications/create`.
-Note that if you have `STORE_TOKENS` enabled (the default), you will need to
+Note that if you have ``STORE_TOKENS`` enabled (the default), you will need to
 set up you application to be able to request an OAuth scope. This means you
 will need to set it as having "CREST Access". The least obtrusive scope is
 "publicData".
@@ -201,7 +211,9 @@ will need to set it as having "CREST Access". The least obtrusive scope is
 Evernote
 --------
 
-Register your OAuth2 application at `https://dev.evernote.com/doc/articles/authentication.php`::
+Register your OAuth2 application at `https://dev.evernote.com/doc/articles/authentication.php`:
+
+.. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
         'evernote': {
@@ -222,22 +234,28 @@ to worry about tailoring the login dialog depending on whether or not
 you are using a mobile device. Yet, relying on Javascript may not be
 everybody's cup of tea.
 
-To initiate a login use::
+To initiate a login use:
+
+.. code-block:: python
 
     {% load socialaccount %}
     {% providers_media_js %}
     <a href="{% provider_login_url "facebook" method="js_sdk" %}">Facebook Connect</a>
 
-or::
+or:
+
+.. code-block:: python
 
     {% load socialaccount %}
     <a href="{% provider_login_url "facebook" method="oauth2" %}">Facebook OAuth2</a>
 
-The following Facebook settings are available::
+The following Facebook settings are available:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        {'facebook':
-           {'METHOD': 'oauth2',
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'facebook': {
+            'METHOD': 'oauth2',
             'SCOPE': ['email', 'public_profile', 'user_friends'],
             'AUTH_PARAMS': {'auth_type': 'reauthenticate'},
             'FIELDS': [
@@ -251,60 +269,69 @@ The following Facebook settings are available::
                 'timezone',
                 'link',
                 'gender',
-                'updated_time'],
+                'updated_time',
+            ],
             'EXCHANGE_TOKEN': True,
             'LOCALE_FUNC': 'path.to.callable',
             'VERIFIED_EMAIL': False,
-            'VERSION': 'v2.4'}}
+            'VERSION': 'v2.4',
+        }
+    }
 
 METHOD:
     Either `js_sdk` or `oauth2`. The default is `oauth2`.
 
 SCOPE:
     By default, the `email` scope is required depending on whether or not
-    `SOCIALACCOUNT_QUERY_EMAIL` is enabled.
-    Apps using permissions beyond `email`, `public_profile` and `user_friends` require review by Facebook.
-    See `Permissions with Facebook Login <https://developers.facebook.com/docs/facebook-login/permissions>`_ for more
-    information.
+    ``SOCIALACCOUNT_QUERY_EMAIL`` is enabled.
+    Apps using permissions beyond `email`, `public_profile` and `user_friends`
+    require review by Facebook.
+    See `Permissions with Facebook Login <https://developers.facebook.com/docs/facebook-login/permissions>`_
+    for more information.
 
 AUTH_PARAMS:
-    Use `AUTH_PARAMS` to pass along other parameters to the `FB.login`
+    Use ``AUTH_PARAMS`` to pass along other parameters to the `FB.login`
     JS SDK call.
 
 FIELDS:
     The fields to fetch from the Graph API `/me/?fields=` endpoint.
     For example, you could add the `'friends'` field in order to
-    capture the user's friends that have also logged into your app using Facebook (requires `'user_friends'` scope).
+    capture the user's friends that have also logged into your app using
+    Facebook (requires `'user_friends'` scope).
 
 EXCHANGE_TOKEN:
     The JS SDK returns a short-lived token suitable for client-side use. Set
-    `EXCHANGE_TOKEN = True` to make a server-side request to upgrade to a
+    ``EXCHANGE_TOKEN = True`` to make a server-side request to upgrade to a
     long-lived token before storing in the `SocialToken` record. See
     `Expiration and Extending Tokens <https://developers.facebook.com/docs/facebook-login/access-tokens#extending>`_.
 
 LOCALE_FUNC:
     The locale for the JS SDK is chosen based on the current active language of
     the request, taking a best guess. This can be customized using the
-    `LOCALE_FUNC` setting, which takes either a callable or a path to a callable.
+    ``LOCALE_FUNC`` setting, which takes either a callable or a path to a callable.
     This callable must take exactly one argument, the request, and return `a
     valid Facebook locale <http://developers.facebook.com/docs/
-    internationalization/>`_ as a string, e.g. US English::
+    internationalization/>`_ as a string, e.g. US English:
 
-        SOCIALACCOUNT_PROVIDERS = \
-            { 'facebook':
-                { 'LOCALE_FUNC': lambda request: 'en_US'} }
+    .. code-block:: python
+
+        SOCIALACCOUNT_PROVIDERS = {
+            'facebook': {
+                'LOCALE_FUNC': lambda request: 'en_US'
+            }
+        }
 
 VERIFIED_EMAIL:
-    It is not clear from the Facebook documentation whether or not the
-    fact that the account is verified implies that the e-mail address
-    is verified as well. For example, verification could also be done
-    by phone or credit card. To be on the safe side, the default is to
-    treat e-mail addresses from Facebook as unverified. But, if you
-    feel that is too paranoid, then use this setting to mark them as
-    verified. Due to lack of an official statement from the side of Facebook,
-    attempts have been made to
+    It is not clear from the Facebook documentation whether or not the fact
+    that the account is verified implies that the e-mail address is verified
+    as well. For example, verification could also be done by phone or credit
+    card. To be on the safe side, the default is to treat e-mail addresses
+    from Facebook as unverified. But, if you feel that is too paranoid, then
+    use this setting to mark them as verified. Due to lack of an official
+    statement from the side of Facebook, attempts have been made to
     `reverse engineer the meaning of the verified flag <https://stackoverflow.com/questions/14280535/is-it-possible-to-check-if-an-email-is-confirmed-on-facebook>`_.
-    Do know that by setting this to `True` you may be introducing a security risk.
+    Do know that by setting this to ``True`` you may be introducing a security
+    risk.
 
 VERSION:
     The Facebook Graph API version to use. The default is `v2.4`.
@@ -317,8 +344,9 @@ App registration (get your key and secret here)
     `reviewed by Facebook <https://developers.facebook.com/docs/apps/review>`_.
 
 Development callback URL
-    Leave your App Domains empty and put `http://localhost:8000` in the section labeled `Website with Facebook
-    Login`. Note that you'll need to add your site's actual domain to this section once it goes live.
+    Leave your App Domains empty and put `http://localhost:8000` in the
+    section labeled `Website with Facebook Login`. Note that you'll need to
+    add your site's actual domain to this section once it goes live.
 
 
 Firefox Accounts
@@ -333,14 +361,17 @@ The provider is OAuth2 based. More info:
 
 Note: This is not the same as the Mozilla Persona provider below.
 
-The following Firefox Accounts settings are available::
+The following Firefox Accounts settings are available:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        {'fxa':
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'fxa': {
             'SCOPE': ['profile'],
             'OAUTH_ENDPOINT': 'https://oauth.accounts.firefox.com/v1',
-            'PROFILE_ENDPOINT': 'https://profile.accounts.firefox.com/v1'}}
-
+            'PROFILE_ENDPOINT': 'https://profile.accounts.firefox.com/v1',
+        }
+    }
 
 SCOPE:
     Requested OAuth2 scope. Default is ['profile'], which will work for
@@ -362,15 +393,22 @@ Flickr
 App registration (get your key and secret here)
     https://www.flickr.com/services/apps/create/
 
-You can optionally specify the application permissions to use. If no `perms`
-value is set, the Flickr provider will use `read` by default.::
+You can optionally specify the application permissions to use. If no ``perms``
+value is set, the Flickr provider will use ``read`` by default.
 
-    SOCIALACCOUNT_PROVIDERS = \
-        { 'flickr':
-            { 'AUTH_PARAMS': { 'perms': 'write' } }}
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'flickr': {
+            'AUTH_PARAMS': {
+                'perms': 'write',
+            }
+        }
+    }
 
 More info:
     https://www.flickr.com/services/api/auth.oauth.html#authorization
+
 
 GitHub
 ------
@@ -386,13 +424,16 @@ Enterprise Support
 
 To use with GitHub Enterprise, add your server URL to your settings.py file.
 
-Example::
+Example:
+
+.. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
         'github': {
-            'GITHUB_URL': https://github.com
+            'GITHUB_URL': https://github.com,
         }
     }
+
 
 GitLab
 ------
@@ -409,12 +450,15 @@ GITLAB_URL:
     Override endpoint to request an authorization and access token. For your
     private GitLab server you use: ``https://your.gitlab.server.tld``
 
-Example::
+Example:
 
-    SOCIALACCOUNT_PROVIDERS = \
-                    { 'gitlab':
-                      { 'GITLAB_URL': 'https://your.gitlab.server.tld' }
-                    }
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'gitlab': {
+            'GITLAB_URL': 'https://your.gitlab.server.tld',
+        }
+    }
 
 
 Google
@@ -433,11 +477,20 @@ Create a google app to obtain a key and secret through the developer console.
 Google Developer Console
     https://console.developers.google.com/
 
-After you create a project you will have to create a "Client ID" and fill in some project details for the consent form that will be presented to the client.
+After you create a project you will have to create a "Client ID" and fill in
+some project details for the consent form that will be presented to the client.
 
-Under "APIs & auth" go to "Credentials" and create a new Client ID. Probably you will want a "Web application" Client ID. Provide your domain name or test domain name in "Authorized JavaScript origins". Finally fill in "http://127.0.0.1:8000/accounts/google/login/callback/" in the "Authorized redirect URI" field. You can fill multiple URLs, one for each test domain. After creating the Client ID you will find all details for the Django configuration on this page.
+Under "APIs & auth" go to "Credentials" and create a new Client ID. Probably
+you will want a "Web application" Client ID. Provide your domain name or test
+domain name in "Authorized JavaScript origins". Finally fill in
+``http://127.0.0.1:8000/accounts/google/login/callback/`` in the
+"Authorized redirect URI" field. You can fill multiple URLs, one for each test
+domain. After creating the Client ID you will find all details for the Django
+configuration on this page.
 
-Users that login using the app will be presented a consent form. For this to work additional information is required. Under "APIs & auth" go to "Consent screen" and at least provide an email and product name.
+Users that login using the app will be presented a consent form. For this to
+work additional information is required. Under "APIs & auth" go to
+"Consent screen" and at least provide an email and product name.
 
 
 Django configuration
@@ -453,16 +506,24 @@ Fill in the form as follows:
 * Secret key, is called "Client secret" by Google
 * Key, is not needed, leave blank.
 
+Optionally, you can specify the scope to use as follows:
 
-Optionally, you can specify the scope to use as follows::
+.. code-block:: python
 
-    SOCIALACCOUNT_PROVIDERS = \
-        { 'google':
-            { 'SCOPE': ['profile', 'email'],
-              'AUTH_PARAMS': { 'access_type': 'online' } }}
+    SOCIALACCOUNT_PROVIDERS = {
+        'google': {
+            'SCOPE': [
+                'profile',
+                'email',
+            ],
+            'AUTH_PARAMS': {
+                'access_type': 'online',
+            }
+        }
+    }
 
-By default, `profile` scope is required, and optionally `email` scope
-depending on whether or not `SOCIALACCOUNT_QUERY_EMAIL` is enabled.
+By default, ``profile`` scope is required, and optionally ``email`` scope
+depending on whether or not ``SOCIALACCOUNT_QUERY_EMAIL`` is enabled.
 
 
 Instagram
@@ -476,14 +537,13 @@ Development callback URL
 
 
 Kakao
----------
+-----
 
 App registration (get your key here)
     https://developers.kakao.com/apps
 
 Development callback URL
     http://localhost:8000/accounts/kakao/login/callback/
-
 
 
 Line
@@ -500,33 +560,41 @@ LinkedIn
 --------
 
 The LinkedIn provider comes in two flavors: OAuth 1.0
-(`allauth.socialaccount.providers.linkedin`) and OAuth 2.0
-(`allauth.socialaccount.providers.linkedin_oauth2`).
+(``allauth.socialaccount.providers.linkedin``) and OAuth 2.0
+(``allauth.socialaccount.providers.linkedin_oauth2``).
 
-You can specify the scope and fields to fetch as follows::
+You can specify the scope and fields to fetch as follows:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        {'linkedin':
-          {'SCOPE': ['r_emailaddress'],
-           'PROFILE_FIELDS': ['id',
-                             'first-name',
-                             'last-name',
-                             'email-address',
-                             'picture-url',
-                             'public-profile-url']}}
+.. code-block:: python
 
-By default, `r_emailaddress` scope is required depending on whether or
-not `SOCIALACCOUNT_QUERY_EMAIL` is enabled.
+    SOCIALACCOUNT_PROVIDERS = {
+        'linkedin': {
+            'SCOPE': [
+                'r_emailaddress',
+            ],
+            'PROFILE_FIELDS': [
+                'id',
+                'first-name',
+                'last-name',
+                'email-address',
+                'picture-url',
+                'public-profile-url',
+            ]
+        }
+    }
 
-Note: if you are experiencing issues where it seems as if the scope
-has no effect you may be using an old LinkedIn app that is not
-scope enabled. Please refer to
+By default, ``r_emailaddress`` scope is required depending on whether or
+not ``SOCIALACCOUNT_QUERY_EMAIL`` is enabled.
+
+Note: if you are experiencing issues where it seems as if the scope has no
+effect you may be using an old LinkedIn app that is not scope enabled.
+Please refer to
 `https://developer.linkedin.com/forum/when-will-old-apps-have-scope-parameter-enabled`
 for more background information.
 
-Furthermore, we have experienced trouble upgrading from OAuth 1.0 to
-OAuth 2.0 using the same app. Attempting to do so resulted in a weird
-error message when fetching the access token::
+Furthermore, we have experienced trouble upgrading from OAuth 1.0 to OAuth 2.0
+using the same app. Attempting to do so resulted in a weird error message when
+fetching the access token::
 
     missing required parameters, includes an invalid parameter value, parameter more then once. : Unable to retrieve access token : authorization code not found
 
@@ -536,8 +604,9 @@ App registration (get your key and secret here)
 Development callback URL
     Leave the OAuth redirect URL empty.
 
+
 Naver
----------
+-----
 
 App registration (get your key and secret here)
     https://developers.naver.com/appinfo
@@ -559,29 +628,34 @@ Development callback URL
 OpenID
 ------
 
-The OpenID provider does not require any settings per se. However, a
-typical OpenID login page presents the user with a predefined list of
-OpenID providers and allows the user to input their own OpenID identity
-URL in case their provider is not listed by default. The list of
-providers displayed by the builtin templates can be configured as
-follows::
+The OpenID provider does not require any settings per se. However, a typical
+OpenID login page presents the user with a predefined list of OpenID providers
+and allows the user to input their own OpenID identity URL in case their
+provider is not listed by default. The list of providers displayed by the
+builtin templates can be configured as follows:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        { 'openid':
-            { 'SERVERS':
-                [dict(id='yahoo',
-                      name='Yahoo',
-                      openid_url='http://me.yahoo.com'),
-                 dict(id='hyves',
-                      name='Hyves',
-                      openid_url='http://hyves.nl'),
-                 dict(id='google',
-                      name='Google',
-                      openid_url='https://www.google.com/accounts/o8/id')]}}
+.. code-block:: python
 
+    SOCIALACCOUNT_PROVIDERS = {
+        'openid': {
+            'SERVERS': [
+                dict(id='yahoo',
+                     name='Yahoo',
+                     openid_url='http://me.yahoo.com'),
+                dict(id='hyves',
+                     name='Hyves',
+                     openid_url='http://hyves.nl'),
+                dict(id='google',
+                     name='Google',
+                     openid_url='https://www.google.com/accounts/o8/id'),
+            ]
+        }
+    }
 
 If you want to manually include login links yourself, you can use the
-following template tag::
+following template tag:
+
+.. code-block:: python
 
     {% load socialaccount %}
     <a href="{% provider_login_url "openid" openid="https://www.google.com/accounts/o8/id" next="/success/url/" %}">Google</a>
@@ -590,39 +664,43 @@ following template tag::
 ORCID
 -----
 
-The ORCID provider should work out of the box provided that you are using the Production ORCID registry and the public API. In other settings, you will need to define the API you are using
-in your site's settings, as follows::
+The ORCID provider should work out of the box provided that you are using the
+Production ORCID registry and the public API. In other settings, you will need
+to define the API you are using in your site's settings, as follows:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        {'orcid':
-           {
-             # Base domain of the API. Default value: 'orcid.org', for the production API
-            'BASE_DOMAIN':'sandbox.orcid.org', # for the sandbox API
-             # Member API or Public API? Default: False (for the public API)
-             'MEMBER_API': True, # for the member API
-           }
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'orcid': {
+            # Base domain of the API. Default value: 'orcid.org', for the production API
+            'BASE_DOMAIN':'sandbox.orcid.org',  # for the sandbox API
+            # Member API or Public API? Default: False (for the public API)
+            'MEMBER_API': True,  # for the member API
         }
+    }
 
 
 Paypal
 ------
 
-The following Paypal settings are available::
+The following Paypal settings are available:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        {'paypal':
-           {'SCOPE': ['openid', 'email'],
-            'MODE': 'live'}}
+.. code-block:: python
 
+    SOCIALACCOUNT_PROVIDERS = {
+        'paypal': {
+            'SCOPE': ['openid', 'email'],
+            'MODE': 'live',
+        }
+    }
 
-SCOPE
+SCOPE:
+    In the Paypal developer site, you must also check the required attributes
+    for your application. For a full list of scope options, see
+    https://developer.paypal.com/docs/integration/direct/identity/attributes/
 
-In the Paypal developer site, you must also check the required attributes for your application.
-For a full list of scope options, see https://developer.paypal.com/docs/integration/direct/identity/attributes/
-
-MODE
-
-Either `live` or `test`. Set to test to use the Paypal sandbox.
+MODE:
+    Either `live` or `test`. Set to test to use the Paypal sandbox.
 
 App registration (get your key and secret here)
     https://developer.paypal.com/webapps/developer/applications/myapps
@@ -639,23 +717,32 @@ Note: Mozilla Persona will be shut down on November 30th 2016. See
 for details.
 
 Mozilla Persona requires one setting, the "AUDIENCE" which needs to be the
-hardcoded hostname and port of your website. See https://developer.mozilla.org/en-US/Persona/Security_Considerations#Explicitly_specify_the_audience_parameter for more
-information why this needs to be set explicitly and can't be derived from
-user provided data::
+hardcoded hostname and port of your website. See
+https://developer.mozilla.org/en-US/Persona/Security_Considerations#Explicitly_specify_the_audience_parameter
+for more information why this needs to be set explicitly and can't be derived
+from user provided data:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        { 'persona':
-            { 'AUDIENCE': 'https://www.example.com' } }
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'persona': {
+            'AUDIENCE': 'https://www.example.com',
+        }
+    }
 
 
-The optional `REQUEST_PARAMETERS` dictionary contains parameters that are
-passed as is to the `navigator.id.request()` method to influence the
-look and feel of the Persona dialog::
+The optional ``REQUEST_PARAMETERS`` dictionary contains parameters that are
+passed as is to the ``navigator.id.request()`` method to influence the
+look and feel of the Persona dialog:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        { 'persona':
-            { 'AUDIENCE': 'https://www.example.com',
-              'REQUEST_PARAMETERS': {'siteName': 'Example' } } }
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'persona': {
+            'AUDIENCE': 'https://www.example.com',
+            'REQUEST_PARAMETERS': {'siteName': 'Example'},
+        }
+    }
 
 
 Pinterest
@@ -665,22 +752,27 @@ The Pinterest OAuth2 documentation:
 
     https://developers.pinterest.com/docs/api/overview/#authentication
 
-You can optionally specify additional permissions to use. If no `SCOPE` value
-is set, the Pinterest provider will use `read_public` by default.::
+You can optionally specify additional permissions to use. If no ``SCOPE``
+value is set, the Pinterest provider will use ``read_public`` by default.
+
+.. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
         'pinterest': {
-            'SCOPE': ['read_public', 'read_relationships']
+            'SCOPE': [
+                'read_public',
+                'read_relationships',
+            ]
         }
     }
 
-SCOPE
-
-For a full list of scope options, see https://developers.pinterest.com/docs/api/overview/#scopes
+SCOPE:
+    For a full list of scope options, see
+    https://developers.pinterest.com/docs/api/overview/#scopes
 
 
 Reddit
--------
+------
 
 App registration (get your key and secret here)
     https://www.reddit.com/prefs/apps/
@@ -691,17 +783,19 @@ Development callback URL
 By default, access to Reddit is temporary. You can specify the `duration`
 auth parameter to make it `permanent`.
 
-You can optionally specify additional permissions to use. If no `SCOPE` value
-is set, the Reddit provider will use `identity` by default.
+You can optionally specify additional permissions to use. If no ``SCOPE``
+value is set, the Reddit provider will use ``identity`` by default.
 
 In addition, you should override your user agent to comply with Reddit's API
 rules, and specify something in the format
-`<platform>:<app ID>:<version string> (by /u/<reddit username>)`. Otherwise,
-you will risk additional rate limiting in your application.::
+``<platform>:<app ID>:<version string> (by /u/<reddit username>)``. Otherwise,
+you will risk additional rate limiting in your application.
+
+.. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
         'reddit': {
-            'AUTH_PARAMS': { 'duration': 'permanent' },
+            'AUTH_PARAMS': {'duration': 'permanent'},
             'SCOPE': ['identity', 'submit'],
             'USER_AGENT': 'django:myappid:1.0 (by /u/yourredditname)',
         }
@@ -716,18 +810,21 @@ example, for a shop `petstore.myshopify.com`, use this::
 
     /accounts/shopify/login/?shop=petstore
 
-You can create login URLs like these as follows::
+You can create login URLs like these as follows:
+
+.. code-block:: python
 
     {% provider_login_url "shopify" shop="petstore" %}
 
-For setting up authentication in your app, use this url as your `App URL` (if your server runs at
-localhost:8000)::
+For setting up authentication in your app, use this url as your `App URL`
+(if your server runs at localhost:8000)::
 
     http://localhost:8000/accounts/shopify/login/
 
 And set `Redirection URL` to::
 
     http://localhost:8000/accounts/shopify/login/callback/
+
 
 Slack
 -----
@@ -741,11 +838,11 @@ Development callback URL
 API documentation
     https://api.slack.com/docs/sign-in-with-slack
 
+
 SoundCloud
 ----------
 
-SoundCloud allows you to choose between OAuth1 and OAuth2. Choose the
-latter.
+SoundCloud allows you to choose between OAuth1 and OAuth2. Choose the latter.
 
 App registration (get your key and secret here)
     http://soundcloud.com/you/apps/new
@@ -757,20 +854,22 @@ Development callback URL
 Stack Exchange
 --------------
 
-Register your OAuth2 app over at
-`http://stackapps.com/apps/oauth/register`.  Do not enable "Client
-Side Flow". For local development you can simply use "localhost" for
-the OAuth domain.
+Register your OAuth2 app over at `http://stackapps.com/apps/oauth/register`.
+Do not enable "Client Side Flow". For local development you can simply use
+"localhost" for the OAuth domain.
 
 As for all providers, provider specific data is stored in
-`SocialAccount.extra_data`. For Stack Exchange we need to choose what
-data to store there by choosing the Stack Exchange site (e.g. Stack
-Overflow, or Server Fault). This can be controlled by means of the
-`SITE` setting::
+``SocialAccount.extra_data``. For Stack Exchange we need to choose what data to
+store there by choosing the Stack Exchange site (e.g. Stack Overflow, or
+Server Fault). This can be controlled by means of the ``SITE`` setting:
 
-    SOCIALACCOUNT_PROVIDERS = \
-        { 'stackexchange':
-            { 'SITE': 'stackoverflow' } }
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'stackexchange': {
+            'SITE': 'stackoverflow',
+        }
+    }
 
 
 Stripe
@@ -827,7 +926,6 @@ in the admin. Add a social app on the admin page::
 
     /admin/socialaccount/socialapp/
 
-
 Use the twitter keys tab of your application to fill in the form. It's located::
 
     https://apps.twitter.com/app/{{yourappid}}/keys
@@ -849,11 +947,11 @@ App registration
 
     https://untappd.com/api/register?register=new
 
-In the app creation form fill in the development callback URL. E.g.::
+In the app creation form fill in the development callback URL, e.g.::
 
     http://127.0.0.1:8000/accounts/untappd/login/callback/
 
-For production, make it your production host. E.g.::
+For production, make it your production host, e.g.::
 
    http://yoursite.com/accounts/untappd/login/callback/
 
@@ -895,7 +993,7 @@ Windows Live
 ------------
 
 The Windows Live provider currently does not use any settings in
-`SOCIALACCOUNT_PROVIDERS`.
+``SOCIALACCOUNT_PROVIDERS``.
 
 App registration (get your key and secret here)
     https://apps.dev.microsoft.com/#/appList
@@ -907,12 +1005,11 @@ Development callback URL
 Weibo
 -----
 
-Register your OAuth2 app over at
-`http://open.weibo.com/apps`. Unfortunately, Weibo does not allow for
-specifying a port number in the authorization callback URL. So for
-development purposes you have to use a callback url of the form
-`http://127.0.0.1/accounts/weibo/login/callback/` and run `runserver
-127.0.0.1:80`.
+Register your OAuth2 app over at `http://open.weibo.com/apps`. Unfortunately,
+Weibo does not allow for specifying a port number in the authorization
+callback URL. So for development purposes you have to use a callback url of
+the form `http://127.0.0.1/accounts/weibo/login/callback/` and run
+`runserver 127.0.0.1:80`.
 
 
 Weixin
@@ -922,19 +1019,20 @@ The Weixin OAuth2 documentation:
 
     https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316505&token=&lang=zh_CN
 
-Weixin supports two kinds of oauth2 authorization, one for open
-platform and one for media platform, AUTHORIZE_URL is the only
-difference between them, you can specify AUTHORIZE_URL in setting, If
-no 'AUTHORIZE_URL' value is set, will support open platform by
-default, which value is
-'https://open.weixin.qq.com/connect/qrconnect'.
+Weixin supports two kinds of oauth2 authorization, one for open platform and
+one for media platform, AUTHORIZE_URL is the only difference between them, you
+can specify ``AUTHORIZE_URL`` in setting, If no ``AUTHORIZE_URL`` value is set
+will support open platform by default, which value is
+`https://open.weixin.qq.com/connect/qrconnect`.
 
-You can optionally specify additional scope to use. If no `SCOPE` value
-is set, will use `snsapi_login` by default.::
+You can optionally specify additional scope to use. If no ``SCOPE`` value
+is set, will use ``snsapi_login`` by default.
+
+.. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
         'weixin': {
-            'AUTHORIZE_URL': 'https://open.weixin.qq.com/connect/oauth2/authorize', # for media platform
+            'AUTHORIZE_URL': 'https://open.weixin.qq.com/connect/oauth2/authorize',  # for media platform
         }
     }
 


### PR DESCRIPTION
When a developer needs to have email and email (confirm) the second email appears after passwords. This is because email (confirm) is declared in BaseSignupForm's ``__init__`` method while passwords in SignupForm are class methods. The solution is to place password declarations in SignupForm's ``__init__`` method.