### PR TITLE
Support for Shopify per-user access mode

### DIFF
--- a/allauth/socialaccount/providers/shopify/provider.py
+++ b/allauth/socialaccount/providers/shopify/provider.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
@@ -11,6 +13,12 @@ class ShopifyProvider(OAuth2Provider):
     name = 'Shopify'
     account_class = ShopifyAccount
 
+    @property
+    def is_per_user(self):
+        grant_options = getattr(settings, 'SOCIALACCOUNT_PROVIDERS', {}).get(
+            'shopify', {}).get('AUTH_PARAMS', {}).get('grant_options[]', '')
+        return grant_options.lower().strip() == 'per-user'
+
     def get_auth_params(self, request, action):
         ret = super(ShopifyProvider, self).get_auth_params(request, action)
         shop = request.GET.get('shop', None)
@@ -22,13 +30,23 @@ class ShopifyProvider(OAuth2Provider):
         return ['read_orders', 'read_products']
 
     def extract_uid(self, data):
-        return str(data['shop']['id'])
+        if self.is_per_user:
+            return str(data['associated_user']['id'])
+        else:
+            return str(data['shop']['id'])
 
     def extract_common_fields(self, data):
-        # See: https://docs.shopify.com/api/shop
-        # User is only available with Shopify Plus, email is the only
-        # common field
-        return dict(email=data['shop']['email'])
+        if self.is_per_user:
+            return dict(
+                email=data['associated_user']['email'],
+                first_name=data['associated_user']['first_name'],
+                last_name=data['associated_user']['last_name'],
+            )
+        else:
+            # See: https://docs.shopify.com/api/shop
+            # Without online mode, User is only available with Shopify Plus, email is the only
+            # common field
+            return dict(email=data['shop']['email'])
 
 
 provider_classes = [ShopifyProvider]

--- a/allauth/socialaccount/providers/shopify/provider.py
+++ b/allauth/socialaccount/providers/shopify/provider.py
@@ -44,8 +44,8 @@ class ShopifyProvider(OAuth2Provider):
             )
         else:
             # See: https://docs.shopify.com/api/shop
-            # Without online mode, User is only available with Shopify Plus, email is the only
-            # common field
+            # Without online mode, User is only available with Shopify Plus,
+            # email is the only common field
             return dict(email=data['shop']['email'])
 
 

--- a/allauth/socialaccount/providers/shopify/tests.py
+++ b/allauth/socialaccount/providers/shopify/tests.py
@@ -1,6 +1,10 @@
+import json
+from django.contrib.auth import get_user_model
+
 from django.test.utils import override_settings
 
 from allauth.compat import parse_qs, reverse, urlparse
+from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers import registry
 from allauth.socialaccount.tests import create_oauth2_tests
 from allauth.tests import MockedResponse, mocked_response
@@ -84,3 +88,56 @@ class ShopifyEmbeddedTests(ShopifyTests):
         resp = self._complete_shopify_login(q, resp, resp_mock,
                                             with_refresh_token)
         return resp
