### PR TITLE
[Bitbucket OAuth2] Extract username for common fields

### DIFF
--- a/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
@@ -29,8 +29,9 @@ class BitbucketOAuth2Provider(OAuth2Provider):
         return data['username']
 
     def extract_common_fields(self, data):
-        return dict(name=data.get('display_name'),
-                    email=data.get('email'))
+        return dict(email=data.get('email'),
+                    username=data.get('username'),
+                    name = data.get('display_name'))
 
 
 provider_classes = [BitbucketOAuth2Provider]


### PR DESCRIPTION
It looks like `username` was (intentionally or) unintentionally left out in the extraction of common fields. Interestingly, this fields is extracted in both the [Bitbucket implementation](https://github.com/pennersr/django-allauth/blob/master/allauth/socialaccount/providers/bitbucket/provider.py#L30) and the two major competitors GitHub and GitLab. The `username` field is actually populated in the `extra_data` for Bitbucket_OAuth2, so this probably has been overlooked in the past only.

This PR adds the missing `username` field extraction, and aligns the keyword argument order with the 3 other social account provider implementations, `GitHubProvider`, `GitLabProvider` and `BitbucketProvider`.