### PR TITLE
LOGIN_REDIRECT_URL not ACCOUNT_REDIRECT_URL

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,7 +9,7 @@ ACCOUNT_ADAPTER (="allauth.account.adapter.DefaultAccountAdapter")
 
 ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS (=True)
   The default behaviour is to redirect authenticated users to
-  `ACCOUNT_LOGIN_REDIRECT_URL` when they try accessing login/signup pages.
+  `LOGIN_REDIRECT_URL` when they try accessing login/signup pages.
 
   By changing this setting to `False`, logged in users will not be redirected when
   they access login/signup pages.


### PR DESCRIPTION
I believe this was a case of forgetting to update the docs. 

But i discovered that the correct variable to redirect logged in users from the default `/accounts/profile` url is `LOGIN_REDIRECT_URL` not `ACCOUNT_LOGIN_REDIRECT_URL` as stated in the docs.

Also thanks for this great library. It's a Life saver and would always be a life saver for authentication in django apps 👍 