### PR TITLE
Raise exception if Douban API return invalid data

### DIFF
--- a/allauth/socialaccount/providers/douban/provider.py
+++ b/allauth/socialaccount/providers/douban/provider.py
@@ -24,8 +24,22 @@ class DoubanProvider(OAuth2Provider):
         return data['id']
 
     def extract_common_fields(self, data):
-        return dict(username=data.get('id'),
-                    name=data.get('name'))
+        """
+        Extract data from profile json to populate user instance.
+
+        In Douban profile API:
+
+        - id: a digital string, will never change
+        - uid: defaults to id, but can be changed once, used in profile url, like slug
+        - name: display name, can be changed every 30 days
+
+        So we should use `id` as username here, other than `uid`.
+        Also use `name` as `first_name` for displaying purpose.
+        """
+        return {
+            'username': data['id'],
+            'first_name': data.get('name', ''),
+        }
 
 
 providers.registry.register(DoubanProvider)

--- a/allauth/socialaccount/providers/douban/views.py
+++ b/allauth/socialaccount/providers/douban/views.py
@@ -1,7 +1,5 @@
-import requests
-
 from django.utils.translation import ugettext as _
-
+import requests
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,

--- a/allauth/socialaccount/providers/douban/views.py
+++ b/allauth/socialaccount/providers/douban/views.py
@@ -1,5 +1,7 @@
 import requests
 
+from django.utils.translation import ugettext as _
+
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
@@ -7,6 +9,7 @@ from allauth.socialaccount.providers.oauth2.views import (
 )
 
 from .provider import DoubanProvider
+from ..base import ProviderException
 
 
 class DoubanOAuth2Adapter(OAuth2Adapter):
@@ -19,6 +22,19 @@ class DoubanOAuth2Adapter(OAuth2Adapter):
         headers = {'Authorization': 'Bearer %s' % token.token}
         resp = requests.get(self.profile_url, headers=headers)
         extra_data = resp.json()
+        """
+        Douban may return data like this:
+
+            {
+                'code': 128,
+                'request': 'GET /v2/user/~me',
+                'msg': 'user_is_locked:53358092'
+            }
+
+        """
+        if 'id' not in extra_data:
+            msg = extra_data.get('msg', _('Invalid profile data'))
+            raise ProviderException(msg)
         return self.get_provider().sociallogin_from_response(
             request, extra_data)
 


### PR DESCRIPTION
1. Douban profile API may return invalid data. Raise ProviderException for django-allauth to catch and display.
2. Return right data in extract_common_fields