### PR TITLE
French translation: fix superflous char

### DIFF
--- a/allauth/locale/fr/LC_MESSAGES/django.po
+++ b/allauth/locale/fr/LC_MESSAGES/django.po
@@ -513,7 +513,7 @@ msgid ""
 msgstr ""
 "Merci d'ouvrir une session avec l'un de vos comptes sociaux. Vous pouvez "
 "aussi <a href=\"%(signup_url)s\">ouvrir un compte</a> %(site_name)s puis "
-"vous connecter ci-dessous :"
+"vous connecter ci-dessous :"
 
 #: templates/account/login.html:25
 msgid "or"


### PR DESCRIPTION
There's a spurious character at the end of that sentence, it should not exist.