### PR TITLE
Fix user_logged_out signal behavior

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -33,7 +33,6 @@ from ..utils import (
     get_user_model,
     import_attribute,
 )
-from .signals import user_logged_out
 
 
 try:
@@ -389,12 +388,7 @@ class DefaultAccountAdapter(object):
         django_login(request, user)
 
     def logout(self, request):
-        user = request.user
         django_logout(request)
-        user_logged_out.send(
-            sender=user.__class__,
-            request=request,
-            user=user)
 
     def confirm_email(self, request, email_address):
         """

--- a/allauth/account/signals.py
+++ b/allauth/account/signals.py
@@ -1,8 +1,8 @@
+from django.contrib.auth.signals import user_logged_out  # noqa
 from django.dispatch import Signal
 
 
 user_logged_in = Signal(providing_args=["request", "user"])
-user_logged_out = Signal(providing_args=["request", "user"])
 
 # Typically followed by `user_logged_in` (unless, e-mail verification kicks in)
 user_signed_up = Signal(providing_args=["request", "user"])


### PR DESCRIPTION
Changes the behavior of allauth' user_logged_out signal to the same as [django' one](https://docs.djangoproject.com/en/1.11/ref/contrib/auth/#django.contrib.auth.signals.user_logged_out). To perform this, django' signal is forwarded as allauth' one if the logout comes from the allauth' logout view (to be precise, from logout method of the default AccountAdapter).

It also corrects unexpected test failures when tests are run from a fresh copy of the repo.

Fixes #1787.