### PR TITLE
Fixes Google Provider re-authentication to successfully receive new refresh token

### DIFF
--- a/allauth/socialaccount/providers/google/provider.py
+++ b/allauth/socialaccount/providers/google/provider.py
@@ -36,7 +36,7 @@ class GoogleProvider(OAuth2Provider):
         ret = super(GoogleProvider, self).get_auth_params(request,
                                                           action)
         if action == AuthAction.REAUTHENTICATE:
-            ret['prompt'] = 'select_account'
+            ret['prompt'] = 'select_account consent'
         return ret
 
     def extract_uid(self, data):

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -708,6 +708,9 @@ Optionally, you can specify the scope to use as follows:
 By default, ``profile`` scope is required, and optionally ``email`` scope
 depending on whether or not ``SOCIALACCOUNT_QUERY_EMAIL`` is enabled.
 
+You must set ``AUTH_PARAMS['access_type']`` to ``offline`` in order to
+receive a refresh token on first login and on reauthentication requests.
+
 
 Instagram
 ---------


### PR DESCRIPTION
Google ordinarily only provides a refresh token the first time you connect a Google account. For `offline` access apps, you can also receive a new refresh token if you pass the `consent` auth param.

This param adds the `consent` param in addition to the current `select_account` param (which lets you access the Account Switcher for choosing which Google account).

See also:

* https://github.com/pennersr/django-allauth/pull/1303
* https://github.com/pennersr/django-allauth/pull/1376
