### PR TITLE
[Docs:Showcase] Remove discontinued sites, add Painless, apply sort order

### DIFF
--- a/docs/showcase.rst
+++ b/docs/showcase.rst
@@ -5,22 +5,18 @@ Here are some sites that have `django-allauth` up and running:
 
 - `Drakdoo: Bitcoin trading app <http://www.drakdoo.com>`_
 - `Flatmate Rooms: UK flatshare <https://www.flatmaterooms.co.uk>`_
-- http://www.q-dance.com
-- http://officecheese.com
-- http://www.charityblossom.org
-- http://www.superreceptionist.in
-- http://kwatsi.com
-- http://www.smartgoalapp.com
-- http://healthifyme.com
-- http://www.burufly.com
-- http://eatwith.com
-- http://en.globalquiz.org
-- http://decommentariis.net
-- http://www.heapsortjobs.com
-- http://demo.organice.io
-- https://pizzacharts.com/
-- http://www.sendcloud.nl
+- `Organice Demo <https://demo.organice.io>`_
+- `Painless Cloud <https://painless.cloud>`_
 - http://www.awesound.com
+- http://www.burufly.com
+- http://www.charityblossom.org
+- http://decommentariis.net
+- https://www.eatwith.com
+- http://en.globalquiz.org
+- http://www.heapsortjobs.com
+- https://pizzacharts.com
+- http://www.q-dance.com
+- https://www.sendcloud.nl
 
 If your site also uses `django-allauth` and you want it to show up in this list
 please mail me (raymond.penners@intenct.nl) a link, and I will add it for you.


### PR DESCRIPTION
Some showcases are either not using allauth anymore, or the sites have been discontinued.

- officecheese.com - _discontinued  (redirects to agency website)_
- superreceptionist.in - _uses python social-auth_
- kwatsi.com - _now a static website, no signup / no sign-in_
- smartgoalapp.com - _discontinued (domain parked)_
- healthifyme.com - _have stopped using allauth, site now made using [webflow](http://www.webflow.com)_

**NOTE:** Some other URLs of the list time out when trying to access them, but they cannot be confirmed to be offline or discontinued.

PR Details
------------
1. Remove discontinued sites, scams, advertisement
1. Add Painless Cloud
1. Apply alphabetical sort order (names first, then urls)