### PR TITLE
Build latest docs automatically on RTD for successful builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,12 @@ script:
 after_success:
   - coverage report
   - coveralls
+notifications:
+  webhooks:
+    urls:
+      - https://readthedocs.org/build/django-allauth
+    on_start: never
+    on_cancel: never
+    on_error: never
+    on_failure: never
+    on_success: always


### PR DESCRIPTION
Adds a webhook configuration to the Travis config to trigger building [the latest docs](https://django-allauth.readthedocs.io/en/latest/) on ReadTheDocs.org.

This should work out-of-the-box. If not please check the [docs configuration on RTD](https://readthedocs.org/dashboard/django-allauth/version/latest/).

Background Reading
-------------------
- http://read-the-docs.readthedocs.io/en/latest/webhooks.html#others
- https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications

Addresses https://github.com/pennersr/django-allauth/pull/1609#issuecomment-279645264.