### PR TITLE
docs: Document required read_user scope for GitLab

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -609,6 +609,9 @@ GITLAB_URL:
     Override endpoint to request an authorization and access token. For your
     private GitLab server you use: ``https://your.gitlab.server.tld``
 
+SCOPE:
+    The ``read_user`` scope is required for the login procedure.
+
 Example:
 
 .. code-block:: python
@@ -616,7 +619,8 @@ Example:
     SOCIALACCOUNT_PROVIDERS = {
         'gitlab': {
             'GITLAB_URL': 'https://your.gitlab.server.tld',
-        }
+            'SCOPE': ['read_user'],
+        },
     }
 
 


### PR DESCRIPTION
I just spent like 20 minutes digging through the codebase to figure out how to make GitLab login work, hopefully others won't have to do the same 🙃 