### PR TITLE
Fix email on Eventbrite provider

### DIFF
--- a/allauth/socialaccount/providers/eventbrite/provider.py
+++ b/allauth/socialaccount/providers/eventbrite/provider.py
@@ -1,6 +1,7 @@
 """Customise Provider classes for Eventbrite API v3."""
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from allauth.account.models import EmailAddress
 
 
 class EventbriteAccount(ProviderAccount):
@@ -30,14 +31,31 @@ class EventbriteProvider(OAuth2Provider):
 
     def extract_common_fields(self, data):
         """Extract fields from a basic user query."""
+        emails = data.get('emails', [])
+        if emails:
+            emails = [(int(e['primary']), int(e['verified']), e['email']) for e in emails]
+            emails.sort(reverse=True)
+            email = emails[0][-1]
+        else:
+            email = None
         return dict(
-            emails=data.get('emails'),
+            email=email,
             id=data.get('id'),
             name=data.get('name'),
             first_name=data.get('first_name'),
             last_name=data.get('last_name'),
             image_url=data.get('image_url')
         )
+
+    def extract_email_addresses(self, data):
+        ret = []
+        email = data.get('emails')
+        for email_data in data.get('emails'):
+            ret.append(EmailAddress(email=email_data['email'],
+                       verified=email_data['verified'],
+                       primary=email_data['primary']))
+        return ret
+
 
 
 provider_classes = [EventbriteProvider]


### PR DESCRIPTION
Hi,

I am using the `EventbriteProvider` on the new version of my application (https://www.pygmento.com) and I noticed it does not quite well handle the email field. I updated to provider to match the `GoogleProvider` mechanics.

- the provider returns a dict with a field `email` for `extract_common_fields`, using the primary address returned by Eventbrite
- the provider implements the method `extract_email_addresses`
