### PR TITLE
Add ACCOUNT_SIGNUP_ADD_MESSAGE option

### DIFF
--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -707,7 +707,7 @@ class AccountTests(TestCase):
                        'password1': 'johndoe',
                        'password2': 'johndoe'})
         self.assertFalse(any('Confirmation e-mail sent to' in m.message
-            for m in messages.get_messages(resp.wsgi_request)))
+                for m in messages.get_messages(resp.wsgi_request)))
 
     @override_settings(ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS=False)
     def test_account_authenticated_login_redirects_is_false(self):

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -675,7 +675,8 @@ class AccountTests(TestCase):
                              fetch_redirect_response=False)
         self.assertEqual(mail.outbox[0].to, ['john@example.com'])
         self.assertEqual(len(mail.outbox), 1)
-        self.assertTrue(any('Confirmation e-mail sent to' in m.message for m in messages.get_messages(resp.wsgi_request)))
+        self.assertTrue(any('Confirmation e-mail sent to' in m.message
+                            for m in messages.get_messages(resp.wsgi_request)))
         # Logout & login again
         c.logout()
         # Wait for cooldown
@@ -705,7 +706,8 @@ class AccountTests(TestCase):
                        'email': 'john@example.com',
                        'password1': 'johndoe',
                        'password2': 'johndoe'})
-        self.assertFalse(any('Confirmation e-mail sent to' in m.message for m in messages.get_messages(resp.wsgi_request)))
+        self.assertFalse(any('Confirmation e-mail sent to' in m.message
+                             for m in messages.get_messages(resp.wsgi_request)))
 
     @override_settings(ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS=False)
     def test_account_authenticated_login_redirects_is_false(self):

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -707,7 +707,7 @@ class AccountTests(TestCase):
                        'password1': 'johndoe',
                        'password2': 'johndoe'})
         self.assertFalse(any('Confirmation e-mail sent to' in m.message
-                             for m in messages.get_messages(resp.wsgi_request)))
+            for m in messages.get_messages(resp.wsgi_request)))
 
     @override_settings(ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS=False)
     def test_account_authenticated_login_redirects_is_false(self):

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -6,8 +6,8 @@ from datetime import timedelta
 
 from django import forms
 from django.conf import settings
-from django.contrib.auth.models import AbstractUser, AnonymousUser
 from django.contrib import messages
+from django.contrib.auth.models import AbstractUser, AnonymousUser
 from django.contrib.sites.models import Site
 from django.core import mail, validators
 from django.core.exceptions import ValidationError

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -707,7 +707,7 @@ class AccountTests(TestCase):
                        'password1': 'johndoe',
                        'password2': 'johndoe'})
         self.assertFalse(any('Confirmation e-mail sent to' in m.message
-                for m in messages.get_messages(resp.wsgi_request)))
+                         for m in messages.get_messages(resp.wsgi_request)))
 
     @override_settings(ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS=False)
     def test_account_authenticated_login_redirects_is_false(self):

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -323,7 +323,7 @@ def send_email_confirmation(request, user, signup=False):
                                                            confirm=True)
             assert email_address
         # At this point, if we were supposed to send an email we have sent it.
-        if send_email:
+        if send_email and getattr(settings, 'ACCOUNT_SIGNUP_ADD_MESSAGE', True):
             get_adapter(request).add_message(
                 request,
                 messages.INFO,

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -323,7 +323,8 @@ def send_email_confirmation(request, user, signup=False):
                                                            confirm=True)
             assert email_address
         # At this point, if we were supposed to send an email we have sent it.
-        if send_email and getattr(settings, 'ACCOUNT_SIGNUP_ADD_MESSAGE', True):
+        if send_email and getattr(settings, 'ACCOUNT_SIGNUP_ADD_MESSAGE',
+                                  True):
             get_adapter(request).add_message(
                 request,
                 messages.INFO,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -147,7 +147,7 @@ ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE (=True)
   When signing up, let the user type in their password twice to avoid typos.
 
 ACCOUNT_SIGNUP_ADD_MESSAGE (=True)
-  When signing up, add a message (with ``django.contrib.messages.add_message``).
+  When signing up, add a message with ``django.contrib.messages.add_message``.
 
 ACCOUNT_TEMPLATE_EXTENSION (="html")
   A string defining the template extension to use, defaults to ``html``.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -146,6 +146,9 @@ ACCOUNT_SIGNUP_FORM_CLASS (=None)
 ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE (=True)
   When signing up, let the user type in their password twice to avoid typos.
 
+ACCOUNT_SIGNUP_ADD_MESSAGE (=True)
+  When signing up, add a message (with ``django.contrib.messages.add_message``).
+
 ACCOUNT_TEMPLATE_EXTENSION (="html")
   A string defining the template extension to use, defaults to ``html``.
 


### PR DESCRIPTION
Use case: Hide the "confirmation email sent" message **only directly after signing up** (if optional email verification)