### PR TITLE
UX improvement: Remove first mention of domain name in emails

### DIFF
--- a/allauth/templates/account/email/email_confirmation_message.txt
+++ b/allauth/templates/account/email/email_confirmation_message.txt
@@ -1,6 +1,6 @@
 {% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
 
-You're receiving this e-mail because user {{ user_display }} at {{ site_domain }} has given yours as an e-mail address to connect their account.
+You're receiving this e-mail because user {{ user_display }} has given yours as an e-mail address to connect their account.
 
 To confirm this is correct, go to {{ activate_url }}
 {% endblocktrans %}{% endautoescape %}

--- a/allauth/templates/account/email/password_reset_key_message.txt
+++ b/allauth/templates/account/email/password_reset_key_message.txt
@@ -1,6 +1,6 @@
 {% load i18n %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
 
-You're receiving this e-mail because you or someone else has requested a password for your user account at {{ site_domain }}.
+You're receiving this e-mail because you or someone else has requested a password for your user account.
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
 
 {{ password_reset_url }}


### PR DESCRIPTION
Based on my limited UX testing, it seems that users don't read the confirmation and password reset emails. No surprise there. They just try to click the first link they see.

Because the first link they see is the domain name, I have seen them try to click that link, only to be confused that the email confirmation apparently did not work.

This commit makes the first (and biggest) link the confirmation link. Later on in the email, the site domain is displayed.

I realise that developers can override these templates, but why not make the UX a little bit nicer by default?