### PR TITLE
Update adapter.py to return data for AjaxCapableProcessFormViewMixin

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -333,8 +333,8 @@ class DefaultAccountAdapter(object):
             if hasattr(response, 'render'):
                 response.render()
             resp['html'] = response.content.decode('utf8')
-            if data is not None:
-                resp['data'] = data
+        if data is not None:
+            resp['data'] = data
         return HttpResponse(json.dumps(resp),
                             status=status,
                             content_type='application/json')


### PR DESCRIPTION
Example usage:

If I was to make an ajax request for users updating their emails to 'account_email' the returned ajax response wouldn't contain the data - the list of the emails with their associated data - primary, verified, etc.

It would only contain the redirect location since the form isn't passed resulting in None and the if condition never being hit.