### PR TITLE
Form code literals in RST docs correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ verified. So, e-mail verification needs to be present in both worlds.
 
 Integrating both worlds is quite a tedious process. It is definitely
 not a matter of simply adding one social authentication app, and one
-local account registration app to your `INSTALLED_APPS` list.
+local account registration app to your ``INSTALLED_APPS`` list.
 
 This is the reason this project got started -- to offer a fully
 integrated authentication app that allows for both local and social

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -14,7 +14,7 @@ What is provided is the following:
 
 - The protocol to be used for generating links (e.g. password
   forgotten) for e-mails is configurable by means of the
-  `ACCOUNT_DEFAULT_HTTP_PROTOCOL` setting.
+  ``ACCOUNT_DEFAULT_HTTP_PROTOCOL`` setting.
 
 - Automatically switching to HTTPS is built-in for OAuth providers
   that require this (e.g. Amazon). However, remembering the original
@@ -26,21 +26,21 @@ Custom User Models
 ------------------
 
 If you use a custom user model you need to specify what field
-represents the `username`, if any. Here, `username` really refers to
+represents the ``username``, if any. Here, ``username`` really refers to
 the field representing the nick name the user uses to login, and not
 some unique identifier (possibly including an e-mail address) as is
-the case for Django's `AbstractBaseUser.USERNAME_FIELD`.
+the case for Django's ``AbstractBaseUser.USERNAME_FIELD``.
 
-Meaning, if your custom user model does not have a `username` field
+Meaning, if your custom user model does not have a ``username`` field
 (again, not to be mistaken with an e-mail address or user id), you
-will need to set `ACCOUNT_USER_MODEL_USERNAME_FIELD` to `None`. This
-will disable username related functionality in `allauth`. Remember to
-also to set `ACCOUNT_USERNAME_REQUIRED` to `False`.
+will need to set ``ACCOUNT_USER_MODEL_USERNAME_FIELD`` to ``None``. This
+will disable username related functionality in ``allauth``. Remember to
+also to set ``ACCOUNT_USERNAME_REQUIRED`` to ``False``.
 
-Similarly, you will need to set `ACCOUNT_USER_MODEL_EMAIL_FIELD` to
-`None`, or the proper field (if other than `email`).
+Similarly, you will need to set ``ACCOUNT_USER_MODEL_EMAIL_FIELD`` to
+``None``, or the proper field (if other than ``email``).
 
-For example, if you want to use a custom user model that has `email`
+For example, if you want to use a custom user model that has ``email``
 as the identifying field, and you don't want to collect usernames, you
 need the following in your settings.py::
 
@@ -56,47 +56,47 @@ Creating and Populating User instances
 The following adapter methods can be used to intervene in how User
 instances are created, and populated with data
 
-- `allauth.account.adapter.DefaultAccountAdapter`:
+- ``allauth.account.adapter.DefaultAccountAdapter``:
 
-  - `is_open_for_signup(self, request)`: The default function
-    returns `True`. You can override this method by returning `False`
+  - ``is_open_for_signup(self, request)``: The default function
+    returns ``True``. You can override this method by returning ``False``
     if you want to disable account signup.
 
-  - `new_user(self, request)`: Instantiates a new, empty `User`.
+  - ``new_user(self, request)``: Instantiates a new, empty ``User``.
 
-  - `save_user(self, request, user, form)`: Populates and saves the
-    `User` instance using information provided in the signup form.
+  - ``save_user(self, request, user, form)``: Populates and saves the
+    ``User`` instance using information provided in the signup form.
 
-  - `populate_username(self, request, user)`:
+  - ``populate_username(self, request, user)``:
     Fills in a valid username, if required and missing.  If the
     username is already present it is assumed to be valid (unique).
 
-  - `confirm_email(self, request, email_address)`: Marks the email address as
+  - ``confirm_email(self, request, email_address)``: Marks the email address as
     confirmed and saves to the db.
 
-  - `generate_unique_username(self, txts, regex=None)`: Returns a unique username
+  - ``generate_unique_username(self, txts, regex=None)``: Returns a unique username
     from the combination of strings present in txts iterable. A regex pattern
     can be passed to the method to make sure the generated username matches it.
 
-- `allauth.socialaccount.adapter.DefaultSocialAccountAdapter`:
+- ``allauth.socialaccount.adapter.DefaultSocialAccountAdapter``:
 
-  - `is_open_for_signup(self, request)`: The default function
-    returns that is the same as `ACCOUNT_ADAPTER` in `settings.py`.
-    You can override this method by returning `True`/`False`
+  - ``is_open_for_signup(self, request)``: The default function
+    returns that is the same as ``ACCOUNT_ADAPTER`` in ``settings.py``.
+    You can override this method by returning ``True``/``False``
     if you want to enable/disable socialaccount signup.
 
-  - `new_user(self, request, sociallogin)`: Instantiates a new, empty
-    `User`.
+  - ``new_user(self, request, sociallogin)``: Instantiates a new, empty
+    ``User``.
 
