### PR TITLE
Add support for ALLOWED_HOSTS settings when redirecting 

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -417,7 +417,7 @@ class DefaultAccountAdapter(object):
 
     def is_safe_url(self, url):
         from django.utils.http import is_safe_url
-        return is_safe_url(url)
+        return is_safe_url(url, allowed_hosts=app_settings.REDIRECT_ALLOWED_HOSTS)
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         """Constructs the email confirmation (activation) url.

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -152,6 +152,13 @@ class AppSettings(object):
         return ret
 
     @property
+    def REDIRECT_ALLOWED_HOSTS(self):
+        """
+        Set of allowed hosts when redirecting
+        """
+        return self._setting("REDIRECT_ALLOWED_HOSTS", None)
+
+    @property
     def EMAIL_SUBJECT_PREFIX(self):
         """
         Subject-line prefix to use for email messages sent


### PR DESCRIPTION
When developing cross domain websites (API + SPA) I need to redirect user after social login (parameter `next`) to different safe domain. This was not supported yet.