### PR TITLE
Fixed typo in pt_BR/LC_MESSAGES/django.po

### DIFF
--- a/allauth/locale/pt_BR/LC_MESSAGES/django.po
+++ b/allauth/locale/pt_BR/LC_MESSAGES/django.po
@@ -664,7 +664,7 @@ msgstr "Definir senha"
 
 #: templates/account/signup.html:5 templates/socialaccount/signup.html:5
 msgid "Signup"
-msgstr "Cadatre-se"
+msgstr "Cadastre-se"
 
 #: templates/account/signup.html:8 templates/account/signup.html:18
 #: templates/socialaccount/signup.html:8 templates/socialaccount/signup.html:19


### PR DESCRIPTION
Replaced 'Cadatre' with 'Cadastre-se'