-  - `save_user(self, request, sociallogin, form=None)`: Populates and
-    saves the `User` instance (and related social login data). The
+  - ``save_user(self, request, sociallogin, form=None)``: Populates and
+    saves the ``User`` instance (and related social login data). The
     signup form is not available in case of auto signup.
 
-  - `populate_user(self, request, sociallogin, data)`: Hook that can
+  - ``populate_user(self, request, sociallogin, data)``: Hook that can
     be used to further populate the user instance
-    (`sociallogin.account.user`). Here, `data` is a dictionary of
-    common user properties (`first_name`, `last_name`, `email`,
-    `username`, `name`) that the provider already extracted for you.
+    (``sociallogin.account.user``). Here, ``data`` is a dictionary of
+    common user properties (``first_name``, ``last_name``, ``email``,
+    ``username``, ``name``) that the provider already extracted for you.
 
 
 Invitations
@@ -111,13 +111,13 @@ app of its own.
 
 Still, everything is in place to easily hook up any third party
 invitation app. The account adapter
-(`allauth.account.adapter.DefaultAccountAdapter`) offers the following
+(``allauth.account.adapter.DefaultAccountAdapter``) offers the following
 methods:
 
-- `is_open_for_signup(self, request)`. You can override this method to, for
+- ``is_open_for_signup(self, request)``. You can override this method to, for
   example, inspect the session to check if an invitation was accepted.
 
-- `stash_verified_email(self, request, email)`. If an invitation was
+- ``stash_verified_email(self, request, email)``. If an invitation was
   accepted by following a link in a mail, then there is no need to
   send e-mail verification mails after the signup is completed. Use
   this method to record the fact that an e-mail address was verified.
@@ -143,8 +143,8 @@ When you do provide these yourself, note that both the text and HTML
 versions of the message are sent.
 
 If this does not suit your needs, you can hook up your own custom
-mechanism by overriding the `send_mail` method of the account adapter
-(`allauth.account.adapter.DefaultAccountAdapter`).
+mechanism by overriding the ``send_mail`` method of the account adapter
+(``allauth.account.adapter.DefaultAccountAdapter``).
 
 
 Custom Redirects
@@ -154,19 +154,19 @@ If redirecting to statically configurable URLs (as specified in your
 project settings) is not flexible enough, then you can override the
 following adapter methods:
 
-- `allauth.account.adapter.DefaultAccountAdapter`:
+- ``allauth.account.adapter.DefaultAccountAdapter``:
 
-  - `get_login_redirect_url(self, request)`
+  - ``get_login_redirect_url(self, request)``
 
-  - `get_logout_redirect_url(self, request)`
+  - ``get_logout_redirect_url(self, request)``
 
-  - `get_email_confirmation_redirect_url(self, request)`
+  - ``get_email_confirmation_redirect_url(self, request)``
 
-- `allauth.socialaccount.adapter.DefaultSocialAccountAdapter`:
+- ``allauth.socialaccount.adapter.DefaultSocialAccountAdapter``:
 
-  - `get_connect_redirect_url(self, request, socialaccount)`
+  - ``get_connect_redirect_url(self, request, socialaccount)``
 
-For example, redirecting to `/accounts/<username>/` can be implemented as
+For example, redirecting to ``/accounts/<username>/`` can be implemented as
 follows::
 
     # project/settings.py:
@@ -185,16 +185,16 @@ follows::
 Messages
 --------
 
-The Django messages framework (`django.contrib.messages`) is used if
-it is listed in `settings.INSTALLED_APPS`.  All messages (as in
-`django.contrib.messages`) are configurable by overriding their
+The Django messages framework (``django.contrib.messages``) is used if
+it is listed in ``settings.INSTALLED_APPS``.  All messages (as in
+``django.contrib.messages``) are configurable by overriding their
 respective template. If you want to disable a message simply override
 the message template with a blank one.
 
 Admin
 -----
 
-The Django admin site (`django.contrib.admin`) does not use Django allauth by
+The Django admin site (``django.contrib.admin``) does not use Django allauth by
 default. Since Django admin provides a custom login view, it does not go through
 the normal Django allauth workflow.
 
@@ -203,14 +203,14 @@ the normal Django allauth workflow.
     This limitation means that Django allauth features are not applied to the
     Django admin site:
 
-    * `ACCOUNT_LOGIN_ATTEMPTS_LIMIT` and `ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT` do not
+    * ``ACCOUNT_LOGIN_ATTEMPTS_LIMIT`` and ``ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT`` do not
       protect Django’s admin login from being brute forced.
     * Any other custom workflow that overrides the Django allauth adapter's
       login method will not be applied.
 
 An easy workaround for this is to require users to login before going to the
 Django admin site's login page (note that following would need to be applied to
-every instance of `AdminSite`):
+every instance of ``AdminSite``):
 
 .. code-block:: python
 
@@ -220,7 +220,7 @@ every instance of `AdminSite`):
     admin.site.login = login_required(admin.site.login)
 
 Customizing providers
------
+---------------------
 
 When an existing provider doesn't quite meet your needs, you might find yourself
 needing to customize a provider.
@@ -229,24 +229,24 @@ This can be achieved by subclassing an existing provider and making your changes
 there. Providers are defined as django applications, so typically customizing one
 will mean creating a django application in your project, containing your customized
 urls.py, views.py and provider.py files. What behaviour you can customize is beyond
