### PR TITLE
Fix RemovedInDjango20Warning: assertRedirects had to strip the scheme…

### DIFF
--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -77,7 +77,7 @@ class AccountTests(TestCase):
                                 {'login': '@raymond.penners',
                                  'password': 'psst'})
         self.assertRedirects(resp,
-                             'http://testserver' + settings.LOGIN_REDIRECT_URL,
+                             settings.LOGIN_REDIRECT_URL,
                              fetch_redirect_response=False)
 
     def test_signup_same_email_verified_externally(self):
@@ -191,7 +191,7 @@ class AccountTests(TestCase):
         self._create_user_and_login()
         c = self.client
         resp = c.get(reverse('account_login'))
-        self.assertRedirects(resp, 'http://testserver/accounts/profile/',
+        self.assertRedirects(resp, '/accounts/profile/',
                              fetch_redirect_response=False)
 
     def test_password_reset_get(self):

--- a/allauth/socialaccount/providers/facebook/tests.py
+++ b/allauth/socialaccount/providers/facebook/tests.py
@@ -91,7 +91,7 @@ class FacebookTests(OAuth2TestsMixin, TestCase):
                 = lambda: mocks.pop()
             resp = self.client.post(reverse('facebook_login_by_token'),
                                     data={'access_token': 'dummy'})
-            self.assertRedirects(resp, 'http://testserver/accounts/profile/',
+            self.assertRedirects(resp, '/accounts/profile/',
                                  fetch_redirect_response=False)
 
     @override_settings(
@@ -111,7 +111,7 @@ class FacebookTests(OAuth2TestsMixin, TestCase):
                 = lambda: mocks.pop()
             resp = self.client.post(reverse('facebook_login_by_token'),
                                     data={'access_token': 'dummy'})
-            self.assertRedirects(resp, 'http://testserver/accounts/profile/',
+            self.assertRedirects(resp, '/accounts/profile/',
                                  fetch_redirect_response=False)
 
     @override_settings(

--- a/allauth/socialaccount/providers/openid/tests.py
+++ b/allauth/socialaccount/providers/openid/tests.py
@@ -51,7 +51,7 @@ class OpenIDTests(TestCase):
                     resp = self.client.post(reverse('openid_callback'))
                     self.assertRedirects(
                         resp,
-                        'http://testserver/accounts/profile/',
+                        '/accounts/profile/',
                         fetch_redirect_response=False)
                     get_user_model().objects.get(first_name='raymond')
 
@@ -98,7 +98,7 @@ class OpenIDTests(TestCase):
                     resp = self.client.post(reverse('openid_callback'))
                     self.assertRedirects(
                         resp,
-                        'http://testserver/accounts/profile/',
+                        '/accounts/profile/',
                         fetch_redirect_response=False)
                     socialaccount = \
                         SocialAccount.objects.get(user__first_name='raymond')

--- a/allauth/socialaccount/providers/shopify/tests.py
+++ b/allauth/socialaccount/providers/shopify/tests.py
@@ -127,7 +127,7 @@ class ShopifyPerUserAccessTests(ShopifyTests):
     def test_associated_user(self):
         resp_mocks = self.get_mocked_response()
         resp = self.login(resp_mocks)
-        self.assertRedirects(resp, 'http://testserver/accounts/profile/',
+        self.assertRedirects(resp, '/accounts/profile/',
                              fetch_redirect_response=False)
 
         social_account = SocialAccount.objects.filter(

--- a/allauth/socialaccount/tests.py
+++ b/allauth/socialaccount/tests.py
@@ -54,7 +54,7 @@ class OAuthTestsMixin(object):
                     username=str(random.randrange(1000, 10000000)))
         resp = self.client.post(reverse('socialaccount_signup'),
                                 data=data)
-        self.assertRedirects(resp, 'http://testserver/accounts/profile/',
+        self.assertRedirects(resp, '/accounts/profile/',
                              fetch_redirect_response=False)
         user = resp.context['user']
         self.assertFalse(user.has_usable_password())
@@ -80,7 +80,7 @@ class OAuthTestsMixin(object):
                           % self.provider.id)
             return
         resp = self.login(resp_mocks)
-        self.assertRedirects(resp, 'http://testserver/accounts/profile/',
+        self.assertRedirects(resp, '/accounts/profile/',
                              fetch_redirect_response=False)
         self.assertFalse(resp.context['user'].has_usable_password())
 


### PR DESCRIPTION
… and domain from the expected URL, as it was always added automatically to URLs before Django 1.9

Re #1745