### PR TITLE
Update information to match dev page

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -760,9 +760,20 @@ fetching the access token::
 App registration (get your key and secret here)
     https://www.linkedin.com/secure/developer?newapp=
 
-Development callback URL
-    Leave the OAuth redirect URL empty.
+Authorized Redirect URLs (Oauth2)
+*********************************
+Add any you need (up to 200) consisting of:
 
+    {``ACCOUNT_DEFAULT_HTTP_PROTOCOL``}://{hostname}{:optional_port}/{allauth_base_url}/linkedin_oauth2/login/callback/
+
+For example when using the built-in django server and default settings:
+
+    http://localhost:8000/accounts/linkedin_oauth2/login/callback/
+
+
+Development "Accept" and "Cancel" redirect URL (Oauth 1.0a)
+***********************************************************
+    Leave the OAuth1 redirect URLs empty.
 
 MailChimp (OAuth2)
 ------------------

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -237,7 +237,7 @@ Development callback (redirect) URL
 Doximity
 --------
 
-Doximity Oauth2 implementation documentation
+Doximity OAuth2 implementation documentation
     https://www.doximity.com/developers/documentation#oauth
 
 Request API keys here
@@ -760,7 +760,7 @@ fetching the access token::
 App registration (get your key and secret here)
     https://www.linkedin.com/secure/developer?newapp=
 
-Authorized Redirect URLs (Oauth2)
+Authorized Redirect URLs (OAuth2)
 *********************************
 Add any you need (up to 200) consisting of:
 
@@ -771,7 +771,7 @@ For example when using the built-in django server and default settings:
     http://localhost:8000/accounts/linkedin_oauth2/login/callback/
 
 
-Development "Accept" and "Cancel" redirect URL (Oauth 1.0a)
+Development "Accept" and "Cancel" redirect URL (OAuth 1.0a)
 ***********************************************************
     Leave the OAuth1 redirect URLs empty.
 


### PR DESCRIPTION
The names mentioned do no longer match names in LinkedIn developer backend.
Further more, Oauth 2, will not work without explicit redirect URI's and
the documentation is misleading.

Up to 200 redirect URI's can be specified per application, so
development URI's are no issue and non-existing domains or only locally
resolvable domains are accepted (tested).

Reworded the Oauth 1 bit, but no testing has been done on my part to verify if
empty callbacks are still accepted.