### PR TITLE
Add an example for ACCOUNT_USERNAME_VALIDATORS

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -192,7 +192,7 @@ ACCOUNT_USERNAME_VALIDATORS (=None)
       
       from django.contrib.auth.validators import ASCIIUsernameValidator
 
-      custom_username_validators = [ASCIIUsernameValidator]
+      custom_username_validators = [ASCIIUsernameValidator()]
       
       # In settings.py
       

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -185,6 +185,18 @@ ACCOUNT_USERNAME_VALIDATORS (=None)
   (``'some.module.validators.custom_username_validators'``) to a list of
   custom username validators. If left unset, the validators setup
   within the user model username field are used.
+  
+  Example::
+  
+      # In validators.py
+      
+      from django.contrib.auth.validators import ASCIIUsernameValidator
+
+      custom_username_validators = [ASCIIUsernameValidator]
+      
+      # In settings.py
+      
+      ACCOUNT_USERNAME_VALIDATORS = 'some.module.validators.custom_username_validators'
 
 SOCIALACCOUNT_ADAPTER (="allauth.socialaccount.adapter.DefaultSocialAccountAdapter")
   Specifies the adapter class to use, allowing you to alter certain


### PR DESCRIPTION
Current wording says

> A path to a list of custom username validators.

But it doesn't say it should be a list of callables. I got a `TypeError` when I tried the following:

```py
custom_username_validators = ['django.contrib.auth.validators.ASCIIUsernameValidator']
```

I eventually found out the correct usage in https://github.com/pennersr/django-allauth/blob/04928b121e55aad0db6ed422e32ddc8bda997be2/allauth/account/tests.py#L41-L45 but I thought it would be better to add an example to the documentation.

