### PR TITLE
Kakao can use client_secret now

### DIFF
--- a/allauth/socialaccount/providers/kakao/views.py
+++ b/allauth/socialaccount/providers/kakao/views.py
@@ -23,11 +23,5 @@ class KakaoOAuth2Adapter(OAuth2Adapter):
                                                              extra_data)
 
 
-class KakaoCallbackView(OAuth2CallbackView):
-    def get_client(self, request, app):
-        client = super(KakaoCallbackView, self).get_client(request, app)
-        return client
-
-
 oauth2_login = OAuth2LoginView.adapter_view(KakaoOAuth2Adapter)
-oauth2_callback = KakaoCallbackView.adapter_view(KakaoOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(KakaoOAuth2Adapter)

--- a/allauth/socialaccount/providers/kakao/views.py
+++ b/allauth/socialaccount/providers/kakao/views.py
@@ -26,7 +26,6 @@ class KakaoOAuth2Adapter(OAuth2Adapter):
 class KakaoCallbackView(OAuth2CallbackView):
     def get_client(self, request, app):
         client = super(KakaoCallbackView, self).get_client(request, app)
-        client.consumer_secret = None   # kakao not used client_secret
         return client
 
 


### PR DESCRIPTION
Kakao now supports `client_secret`.

so we don't need to have `client.consumer_secret = None` anymore.