### PR TITLE
Add a signal for social account updates

### DIFF
--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -109,10 +109,18 @@ def _add_social_account(request, sociallogin):
             level = messages.ERROR
             message = 'socialaccount/messages/account_connected_other.txt'
         else:
-            # This account is already connected -- let's play along
-            # and render the standard "account connected" message
-            # without actually doing anything.
-            pass
+            # This account is already connected -- we give the opportunity
+            # for customized behaviour through use of a signal. If not
+            # implemented, we render the standard "account connected"
+            # message without actually doing anything.
+            try:
+                signals.social_account_updated.send(
+                    sender=SocialLogin,
+                    request=request,
+                    sociallogin=sociallogin
+                )
+            except ImmediateHttpResponse as e:
+                return e.response
     else:
         # New account, let's connect
         sociallogin.connect(request, request.user)

--- a/allauth/socialaccount/signals.py
+++ b/allauth/socialaccount/signals.py
@@ -10,6 +10,11 @@ pre_social_login = Signal(providing_args=["request", "sociallogin"])
 # Sent after a user connects a social account to a their local account.
 social_account_added = Signal(providing_args=["request", "sociallogin"])
 
+# Sent after a user connects an already existing social account to a
+# their local account. The social account will have an updated token and
+# refreshed extra_data.
+social_account_updated = Signal(providing_args=["request", "sociallogin"])
+
 # Sent after a user disconnects a social account from their local
 # account.
 social_account_removed = Signal(providing_args=["request", "socialaccount"])


### PR DESCRIPTION
The new signal `social_account_updated` fires when a social login
`connect` flow is completed but the social account already exists
for the currently authenticated user. This allows customization
of how this scenario is handled.