### PR TITLE
Alter get_avatar_url for getting a profile_image(full-size image) on Kakao provider

### DIFF
--- a/allauth/socialaccount/providers/kakao/provider.py
+++ b/allauth/socialaccount/providers/kakao/provider.py
@@ -10,7 +10,7 @@ class KakaoAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.properties['thumbnail_image']
 
-    def get_profile_image_url(self):
+    def get_full_size_avatar_url(self):
         return self.properties['profile_image']
 
     def to_str(self):

--- a/allauth/socialaccount/providers/kakao/provider.py
+++ b/allauth/socialaccount/providers/kakao/provider.py
@@ -3,15 +3,19 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class KakaoAccount(ProviderAccount):
+    @property
+    def properties(self):
+        return self.account.extra_data['properties']
 
     def get_avatar_url(self):
-        return self.account.extra_data.get(
-            'properties', {}).get('thumbnail_image')
+        return self.properties['thumbnail_image']
+
+    def get_profile_image_url(self):
+        return self.properties['profile_image']
 
     def to_str(self):
-        return self.account.extra_data.get(
-            'properties', {}).get(
-            'nickname', self.account.uid)
+        dflt = super(KakaoAccount, self).to_str()
+        return self.properties['nickname'] or dflt
 
 
 class KakaoProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/kakao/provider.py
+++ b/allauth/socialaccount/providers/kakao/provider.py
@@ -8,9 +8,6 @@ class KakaoAccount(ProviderAccount):
         return self.account.extra_data['properties']
 
     def get_avatar_url(self):
-        return self.properties['thumbnail_image']
-
-    def get_full_size_avatar_url(self):
         return self.properties['profile_image']
 
     def to_str(self):


### PR DESCRIPTION
I added a simple feature that gets original profile image from KAKAO API.

The original version of django-allauth's kakao provider only supports the function to get thumbnail profile image.