-the scope of this documentation. 
+the scope of this documentation.
 
 .. warning::
 
-    In your `provider.py` file, you will need to expose the provider class
-    by having a module level attribute called `provider_classes` with your custom
+    In your ``provider.py`` file, you will need to expose the provider class
+    by having a module level attribute called ``provider_classes`` with your custom
     classes in a list. This allows your custom provider to be registered properly
-    on the basis of the `INSTALLED_APPS` setting.
+    on the basis of the ``INSTALLED_APPS`` setting.
 
     Be sure to use a custom id property on your provider class such that its default
     URLs do not clash with the provider you are subclassing.
 
 .. code-block:: python
- 
+
     class GoogleNoDefaultScopeProvider(GoogleProvider):
         id = 'google_no_scope'
-    
+
         def get_default_scope(self):
             return []
-        
+
     provider_classes = [GoogleNoDefaultScopeProvider]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,9 +9,9 @@ ACCOUNT_ADAPTER (="allauth.account.adapter.DefaultAccountAdapter")
 
 ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS (=True)
   The default behaviour is to redirect authenticated users to
-  `LOGIN_REDIRECT_URL` when they try accessing login/signup pages.
+  ``LOGIN_REDIRECT_URL`` when they try accessing login/signup pages.
 
-  By changing this setting to `False`, logged in users will not be redirected when
+  By changing this setting to ``False``, logged in users will not be redirected when
   they access login/signup pages.
 
 ACCOUNT_AUTHENTICATION_METHOD (="username" | "email" | "username_email")
@@ -33,8 +33,8 @@ ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL (=settings.LOGIN_URL)
 
 ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL (=None)
   The URL to redirect to after a successful e-mail confirmation, in
-  case of an authenticated user. Set to `None` to use
-  `settings.LOGIN_REDIRECT_URL`.
+  case of an authenticated user. Set to ``None`` to use
+  ``settings.LOGIN_REDIRECT_URL``.
 
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS (=3)
   Determines the expiration date of email confirmation mails (# of days).
@@ -51,7 +51,7 @@ ACCOUNT_EMAIL_REQUIRED (=False)
 
 ACCOUNT_EMAIL_VERIFICATION (="optional")
   Determines the e-mail verification method during signup -- choose
-  one of `"mandatory"`, `"optional"`, or `"none"`. When set to
+  one of ``"mandatory"``, ``"optional"``, or ``"none"``. When set to
   "mandatory" the user is blocked from logging in until the email
   address is verified. Choose "optional" or "none" to allow logins
   with an unverified e-mail address. In case of "optional", the e-mail
@@ -60,7 +60,7 @@ ACCOUNT_EMAIL_VERIFICATION (="optional")
 
 ACCOUNT_EMAIL_SUBJECT_PREFIX (="[Site] ")
   Subject-line prefix to use for email messages sent. By default, the
-  name of the current `Site` (`django.contrib.sites`) is used.
+  name of the current ``Site`` (``django.contrib.sites``) is used.
 
 ACCOUNT_DEFAULT_HTTP_PROTOCOL (="http")
   The default protocol used for when generating URLs, e.g. for the
@@ -69,12 +69,12 @@ ACCOUNT_DEFAULT_HTTP_PROTOCOL (="http")
 
 ACCOUNT_FORMS (={})
   Used to override forms, for example:
-  `{'login': 'myapp.forms.LoginForm'}`
+  ``{'login': 'myapp.forms.LoginForm'}``
 
 ACCOUNT_LOGIN_ATTEMPTS_LIMIT (=5)
   Number of failed login attempts. When this number is
   exceeded, the user is prohibited from logging in for the
-  specified `ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT` seconds. Set to `None`
+  specified ``ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT`` seconds. Set to ``None``
   to disable this functionality. Important: while this protects the
   allauth login view, it does not protect Django's admin login from
   being brute forced.
@@ -85,9 +85,9 @@ ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT (=300)
 
 ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION (=False)
   The default behaviour is not log users in and to redirect them to
-  `ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL`.
+  ``ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL``.
 
-  By changing this setting to `True`, users will automatically be logged in once
+  By changing this setting to ``True``, users will automatically be logged in once
   they confirm their email address. Note however that this only works when
   confirming the email address **immediately after signing up**, assuming users
   didn't close their browser or used some sort of private browsing mode.
@@ -105,27 +105,27 @@ ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE (=False)
   `Django's session invalidation on password change <https://docs.djangoproject.com/en/1.8/topics/auth/default/#session-invalidation-on-password-change>`_.
 
 ACCOUNT_LOGIN_ON_PASSWORD_RESET (=False)
-  By changing this setting to `True`, users will automatically be logged in
+  By changing this setting to ``True``, users will automatically be logged in
   once they have reset their password. By default they are redirected to the
   password reset done page.
 
 ACCOUNT_LOGOUT_REDIRECT_URL (="/")
   The URL (or URL name) to return to after the user logs out. This is
-  the counterpart to Django's `LOGIN_REDIRECT_URL`.
+  the counterpart to Django's ``LOGIN_REDIRECT_URL``.
 
 ACCOUNT_PASSWORD_INPUT_RENDER_VALUE (=False)
-  `render_value` parameter as passed to `PasswordInput` fields.
+  ``render_value`` parameter as passed to ``PasswordInput`` fields.
 
 ACCOUNT_PRESERVE_USERNAME_CASING (=True)
   This setting determines whether the username is stored in lowercase
-  (`False`) or whether its casing is to be preserved (`True`). Note that when
-  casing is preserved, potentially expensive `__iexact` lookups are performed
-  when filter on username. For now, the default is set to `True` to maintain
+  (``False``) or whether its casing is to be preserved (``True``). Note that when
+  casing is preserved, potentially expensive ``__iexact`` lookups are performed
+  when filter on username. For now, the default is set to ``True`` to maintain
   backwards compatibility.
 
 ACCOUNT_SESSION_REMEMBER (=None)
-  Controls the life time of the session. Set to `None` to ask the user
-  ("Remember me?"), `False` to not remember, and `True` to always
+  Controls the life time of the session. Set to ``None`` to ask the user
+  ("Remember me?"), ``False`` to not remember, and ``True`` to always
   remember.
 
 ACCOUNT_SIGNUP_EMAIL_ENTER_TWICE (=False)
@@ -136,35 +136,35 @@ ACCOUNT_SIGNUP_FORM_CLASS (=None)
   A string pointing to a custom form class
   (e.g. 'myapp.forms.SignupForm') that is used during signup to ask
   the user for additional input (e.g. newsletter signup, birth
-  date). This class should implement a `def signup(self, request, user)`
+  date). This class should implement a ``def signup(self, request, user)``
   method, where user represents the newly signed up user.
 
 ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE (=True)
   When signing up, let the user type in their password twice to avoid typos.
 
 ACCOUNT_TEMPLATE_EXTENSION (="html")
