### PR TITLE
Error in documentation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -160,7 +160,7 @@ following adapter methods:
 
   - `get_logout_redirect_url(self, request)`
 
-  - `get_email_confirmation_redirect_url(self, request)`
+  - `get_email_confirmation_url(self, request)`
 
 - `allauth.socialaccount.adapter.DefaultSocialAccountAdapter`:
 


### PR DESCRIPTION
As I can find out "get_email_confirmation_redirect_url" is wrong name for this method. The correct name is get_email_confirmation_url
This method is in allauth/account/adapter.py.