### PR TITLE
user_id isn't required in request but gets exception if it aren't set

### DIFF
--- a/allauth/socialaccount/providers/vk/views.py
+++ b/allauth/socialaccount/providers/vk/views.py
@@ -40,11 +40,15 @@ class VKOAuth2Adapter(OAuth2Adapter):
     profile_url = 'https://api.vk.com/method/users.get'
 
     def complete_login(self, request, app, token, **kwargs):
-        uid = kwargs['response']['user_id']
+        uid = kwargs['response'].get('user_id')
+        params = {
+            'access_token': token.token,
+            'fields': ','.join(USER_FIELDS),
+        }
+        if uid:
+            params['user_ids'] = uid
         resp = requests.get(self.profile_url,
-                            params={'access_token': token.token,
-                                    'fields': ','.join(USER_FIELDS),
-                                    'user_ids': uid})
+                            params=params)
         resp.raise_for_status()
         extra_data = resp.json()['response'][0]
         email = kwargs['response'].get('email')


### PR DESCRIPTION
user_id isn't required in request to api: https://vk.com/dev/users.get
but gets exception if it aren't set: https://github.com/pennersr/django-allauth/issues/1691