-  A string defining the template extension to use, defaults to `html`.
+  A string defining the template extension to use, defaults to ``html``.
 
 ACCOUNT_USERNAME_BLACKLIST (=[])
   A list of usernames that can't be used by user.
 
 ACCOUNT_UNIQUE_EMAIL (=True)
-  Enforce uniqueness of e-mail addresses. The `emailaddress.email`
-  model field is set to `UNIQUE`. Forms prevent a user from registering
+  Enforce uniqueness of e-mail addresses. The ``emailaddress.email``
+  model field is set to ``UNIQUE``. Forms prevent a user from registering
   with or adding an additional email address if that email address is
   in use by another account.
 
-ACCOUNT_USER_DISPLAY (=a callable returning `user.username`)
-  A callable (or string of the form `'some.module.callable_name'`)
+ACCOUNT_USER_DISPLAY (=a callable returning ``user.username``)
+  A callable (or string of the form ``'some.module.callable_name'``)
   that takes a user as its only argument and returns the display name
-  of the user. The default implementation returns `user.username`.
+  of the user. The default implementation returns ``user.username``.
 
 ACCOUNT_USER_MODEL_EMAIL_FIELD (="email")
-  The name of the field containing the `email`, if any. See custom
+  The name of the field containing the ``email``, if any. See custom
   user models.
 
 ACCOUNT_USER_MODEL_USERNAME_FIELD (="username")
-  The name of the field containing the `username`, if any. See custom
+  The name of the field containing the ``username``, if any. See custom
   user models.
 
 ACCOUNT_USERNAME_MIN_LENGTH (=1)
@@ -173,12 +173,12 @@ ACCOUNT_USERNAME_MIN_LENGTH (=1)
 ACCOUNT_USERNAME_REQUIRED (=True)
   The user is required to enter a username when signing up. Note that
   the user will be asked to do so even if
-  `ACCOUNT_AUTHENTICATION_METHOD` is set to `email`. Set to `False`
+  ``ACCOUNT_AUTHENTICATION_METHOD`` is set to ``email``. Set to ``False``
   when you do not wish to prompt the user to enter a username.
 
 ACCOUNT_USERNAME_VALIDATORS (=None)
   A path
-  (`'some.module.validators.custom_username_validators'`) to a list of
+  (``'some.module.validators.custom_username_validators'``) to a list of
   custom username validators. If left unset, the validators setup
   within the user model username field are used.
 
@@ -193,7 +193,7 @@ SOCIALACCOUNT_AUTO_SIGNUP (=True)
   kick in.
 
 SOCIALACCOUNT_EMAIL_VERIFICATION (=ACCOUNT_EMAIL_VERIFICATION)
-  As `ACCOUNT_EMAIL_VERIFICATION`, but for social accounts.
+  As ``ACCOUNT_EMAIL_VERIFICATION``, but for social accounts.
 
 SOCIALACCOUNT_EMAIL_REQUIRED (=ACCOUNT_EMAIL_REQUIRED)
   The user is required to hand over an e-mail address when signing up
@@ -201,7 +201,7 @@ SOCIALACCOUNT_EMAIL_REQUIRED (=ACCOUNT_EMAIL_REQUIRED)
 
 SOCIALACCOUNT_FORMS (={})
   Used to override forms, for example:
