### PR TITLE
Fixed potentional security issue with leaked password tokens

### DIFF
--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -284,6 +284,9 @@ class AccountTests(TestCase):
         # Extract URL for `password_reset_from_key` view and access it
         url = body[body.find('/password/reset/'):].split()[0]
         resp = self.client.get(url)
+        # Follow the redirect the actual password reset page with the key
+        # hidden.
+        resp = self.client.get(resp.url)
         self.assertTemplateUsed(
             resp,
             'account/password_reset_from_key.%s' %
@@ -336,8 +339,11 @@ class AccountTests(TestCase):
         user = self._request_new_password()
         body = mail.outbox[0].body
         url = body[body.find('/password/reset/'):].split()[0]
+        resp = self.client.get(url)
+        # Follow the redirect the actual password reset page with the key
+        # hidden.
         resp = self.client.post(
-            url,
+            resp.url,
             {'password1': 'newpass123',
              'password2': 'newpass123'})
         self.assertTrue(is_authenticated(user))

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -286,7 +286,8 @@ class AccountTests(TestCase):
         resp = self.client.get(url)
         # Follow the redirect the actual password reset page with the key
         # hidden.
-        resp = self.client.get(resp.url)
+        url = resp.url
+        resp = self.client.get(url)
         self.assertTemplateUsed(
             resp,
             'account/password_reset_from_key.%s' %

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -39,6 +39,7 @@ from .utils import (
     url_str_to_user_pk,
 )
 
+
 INTERNAL_RESET_URL_KEY = "set-password"
 INTERNAL_RESET_SESSION_KEY = "_password_reset_key"
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -64,6 +64,7 @@ def _ajax_response(request, response, form=None, data=None):
 
 
 class RedirectAuthenticatedUserMixin(object):
+
     def dispatch(self, request, *args, **kwargs):
         if is_authenticated(request.user) and \
                 app_settings.AUTHENTICATED_LOGIN_REDIRECTS:
@@ -671,7 +672,6 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
                               'reset_password_from_key',
                               self.form_class)
 
-
     def dispatch(self, request, uidb36, key, **kwargs):
         self.request = request
         self.key = key
@@ -679,7 +679,8 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
         if self.key == INTERNAL_RESET_URL_KEY:
             self.key = self.request.session.get(INTERNAL_RESET_SESSION_KEY, '')
             # (Ab)using forms here to be able to handle errors in XHR #890
-            token_form = UserTokenForm(data={'uidb36': uidb36, 'key': self.key})
+            token_form = UserTokenForm(
+                data={'uidb36': uidb36, 'key': self.key})
             if token_form.is_valid():
                 self.reset_user = token_form.reset_user
                 return super(PasswordResetFromKeyView, self).dispatch(request,
@@ -687,14 +688,16 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
                                                                       self.key,
                                                                       **kwargs)
         else:
-            token_form = UserTokenForm(data={'uidb36': uidb36, 'key': self.key})
+            token_form = UserTokenForm(
+                data={'uidb36': uidb36, 'key': self.key})
             if token_form.is_valid():
                 # Store the key in the session and redirect to the
                 # password reset form at a URL without the key. That
                 # avoids the possibility of leaking the key in the
                 # HTTP Referer header.
                 self.request.session[INTERNAL_RESET_SESSION_KEY] = self.key
-                redirect_url = self.request.path.replace(self.key, INTERNAL_RESET_URL_KEY)
+                redirect_url = self.request.path.replace(
+                    self.key, INTERNAL_RESET_URL_KEY)
                 return redirect(redirect_url)
 
         self.reset_user = None

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -39,6 +39,9 @@ from .utils import (
     url_str_to_user_pk,
 )
 
+INTERNAL_RESET_URL_KEY = "set-password"
+INTERNAL_RESET_SESSION_KEY = "_password_reset_key"
+
 
 sensitive_post_parameters_m = method_decorator(
     sensitive_post_parameters('password', 'password1', 'password2'))
@@ -668,24 +671,37 @@ class PasswordResetFromKeyView(AjaxCapableProcessFormViewMixin, FormView):
                               'reset_password_from_key',
                               self.form_class)
 
+
     def dispatch(self, request, uidb36, key, **kwargs):
         self.request = request
         self.key = key
-        # (Ab)using forms here to be able to handle errors in XHR #890
-        token_form = UserTokenForm(data={'uidb36': uidb36, 'key': key})
 
-        if not token_form.is_valid():
-            self.reset_user = None
-            response = self.render_to_response(
-                self.get_context_data(token_fail=True)
-            )
-            return _ajax_response(self.request, response, form=token_form)
+        if self.key == INTERNAL_RESET_URL_KEY:
+            self.key = self.request.session.get(INTERNAL_RESET_SESSION_KEY, '')
+            # (Ab)using forms here to be able to handle errors in XHR #890
+            token_form = UserTokenForm(data={'uidb36': uidb36, 'key': self.key})
+            if token_form.is_valid():
+                self.reset_user = token_form.reset_user
+                return super(PasswordResetFromKeyView, self).dispatch(request,
+                                                                      uidb36,
+                                                                      self.key,
+                                                                      **kwargs)
         else:
-            self.reset_user = token_form.reset_user
-            return super(PasswordResetFromKeyView, self).dispatch(request,
-                                                                  uidb36,
-                                                                  key,
-                                                                  **kwargs)
+            token_form = UserTokenForm(data={'uidb36': uidb36, 'key': self.key})
+            if token_form.is_valid():
+                # Store the key in the session and redirect to the
+                # password reset form at a URL without the key. That
+                # avoids the possibility of leaking the key in the
+                # HTTP Referer header.
+                self.request.session[INTERNAL_RESET_SESSION_KEY] = self.key
+                redirect_url = self.request.path.replace(self.key, INTERNAL_RESET_URL_KEY)
+                return redirect(redirect_url)
+
+        self.reset_user = None
+        response = self.render_to_response(
+            self.get_context_data(token_fail=True)
+        )
+        return _ajax_response(self.request, response, form=token_form)
 
     def get_context_data(self, **kwargs):
         ret = super(PasswordResetFromKeyView, self).get_context_data(**kwargs)


### PR DESCRIPTION
Django 1.11+ prevents password tokens from being leaked through the
HTTP Referer header if a template calls out to third-party resources
(i.e., JS or CSS) by setting token in session and redirecting.

Fixes #1755 