### PR TITLE
Update default Facebook Graph API version to v2.5

### DIFF
--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -23,7 +23,7 @@ from .locale import get_default_locale_callable
 
 
 GRAPH_API_VERSION = getattr(settings, 'SOCIALACCOUNT_PROVIDERS', {}).get(
-    'facebook', {}).get('VERSION', 'v2.4')
+    'facebook', {}).get('VERSION', 'v2.5')
 GRAPH_API_URL = 'https://graph.facebook.com/' + GRAPH_API_VERSION
 
 NONCE_SESSION_KEY = 'allauth_facebook_nonce'

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -419,7 +419,7 @@ The following Facebook settings are available:
             'EXCHANGE_TOKEN': True,
             'LOCALE_FUNC': 'path.to.callable',
             'VERIFIED_EMAIL': False,
-            'VERSION': 'v2.4',
+            'VERSION': 'v2.5',
         }
     }
 
@@ -479,7 +479,7 @@ VERIFIED_EMAIL:
     risk.
 
 VERSION:
-    The Facebook Graph API version to use. The default is ``v2.4``.
+    The Facebook Graph API version to use. The default is ``v2.5``.
 
 App registration (get your key and secret here)
     A key and secret key can be obtained by


### PR DESCRIPTION
As of October 7th, 2017, currently used default Facebook Graph API v2.4 will reach its end of life.