-  `{'signup': 'myapp.forms.SignupForm'}`
+  ``{'signup': 'myapp.forms.SignupForm'}``
 
 SOCIALACCOUNT_PROVIDERS (= dict)
   Dictionary containing provider specific settings.

--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -18,7 +18,7 @@ following decorator::
 The behavior is as follows:
 
 - If the user isn't logged in, it acts identical to the
-  `login_required` decorator.
+  ``login_required`` decorator.
 
 - If the user is logged in but has no verified e-mail address, an
   e-mail verification mail is automatically resent and the user is

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -39,7 +39,7 @@ Troubleshooting
 The /accounts/ URL is giving me a 404
 *************************************
 
-There is no such URL. Try `/accounts/login/` instead.
+There is no such URL. Try ``/accounts/login/`` instead.
 
 When I attempt to login I run into a 404 on /accounts/profile/
 **************************************************************
@@ -55,7 +55,7 @@ When I sign up I run into connectivity errors (connection refused et al)
 ************************************************************************
 
 You probably have not got an e-mail (SMTP) server running on the
-machine you are developing on. Therefore, `allauth` is unable to send
+machine you are developing on. Therefore, ``allauth`` is unable to send
 verification mails.
 
 You can work around this by adding the following line to

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -139,6 +139,6 @@ In your Django root execute the command below to create your database tables::
 Now start your server, visit your admin pages (e.g. http://localhost:8000/admin/)
 and follow these steps:
 
-1. Add a `Site` for your domain, matching `settings.SITE_ID` (`django.contrib.sites` app).
-2. For each OAuth based provider, add a `Social App` (`socialaccount` app).
+1. Add a ``Site`` for your domain, matching ``settings.SITE_ID`` (``django.contrib.sites`` app).
+2. For each OAuth based provider, add a ``Social App`` (``socialaccount`` app).
 3. Fill in the site and the OAuth app credentials obtained from the provider.

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -266,7 +266,7 @@ value is set, the Edmodo provider will use ``basic`` by default:
 Eve Online
 ----------
 
-Register your application at `https://developers.eveonline.com/applications/create`.
+Register your application at ``https://developers.eveonline.com/applications/create``.
 Note that if you have ``STORE_TOKENS`` enabled (the default), you will need to
 set up your application to be able to request an OAuth scope. This means you
 will need to set it as having "CREST Access". The least obtrusive scope is
@@ -277,8 +277,8 @@ Eventbrite
 ------------------
 
 Log in and click your profile name in the top right navigation, then select
-`Account Settings`. Choose `App Management` near the bottom of the left
-navigation column. You can then click `Create A New App` on the upper left
+``Account Settings``. Choose ``App Management`` near the bottom of the left
+navigation column. You can then click ``Create A New App`` on the upper left
 corner.
 
 App registration
@@ -289,13 +289,13 @@ Fill in the form with the following link
 Development callback URL
     http://127.0.0.1:8000/accounts/eventbrite/login/callback/
 
-for both the `Application URL` and `OAuth Redirect URI`.
+for both the ``Application URL`` and ``OAuth Redirect URI``.
 
 
 Evernote
 --------
 
-Register your OAuth2 application at `https://dev.evernote.com/doc/articles/authentication.php`:
+Register your OAuth2 application at ``https://dev.evernote.com/doc/articles/authentication.php``:
 
 .. code-block:: python
 
@@ -363,30 +363,30 @@ The following Facebook settings are available:
     }
 
 METHOD:
-    Either `js_sdk` or `oauth2`. The default is `oauth2`.
+    Either ``js_sdk`` or ``oauth2``. The default is ``oauth2``.
 
 SCOPE:
-    By default, the `email` scope is required depending on whether or not
+    By default, the ``email`` scope is required depending on whether or not
     ``SOCIALACCOUNT_QUERY_EMAIL`` is enabled.
-    Apps using permissions beyond `email`, `public_profile` and `user_friends`
+    Apps using permissions beyond ``email``, ``public_profile`` and ``user_friends``
     require review by Facebook.
     See `Permissions with Facebook Login <https://developers.facebook.com/docs/facebook-login/permissions>`_
     for more information.
 
 AUTH_PARAMS:
-    Use ``AUTH_PARAMS`` to pass along other parameters to the `FB.login`
+    Use ``AUTH_PARAMS`` to pass along other parameters to the ``FB.login``
     JS SDK call.
 
 FIELDS:
-    The fields to fetch from the Graph API `/me/?fields=` endpoint.
-    For example, you could add the `'friends'` field in order to
+    The fields to fetch from the Graph API ``/me/?fields=`` endpoint.
+    For example, you could add the ``'friends'`` field in order to
     capture the user's friends that have also logged into your app using
-    Facebook (requires `'user_friends'` scope).
+    Facebook (requires ``'user_friends'`` scope).
 
 EXCHANGE_TOKEN:
     The JS SDK returns a short-lived token suitable for client-side use. Set
     ``EXCHANGE_TOKEN = True`` to make a server-side request to upgrade to a
-    long-lived token before storing in the `SocialToken` record. See
+    long-lived token before storing in the ``SocialToken`` record. See
     `Expiration and Extending Tokens <https://developers.facebook.com/docs/facebook-login/access-tokens#extending>`_.
 
 LOCALE_FUNC:
