### PR TITLE
Issue #1701: Do not set the fbsr cookie

### DIFF
--- a/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
+++ b/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
@@ -42,7 +42,7 @@
           appId: opts.appId,
           version: opts.version,
           status: true,
-          cookie: true,
+          cookie: false,
           xfbml: true
         })
         fbInitialized = true


### PR DESCRIPTION
After visiting the login page, the fbsr_<appID> cookie is set if the facebook provider is available. It is never cleared and sent with every subsequent request to the application. This only happens if I currently have an active facebook session.

The cookie value is quite large and significantly increases the request size. The request becomes more difficult to read. I am not sure if setting the cookie has security implications.

I was able to workaround this by setting the cookie parameter of FB.init() to false in fbconnect.js.
