### PR TITLE
Fix testenv standardjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build
 dist
 *.egg*
 example/local_settings.py
+node_modules/
 
 # Unit test / coverage reports
 htmlcov/

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ commands =
 [testenv:standardjs]
 skip_install = True
 commands =
+	/usr/bin/env bash -c "mkdir -p {toxinidir}/node_modules"
 	/usr/bin/env npm install standard --no-lockfile --no-progress --non-interactive --silent
 	/usr/bin/env bash -c "find {toxinidir}/allauth -name '*.js' | xargs {toxinidir}/node_modules/.bin/standard"
 


### PR DESCRIPTION
Due to the lack of a `package.json` and `node_modules` directory on the
repo, npm could install standard in another directory than
`node_modules/bin/`, which means the standardjs doesn't start.
This PR fixes this behavior.

If a package.json file is added, the mkdir instruction from tox.ini can be
deleted.