@@ -418,7 +418,7 @@ VERIFIED_EMAIL:
     risk.
 
 VERSION:
-    The Facebook Graph API version to use. The default is `v2.4`.
+    The Facebook Graph API version to use. The default is ``v2.4``.
 
 App registration (get your key and secret here)
     A key and secret key can be obtained by
@@ -428,8 +428,8 @@ App registration (get your key and secret here)
     `reviewed by Facebook <https://developers.facebook.com/docs/apps/review>`_.
 
 Development callback URL
-    Leave your App Domains empty and put `http://localhost:8000` in the
-    section labeled `Website with Facebook Login`. Note that you'll need to
+    Leave your App Domains empty and put ``http://localhost:8000`` in the
+    section labeled ``Website with Facebook Login``. Note that you'll need to
     add your site's actual domain to this section once it goes live.
 
 
@@ -687,7 +687,7 @@ not ``SOCIALACCOUNT_QUERY_EMAIL`` is enabled.
 Note: if you are experiencing issues where it seems as if the scope has no
 effect you may be using an old LinkedIn app that is not scope enabled.
 Please refer to
-`https://developer.linkedin.com/forum/when-will-old-apps-have-scope-parameter-enabled`
+``https://developer.linkedin.com/forum/when-will-old-apps-have-scope-parameter-enabled``
 for more background information.
 
 Furthermore, we have experienced trouble upgrading from OAuth 1.0 to OAuth 2.0
@@ -874,7 +874,7 @@ SCOPE:
     https://developer.paypal.com/docs/integration/direct/identity/attributes/
 
 MODE:
-    Either `live` or `test`. Set to test to use the Paypal sandbox.
+    Either ``live`` or ``test``. Set to test to use the Paypal sandbox.
 
 App registration (get your key and secret here)
     https://developer.paypal.com/webapps/developer/applications/myapps
@@ -954,8 +954,8 @@ App registration (get your key and secret here)
 Development callback URL
     http://localhost:8000/accounts/reddit/login/callback/
 
-By default, access to Reddit is temporary. You can specify the `duration`
-auth parameter to make it `permanent`.
+By default, access to Reddit is temporary. You can specify the ``duration``
+auth parameter to make it ``permanent``.
 
 You can optionally specify additional permissions to use. If no ``SCOPE``
 value is set, the Reddit provider will use ``identity`` by default.
@@ -979,8 +979,8 @@ you will risk additional rate limiting in your application.
 Shopify
 -------
 
-The Shopify provider requires a `shop` parameter to login. For
-example, for a shop `petstore.myshopify.com`, use this::
+The Shopify provider requires a ``shop`` parameter to login. For
+example, for a shop ``petstore.myshopify.com``, use this::
 
     /accounts/shopify/login/?shop=petstore
 
@@ -990,12 +990,12 @@ You can create login URLs like these as follows:
 
     {% provider_login_url "shopify" shop="petstore" %}
 
-For setting up authentication in your app, use this url as your `App URL`
+For setting up authentication in your app, use this url as your ``App URL``
 (if your server runs at localhost:8000)::
 
     http://localhost:8000/accounts/shopify/login/
 
-And set `Redirection URL` to::
+And set ``Redirection URL`` to::
 
     http://localhost:8000/accounts/shopify/login/callback/
 
@@ -1042,7 +1042,7 @@ Development callback URL
 Stack Exchange
 --------------
 
-Register your OAuth2 app over at `http://stackapps.com/apps/oauth/register`.
+Register your OAuth2 app over at ``http://stackapps.com/apps/oauth/register``.
 Do not enable "Client Side Flow". For local development you can simply use
 "localhost" for the OAuth domain.
 
@@ -1197,11 +1197,11 @@ after it is created, then click "Generate New Password" to create it.
 Weibo
 -----
 
-Register your OAuth2 app over at `http://open.weibo.com/apps`. Unfortunately,
+Register your OAuth2 app over at ``http://open.weibo.com/apps``. Unfortunately,
 Weibo does not allow for specifying a port number in the authorization
 callback URL. So for development purposes you have to use a callback url of
-the form `http://127.0.0.1/accounts/weibo/login/callback/` and run
-`runserver 127.0.0.1:80`.
+the form ``http://127.0.0.1/accounts/weibo/login/callback/`` and run
+``runserver 127.0.0.1:80``.
 
 
 Weixin
@@ -1215,7 +1215,7 @@ Weixin supports two kinds of oauth2 authorization, one for open platform and
 one for media platform, AUTHORIZE_URL is the only difference between them, you
 can specify ``AUTHORIZE_URL`` in setting, If no ``AUTHORIZE_URL`` value is set
 will support open platform by default, which value is
-`https://open.weixin.qq.com/connect/qrconnect`.
+``https://open.weixin.qq.com/connect/qrconnect``.
 
 You can optionally specify additional scope to use. If no ``SCOPE`` value
 is set, will use ``snsapi_login`` by default.

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -9,49 +9,49 @@ allauth.account
 ---------------
 
 
