### PR TITLE
Drop Django 1.4/Python 2.6 compatibility hacks

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import warnings
+from importlib import import_module
 
 from django import forms
 from django.core import exceptions
@@ -22,11 +23,6 @@ from .utils import (perform_login, setup_user_email, url_str_to_user_pk,
 from .app_settings import AuthenticationMethod
 from . import app_settings
 from .adapter import get_adapter
-
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
 
 
 class PasswordVerificationMixin(object):

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -1,10 +1,4 @@
 from datetime import timedelta
-try:
-    from django.utils.timezone import now
-except ImportError:
-    from datetime import datetime
-    now = datetime.now
-
 from django.contrib import messages
 from django.db import models
 from django.db.models import Q
@@ -13,6 +7,7 @@ from django.http import HttpResponseRedirect
 from django.utils import six
 from django.utils.http import urlencode
 from django.utils.http import int_to_base36, base36_to_int
+from django.utils.timezone import now
 from django.core.exceptions import ValidationError
 
 from allauth.compat import OrderedDict

--- a/allauth/compat.py
+++ b/allauth/compat.py
@@ -29,11 +29,6 @@ try:
 except ImportError:
     from urlparse import parse_qsl, parse_qs, urlparse, urlunparse  # noqa
 
-try:
-    import importlib
-except ImportError:
-    from django.utils import importlib  # noqa
-
 if django.VERSION >= (1, 9, 0):
     from django.contrib.auth.password_validation import validate_password
 else:

--- a/allauth/socialaccount/providers/__init__.py
+++ b/allauth/socialaccount/providers/__init__.py
@@ -1,8 +1,8 @@
+import importlib
+
 from collections import OrderedDict
 
 from django.conf import settings
-
-from allauth.compat import importlib
 
 
 class ProviderRegistry(object):

--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -2,16 +2,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from importlib import import_module
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.core import mail
-
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
+from requests.exceptions import HTTPError
 
 from allauth.compat import reverse
 from allauth.socialaccount.tests import OAuth2TestsMixin
@@ -21,8 +19,6 @@ from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.tests import MockedResponse, TestCase, patch
 from allauth.account.signals import user_signed_up
 from allauth.account.adapter import get_adapter
-
-from requests.exceptions import HTTPError
 
 from .provider import GoogleProvider
 

--- a/allauth/urls.py
+++ b/allauth/urls.py
@@ -1,5 +1,5 @@
+from importlib import import_module
 from django.conf.urls import url, include
-from allauth.compat import importlib
 
 from allauth.socialaccount import providers
 
@@ -12,7 +12,7 @@ if app_settings.SOCIALACCOUNT_ENABLED:
 
 for provider in providers.registry.get_list():
     try:
-        prov_mod = importlib.import_module(provider.get_package() + '.urls')
+        prov_mod = import_module(provider.get_package() + '.urls')
     except ImportError:
         continue
     prov_urlpatterns = getattr(prov_mod, 'urlpatterns', None)

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.validators import validate_email, ValidationError
+from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.db.models import FieldDoesNotExist, FileField
 from django.db.models.fields import (DateTimeField, DateField,
@@ -134,7 +135,7 @@ def email_address_exists(email, exclude_user=None):
             users = get_user_model().objects
             if exclude_user:
                 users = users.exclude(pk=exclude_user.pk)
-            ret = users.filter(**{email_field+'__iexact': email}).exists()
+            ret = users.filter(**{email_field + '__iexact': email}).exists()
     return ret
 
 
@@ -151,27 +152,6 @@ def import_callable(path_or_callable):
     else:
         ret = path_or_callable
     return ret
-
-
-try:
-    from django.contrib.auth import get_user_model
-except ImportError:
-    # To keep compatibility with Django 1.4
-    def get_user_model():
-        from . import app_settings
-        from django.db.models import get_model
-
-        try:
-            app_label, model_name = app_settings.USER_MODEL.split('.')
-        except ValueError:
-            raise ImproperlyConfigured("AUTH_USER_MODEL must be of the"
-                                       " form 'app_label.model_name'")
-        user_model = get_model(app_label, model_name)
-        if user_model is None:
-            raise ImproperlyConfigured("AUTH_USER_MODEL refers to model"
-                                       " '%s' that has not been installed"
-                                       % app_settings.USER_MODEL)
-        return user_model
 
 
 def get_current_site(request=None):

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -1,6 +1,7 @@
 import random
 import string
 import base64
+import importlib
 import re
 import unicodedata
 import json
@@ -22,7 +23,7 @@ try:
     from django.utils.encoding import force_text, force_bytes
 except ImportError:
     from django.utils.encoding import force_unicode as force_text
-from allauth.compat import importlib, reverse, NoReverseMatch
+from allauth.compat import reverse, NoReverseMatch
 
 
 # Magic number 7: if you run into collisions with this number, then you are


### PR DESCRIPTION
Also, @pennersr any thoughts on dropping Django 1.7 compatibility? It's no longer supported upstream, and Django 1.9 support ends in April.