### PR TITLE
Allow forcing stateless operation for an OpenID provider

### DIFF
--- a/allauth/socialaccount/providers/openid/provider.py
+++ b/allauth/socialaccount/providers/openid/provider.py
@@ -59,7 +59,8 @@ class OpenIDProvider(Provider):
     def get_server_settings(self, endpoint):
         servers = self.get_settings().get('SERVERS', [])
         for server in servers:
-            if endpoint == server.get('openid_url'):
+            if endpoint is not None \
+                    and endpoint.startswith(server.get('openid_url')):
                 return server
         return {}
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1061,6 +1061,16 @@ following template tag:
     {% load socialaccount %}
     <a href="{% provider_login_url "openid" openid="https://www.google.com/accounts/o8/id" next="/success/url/" %}">Google</a>
 
+The OpenID provider can be forced to operate in stateless mode as follows::
+
+    SOCIALACCOUNT_PROVIDERS = \
+        { 'openid':
+            { 'SERVERS':
+                [ dict(id='steam',
+                    name='Steam',
+                    openid_url='https://steamcommunity.com/openid',
+                    stateless=True,
+                )]}}
 
 ORCID
 -----


### PR DESCRIPTION
There are OpenID providers (eg. Steam) which have known problems with stateful operation.
This PR adds a "stateless" flag on an OpenID provider which forces stateless operation.