-- `allauth.account.signals.user_logged_in(request, user)`
+- ``allauth.account.signals.user_logged_in(request, user)``
 
   Sent when a user logs in.
 
-- `allauth.account.signals.user_logged_out(request, user)`
+- ``allauth.account.signals.user_logged_out(request, user)``
 
   Sent when a user logs out.
 
-- `allauth.account.signals.user_signed_up(request, user)`
+- ``allauth.account.signals.user_signed_up(request, user)``
 
   Sent when a user signs up for an account. This signal is
-  typically followed by a `user_logged_in`, unless e-mail verification
+  typically followed by a ``user_logged_in``, unless e-mail verification
   prohibits the user to log in.
 
-- `allauth.account.signals.password_set(request, user)`
+- ``allauth.account.signals.password_set(request, user)``
 
   Sent when a password has been successfully set for the first time.
 
-- `allauth.account.signals.password_changed(request, user)`
+- ``allauth.account.signals.password_changed(request, user)``
 
   Sent when a password has been successfully changed.
 
-- `allauth.account.signals.password_reset(request, user)`
+- ``allauth.account.signals.password_reset(request, user)``
 
   Sent when a password has been successfully reset.
 
-- `allauth.account.signals.email_confirmed(email_address)`
+- ``allauth.account.signals.email_confirmed(email_address)``
 
   Sent after the email address in the db was updated and set to confirmed.
 
-- `allauth.account.signals.email_confirmation_sent(confirmation)`
+- ``allauth.account.signals.email_confirmation_sent(confirmation)``
 
   Sent right after the email confirmation is sent.
 
-- `allauth.account.signals.email_changed(request, user, from_email_address, to_email_address)`
+- ``allauth.account.signals.email_changed(request, user, from_email_address, to_email_address)``
 
   Sent when a primary email address has been changed.
 
-- `allauth.account.signals.email_added(request, user, email_address)`
+- ``allauth.account.signals.email_added(request, user, email_address)``
 
   Sent when a new email address has been added.
 
-- `allauth.account.signals.email_removed(request, user, email_address)`
+- ``allauth.account.signals.email_removed(request, user, email_address)``
 
   Sent when an email address has been deleted.
 
@@ -59,7 +59,7 @@ allauth.account
 allauth.socialaccount
 ---------------------
 
-- `allauth.socialaccount.signals.pre_social_login(request, sociallogin)`
+- ``allauth.socialaccount.signals.pre_social_login(request, sociallogin)``
 
   Sent after a user successfully authenticates via a social provider,
   but before the login is fully processed. This signal is emitted as
@@ -68,11 +68,11 @@ allauth.socialaccount
   tokens and profile information, if applicable for the provider, is
   provided.
 
-- `allauth.socialaccount.signals.social_account_added(request, sociallogin)`
+- ``allauth.socialaccount.signals.social_account_added(request, sociallogin)``
 
   Sent after a user connects a social account to a their local account.
 
-- `allauth.socialaccount.signals.social_account_removed(request, socialaccount)`
+- ``allauth.socialaccount.signals.social_account_removed(request, socialaccount)``
 
   Sent after a user disconnects a social account from their local
   account.

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -17,15 +17,15 @@ Template Tags
 
 The following template tag libraries are available:
 
-- `account`: tags for dealing with accounts in general
+- ``account``: tags for dealing with accounts in general
 
-- `socialaccount`: tags focused on social accounts
+- ``socialaccount``: tags focused on social accounts
 
 
 Account Tags
 ************
 
-Use `user_display` to render a user name without making assumptions on
+Use ``user_display`` to render a user name without making assumptions on
 how the user is represented (e.g. render the username, or first
 name?)::
 
@@ -33,35 +33,35 @@ name?)::
 
     {% user_display user %}
 
-Or, if you need to use in a `{% blocktrans %}`::
+Or, if you need to use in a ``{% blocktrans %}``::
 
     {% load account %}
 
     {% user_display user as user_display %}
     {% blocktrans %}{{ user_display }} has logged in...{% endblocktrans %}
 
-Then, override the `ACCOUNT_USER_DISPLAY` setting with your project
+Then, override the ``ACCOUNT_USER_DISPLAY`` setting with your project
 specific user display callable.
 
 
 Social Account Tags
 *******************
 
-Use the `provider_login_url` tag to generate provider specific login URLs::
+Use the ``provider_login_url`` tag to generate provider specific login URLs::
 
     {% load socialaccount %}
 
     <a href="{% provider_login_url "openid" openid="https://www.google.com/accounts/o8/id" next="/success/url/" %}">Google</a>
     <a href="{% provider_login_url "twitter" %}">Twitter</a>
 
-Here, you can pass along an optional `process` parameter that
+Here, you can pass along an optional ``process`` parameter that
 indicates how to process the social login. You can choose between
-`login` and `connect`::
+``login`` and ``connect``::
 
     <a href="{% provider_login_url "twitter" process="connect" %}">Connect a Twitter account</a>
 
