### PR TITLE
Fixed a typo error in French Localization.

### DIFF
--- a/allauth/locale/fr/LC_MESSAGES/django.po
+++ b/allauth/locale/fr/LC_MESSAGES/django.po
@@ -106,7 +106,7 @@ msgstr "E-mail (facultatif)"
 
 #: account/forms.py:325
 msgid "You must type the same email each time."
-msgstr "Vous devez saisir deux fois le même mot de passe."
+msgstr "Vous devez saisir deux fois le même email."
 
 #: account/forms.py:348 account/forms.py:457
 msgid "Password (again)"


### PR DESCRIPTION
The translation of "password" was used in place of "email".