+
+
+@override_settings(SOCIALACCOUNT_PROVIDERS={
+    'shopify': {'AUTH_PARAMS': {'grant_options[]': 'per-user'},}})
+class ShopifyPerUserAccessTests(ShopifyTests):
+    """
+    Shopify has two access modes, offline (the default) and online/per-user.
+    Enabling 'online' access should cause all-auth to tie the logged in
+    Shopify user to the all-auth account (rather than the shop as a whole).
+
+    See Also:
+    https://help.shopify.com/api/getting-started/authentication/
+    oauth#api-access-modes
+    """
+
+    def get_login_response_json(self, with_refresh_token=True):
+        response_data = {
+            "access_token": "testac",
+            "scope": "write_orders,read_customers",
+            "expires_in": 86399,
+            "associated_user_scope": "write_orders",
+            "associated_user": {
+                "id": 902541635,
+                "first_name": "Jon",
+                "last_name": "Smith",
+                "email": "jon@example.com",
+                "account_owner": True
+            }
+        }
+        if with_refresh_token:
+            response_data['refresh_token'] = 'testrf'
+
+        return json.dumps(response_data)
+
+    @override_settings(SOCIALACCOUNT_AUTO_SIGNUP=True,
+                       SOCIALACCOUNT_EMAIL_REQUIRED=True,
+                       ACCOUNT_EMAIL_REQUIRED=True)
+    def test_associated_user(self):
+        resp_mocks = self.get_mocked_response()
+        resp = self.login(resp_mocks)
+        self.assertRedirects(resp, 'http://testserver/accounts/profile/',
+                             fetch_redirect_response=False)
+
+        social_account = SocialAccount.objects.filter(
+            provider=self.provider.id,
+            uid=902541635,
+        ).first()
+        self.assertIsNotNone(social_account)
+        self.assertTrue('associated_user' in social_account.extra_data)
+
+        self.assertEqual(social_account.user.email, 'jon@example.com')
+        self.assertEqual(social_account.user.first_name, 'Jon')
+        self.assertEqual(social_account.user.last_name, 'Smith')

--- a/allauth/socialaccount/providers/shopify/tests.py
+++ b/allauth/socialaccount/providers/shopify/tests.py
@@ -1,5 +1,4 @@
 import json
-from django.contrib.auth import get_user_model
 
 from django.test.utils import override_settings
 
@@ -91,7 +90,7 @@ class ShopifyEmbeddedTests(ShopifyTests):
 
 
 @override_settings(SOCIALACCOUNT_PROVIDERS={
-    'shopify': {'AUTH_PARAMS': {'grant_options[]': 'per-user'},}})
+    'shopify': {'AUTH_PARAMS': {'grant_options[]': 'per-user'}}})
 class ShopifyPerUserAccessTests(ShopifyTests):
     """
     Shopify has two access modes, offline (the default) and online/per-user.

--- a/allauth/socialaccount/providers/shopify/views.py
+++ b/allauth/socialaccount/providers/shopify/views.py
@@ -54,6 +54,9 @@ class ShopifyOAuth2Adapter(OAuth2Adapter):
             self.profile_url,
             headers=headers)
         extra_data = response.json()
+        associated_user = kwargs['response'].get('associated_user')
+        if associated_user:
+            extra_data['associated_user'] = associated_user
         return self.get_provider().sociallogin_from_response(
             request, extra_data)
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1037,6 +1037,16 @@ Note that there is more an embedded app creator must do in order to have a page 
 Shopify (building the x_frame_exempt landing page, handing session expiration, etc...).
 However that functionality is outside the scope of django-allauth.
 
+**Online/per-user access mode**
+Shopify has two access modes, offline (the default) and online/per-user. Enabling 'online' access will
+cause all-auth to tie the logged in Shopify user to the all-auth account (rather than the shop as a whole).::
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'shopify': {
+            'AUTH_PARAMS': {'grant_options[]': 'per-user'},
+        }
+    }
+
 
 Slack
 -----


### PR DESCRIPTION
This an optional feature that allows an all-auth site to tie the actual token, email, first and last of the Shopify user to the all-auth account, rather than the shop's token and email. 

As noted in code comments before this change, the extra_data for the user can not be obtained from an API request. However it can now be obtained by utilizing 'online' as an access_mode. This causes shopify to provide the user's details when passing back the auth token (and gives a token with a ~24hr expiration).

See Also: https://help.shopify.com/api/getting-started/authentication/oauth#api-access-modes

The code is entirely based off whether or not the 'associated_user' is given to us by Shopify. Which will be true if they put in the existing AUTH_PARAM setting. I thought this more explicit then adding a setting (e.g. ONLINE_ACCESS_MODE: True/False) that sets the auth param for them.