### PR TITLE
Fix local development without https.

### DIFF
--- a/allauth/socialaccount/providers/amazon/views.py
+++ b/allauth/socialaccount/providers/amazon/views.py
@@ -15,7 +15,7 @@ class AmazonOAuth2Adapter(OAuth2Adapter):
     authorize_url = 'http://www.amazon.com/ap/oa'
     profile_url = 'https://www.amazon.com/ap/user/profile'
     supports_state = False
-    redirect_uri_protocol = 'https'
+    redirect_uri_protocol = None
 
     def complete_login(self, request, app, token, **kwargs):
         response = requests.get(

--- a/allauth/socialaccount/providers/dropbox_oauth2/views.py
+++ b/allauth/socialaccount/providers/dropbox_oauth2/views.py
@@ -14,7 +14,7 @@ class DropboxOAuth2Adapter(OAuth2Adapter):
     access_token_url = 'https://api.dropbox.com/1/oauth2/token'
     authorize_url = 'https://www.dropbox.com/1/oauth2/authorize'
     profile_url = 'https://api.dropbox.com/1/account/info'
-    redirect_uri_protocol = 'https'
+    redirect_uri_protocol = None
 
     def complete_login(self, request, app, token, **kwargs):
         extra_data = requests.get(self.profile_url, params={


### PR DESCRIPTION
https is forced even for local development. A change was made about a year ago that seems to have introduced this behavior.

https://github.com/pennersr/django-allauth/commit/4032ad85e517c3e38b1ad809375554d61f78bee6