### PR TITLE
PasswordField was applying translation when it shouldnt. Attempts to …

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -70,7 +70,7 @@ class PasswordField(forms.CharField):
                                   app_settings.PASSWORD_INPUT_RENDER_VALUE)
         kwargs['widget'] = forms.PasswordInput(render_value=render_value,
                                                attrs={'placeholder':
-                                                      _(kwargs.get("label"))})
+                                                      kwargs.get("label")})
         super(PasswordField, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
…login on django 2.0 failed with TypeError: __str__ returned non-string (type __proxy__)