### PR TITLE
twitch: Add user_read as default scope

### DIFF
--- a/allauth/socialaccount/providers/twitch/provider.py
+++ b/allauth/socialaccount/providers/twitch/provider.py
@@ -23,9 +23,14 @@ class TwitchProvider(OAuth2Provider):
         return str(data['_id'])
 
     def extract_common_fields(self, data):
-        return dict(username=data.get('name'),
-                    name=data.get('display_name'),
-                    email=data.get('email'))
+        return {
+            "username": data.get("name"),
+            "name": data.get("display_name"),
+            "email": data.get("email"),
+        }
+
+    def get_default_scope(self):
+        return ["user_read"]
 
 
 provider_classes = [TwitchProvider]

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -968,7 +968,7 @@ Development callback URL
 Persona
 -------
 
-Note: Mozilla Persona will be shut down on November 30th 2016. See
+Note: Mozilla Persona was shut down on November 30th 2016. See
 `the announcement <https://wiki.mozilla.org/Identity/Persona_Shutdown_Guidelines_for_Reliers>`_
 for details.
 


### PR DESCRIPTION
Without user_read, the default authentication causes a confusing 401.

Also update wording for persona documentation.