### PR TITLE
Add signal for failed user authentication 

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -29,6 +29,7 @@ from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from . import app_settings
+from .signals import user_auth_failed
 from ..utils import (
     build_absolute_uri,
     email_address_exists,
@@ -492,6 +493,7 @@ class DefaultAccountAdapter(object):
         dt = timezone.now()
         data.append(time.mktime(dt.timetuple()))
         cache.set(cache_key, data, app_settings.LOGIN_ATTEMPTS_TIMEOUT)
+        user_auth_failed.send(sender=self.__class__, request=request)
 
     def is_ajax(self, request):
         return request.is_ajax()

--- a/allauth/account/signals.py
+++ b/allauth/account/signals.py
@@ -3,6 +3,7 @@ from django.dispatch import Signal
 
 
 user_logged_in = Signal(providing_args=["request", "user"])
+user_auth_failed = Signal(providing_args=["request"])
 
 # Typically followed by `user_logged_in` (unless, e-mail verification kicks in)
 user_signed_up = Signal(providing_args=["request", "user"])


### PR DESCRIPTION
Emits a new signal when a user failed to authenticate. This is so we can run our own custom code to block users permanently if they fail login a certain number of attempts.