### PR TITLE
handle validators being a list

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -296,10 +296,11 @@ class AppSettings(object):
         from django.core.exceptions import ImproperlyConfigured
         from allauth.utils import import_attribute
         from allauth.utils import get_user_model
-
-        path = self._setting('USERNAME_VALIDATORS', None)
-        if path:
-            ret = import_attribute(path)
+        ret = []
+        validators = self._setting('USERNAME_VALIDATORS', None)
+        if validators:
+            for path in validators:
+                ret.append(import_attribute(path))
             if not isinstance(ret, list):
                 raise ImproperlyConfigured(
                     'ACCOUNT_USERNAME_VALIDATORS is expected to be a list')
@@ -307,8 +308,6 @@ class AppSettings(object):
             if self.USER_MODEL_USERNAME_FIELD is not None:
                 ret = get_user_model()._meta.get_field(
                     self.USER_MODEL_USERNAME_FIELD).validators
-            else:
-                ret = []
         return ret
 
 


### PR DESCRIPTION
This fixes a bug when setting USERNAME_VALIDATORS.

USERNAME_VALIDATORS is a list of paths which fails when passed to import_attribute() - so instead pass each path in the list to import_attribute().