-Furthermore, you can pass along an `action` parameter with value
-`reauthenticate` to indicate that you want the user to be re-prompted
+Furthermore, you can pass along an ``action`` parameter with value
+``reauthenticate`` to indicate that you want the user to be re-prompted
 for authentication even if they already signed in before. For now, this
 is supported by Facebook, Google and Twitter only.
 

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -4,24 +4,24 @@ Views
 Login (``account_login``)
 -------------------------
 
-Users login via the `allauth.account.views.LoginView` view over at
-`/accounts/login/` (URL name ``account_login``). When users attempt to login
-while their account is inactive (`user.is_active`) they are presented with the
-`account/account_inactive.html` template.
+Users login via the ``allauth.account.views.LoginView`` view over at
+``/accounts/login/`` (URL name ``account_login``). When users attempt to login
+while their account is inactive (``user.is_active``) they are presented with the
+``account/account_inactive.html`` template.
 
 
 Signup (``account_signup``)
 ---------------------------
 
-Users sign up via the `allauth.account.views.SignupView` view over at
-`/accounts/signup/` (URL name ``account_signup``).
+Users sign up via the ``allauth.account.views.SignupView`` view over at
+``/accounts/signup/`` (URL name ``account_signup``).
 
 
-Logout (``account_logout``)
----------------------------
+Logout (```account_logout``)
+----------------------------
 
-The logout view (`allauth.account.views.LogoutView`) over at
-`/accounts/logout/` (URL name ``account_logout``) requests for confirmation
+The logout view (``allauth.account.views.LogoutView``) over at
+``/accounts/logout/`` (URL name ``account_logout``) requests for confirmation
 before logging out. The user is logged out only when the confirmation is
 received by means of a POST request.
 
@@ -37,21 +37,21 @@ For this and more background information on the subject, see:
 
 If you insist on having logout on GET, then please consider adding a
 bit of Javascript to automatically turn a click on a logout link into
-a POST. As a last resort, you can set `ACCOUNT_LOGOUT_ON_GET` to
-`True`.
+a POST. As a last resort, you can set ``ACCOUNT_LOGOUT_ON_GET`` to
+``True``.
 
 
 Password Management
 -------------------
 
 Authenticated users can manage their password account using the
-`allauth.account.views.PasswordSetView` and
-`allauth.account.views.PasswordChangeView` views, over at
-`/accounts/password/set/` respectively `/accounts/password/change/` (URL names
+``allauth.account.views.PasswordSetView`` and
+``allauth.account.views.PasswordChangeView`` views, over at
+``/accounts/password/set/`` respectively ``/accounts/password/change/`` (URL names
 ``account_set_password`` and ``account_inactive`` respectively).
 
 Users are redirected between these views, according to whether or not
-they have setup a password (`user.has_usable_password()`).  Typically,
+they have setup a password (``user.has_usable_password()``).  Typically,
 when users signup via a social provider they will not have a password
 set.
 
@@ -60,9 +60,9 @@ Password Reset (``account_reset_password``)
 -------------------------------------------
 
 Users can request a password reset using the
-`allauth.account.views.PasswordResetView` view over at
+``allauth.account.views.PasswordResetView`` view over at
 ``/accounts/password/reset/`` (URL name ``account_reset_password``).  An e-mail
-will be sent containing a reset link pointing to `PasswordResetFromKeyView`
+will be sent containing a reset link pointing to ``PasswordResetFromKeyView``
 view.
 
 
@@ -70,7 +70,7 @@ E-mails Management (``account_email``)
 --------------------------------------
 
 Users manage the e-mail addresses tied to their account using the
-`allauth.account.views.EmailView` view over at `/accounts/email/` (URL name
+``allauth.account.views.EmailView`` view over at ``/accounts/email/`` (URL name
 ``account_email``). Here, users can add (and verify) e-mail addresses, remove
 e-mail addresses, and choose a new primary e-mail address.
 
@@ -78,11 +78,11 @@ e-mail addresses, and choose a new primary e-mail address.
 E-mail Verification
 -------------------
 
-Depending on the setting `ACCOUNT_EMAIL_VERIFICATION`, a verification
+Depending on the setting ``ACCOUNT_EMAIL_VERIFICATION``, a verification
 e-mail is sent pointing to the
-`allauth.account.views.ConfirmEmailView` view.
+``allauth.account.views.ConfirmEmailView`` view.
 
-The setting `ACCOUNT_CONFIRM_EMAIL_ON_GET` determines whether users
+The setting ``ACCOUNT_CONFIRM_EMAIL_ON_GET`` determines whether users
 have to manually confirm the address by submiting a confirmation form,
 or whether the address is automatically confirmed by a mere GET
 request.
@@ -91,6 +91,6 @@ request.
 Social Connections (``socialaccount_connections``)
 --------------------------------------------------
 
-The `allauth.socialaccount.views.ConnectionsView` view over at
-`/accounts/social/connections/` (URL name ``socialaccount_connections``) allows
+The ``allauth.socialaccount.views.ConnectionsView`` view over at
+``/accounts/social/connections/`` (URL name ``socialaccount_connections``) allows
 users to manage the social accounts tied to their local account.


### PR DESCRIPTION
Unlike Markdown, you should surround code literals with double backticks
on either side, ``like this``. This goes through all the .rst files and corrects this.