### PR TITLE
Trigger social account signals on login and update docs

### DIFF
--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -177,6 +177,12 @@ def _complete_social_login(request, sociallogin):
     if sociallogin.is_existing:
         # Login existing user
         ret = _login_social_account(request, sociallogin)
+        signals.social_account_updated.send(
+            sender=SocialLogin,
+            request=request,
+            sociallogin=sociallogin
+        )
+
     else:
         # New social user
         ret = _process_signup(request, sociallogin)

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -72,6 +72,13 @@ allauth.socialaccount
 
   Sent after a user connects a social account to a their local account.
 
+- `allauth.socialaccount.signals.social_account_updated(request, sociallogin)`
+
+  Sent after a social account has been updated. This happens when a user
+  logs in using an already connected social account, or completes a `connect`
+  flow for an already connected social account. Useful if you need to
+  unpack extra data for social accounts as they are updated.
+
 - ``allauth.socialaccount.signals.social_account_removed(request, socialaccount)``
 
   Sent after a user disconnects a social account from their local


### PR DESCRIPTION
During the social `login` process, the user adds or updates a social account. This PR ensures the relevant signal is fired in both those cases to be consistent with the signals fired during the `connect` process.