### PR TITLE
create base email template for easier customizability

### DIFF
--- a/allauth/templates/account/email/email_confirmation_message.txt
+++ b/allauth/templates/account/email/email_confirmation_message.txt
@@ -1,8 +1,8 @@
-{% load account %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
+{% extends 'base.txt' %}{% load account %}{% block content %}{% user_display user as user_display %}{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
 
 You're receiving this e-mail because user {{ user_display }} has given yours as an e-mail address to connect their account.
 
 To confirm this is correct, go to {{ activate_url }}
 {% endblocktrans %}{% endautoescape %}
 {% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you from {{ site_name }}!
-{{ site_domain }}{% endblocktrans %}
+{{ site_domain }}{% endblocktrans %}{% endblock content %}

--- a/allauth/templates/account/email/password_reset_key_message.txt
+++ b/allauth/templates/account/email/password_reset_key_message.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
+{% extends 'base.txt' %}{% load i18n %}{% block content %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
 
 You're receiving this e-mail because you or someone else has requested a password for your user account.
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
@@ -8,4 +8,4 @@ It can be safely ignored if you did not request a password reset. Click the link
 {% if username %}{% blocktrans %}In case you forgot, your username is {{ username }}.{% endblocktrans %}
 
 {% endif %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you for using {{ site_name }}!
-{{ site_domain }}{% endblocktrans %}
+{{ site_domain }}{% endblocktrans %}{% endblock content %}

--- a/allauth/templates/base.txt
+++ b/allauth/templates/base.txt
@@ -1,0 +1,1 @@
+{% block content %}{% endblock content %}


### PR DESCRIPTION
Hi,

it would be pretty useful to have a `base.txt` to overwrite for easier extensability, similar to `base.html`.

There are countries out there (including mine) which demand by law that you have an imprint in every mail you send as an organization.

Right now you need to copy all relevant mail templates into your project and edit every single template. Additionally, you need to repeat that if the mail templates will be updated.

This PR is my suggestion to add a `base.txt` to `templates/` which only contains `{% block content %}{% endblock content %}`. This way one can add custom stuff (e.g. an imprint).