### PR TITLE
Update ORCID to v2.1 API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Andrey Balandin
 Andrey Akolpakov
 Andy Matthews
 Ani Vera
+Antonin Delpeuch
 Aron Griffis
 Basil Shubin
 Ben Timby

--- a/allauth/socialaccount/providers/orcid/provider.py
+++ b/allauth/socialaccount/providers/orcid/provider.py
@@ -9,7 +9,7 @@ class Scope(object):
 class OrcidAccount(ProviderAccount):
     def get_profile_url(self):
         return extract_from_dict(self.account.extra_data,
-                                 ['orcid-profile', 'orcid-identifier', 'uri'])
+                                 ['orcid-identifier', 'uri'])
 
     def to_str(self):
         return self.account.uid
@@ -24,20 +24,15 @@ class OrcidProvider(OAuth2Provider):
         return [Scope.USERINFO_PROFILE]
 
     def extract_uid(self, data):
-        return extract_from_dict(data, ['orcid-profile', 'orcid-identifier',
-                                        'path'])
+        return extract_from_dict(data, ['orcid-identifier', 'path'])
 
     def extract_common_fields(self, data):
         common_fields = dict(
-            email=extract_from_dict(data, ['orcid-profile', 'orcid-bio',
-                                           'contact-details', 'email', 0,
-                                           'value']),
-            last_name=extract_from_dict(data, ['orcid-profile', 'orcid-bio',
-                                               'personal-details',
+            email=extract_from_dict(data, ['person', 'emails', 0,
+                                           'email']),
+            last_name=extract_from_dict(data, ['person', 'name',
                                                'family-name', 'value']),
-            first_name=extract_from_dict(data, ['orcid-profile',
-                                                'orcid-bio',
-                                                'personal-details',
+            first_name=extract_from_dict(data, ['person', 'name',
                                                 'given-names', 'value']),)
         return dict((key, value) for (key, value) in common_fields.items()
                     if value)

--- a/allauth/socialaccount/providers/orcid/tests.py
+++ b/allauth/socialaccount/providers/orcid/tests.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
 
@@ -9,120 +12,363 @@ class OrcidTests(OAuth2TestsMixin, TestCase):
 
     def get_mocked_response(self):
         return MockedResponse(200, """
-        {
-            "message-version": "1.1",
-            "orcid-profile": {
-                "orcid-bio": {
-                    "personal-details": {
-                        "given-names": {
-                            "value": "myname"
-                        },
-                        "other-names": {
-                            "other-name": [
-                                {
-                                    "value": "myself"
-                                }
-                            ],
-                            "visibility": "PUBLIC"
-                        },
-                        "family-name": {
-                            "value": "mylastname"
-                        }
-                    },
-                    "delegation": null,
-                    "applications": null,
-                    "contact-details": {
-                        "email": [],
-                        "address": {
-                            "country": {
-                                "value": "AR",
-                                "visibility": "PUBLIC"
-                            }
-                        }
-                    },
-                    "keywords": {
-                        "keyword": [
-                            {
-                                "value": "basil"
-                            },
-                            {
-                                "value": "pizza"
-                            }
-                        ],
-                        "visibility": "PUBLIC"
-                    },
-                    "scope": null,
-                    "biography": {
-                        "value": "mybio",
-                        "visibility": "PUBLIC"
-                    }
+    {
+    "orcid-identifier": {
+        "uri": "https://sandbox.orcid.org/0000-0001-6796-198X",
+        "path": "0000-0001-6796-198X",
+        "host": "sandbox.orcid.org"
+    },
+    "preferences": {
+        "locale": "EN"
+    },
+    "history": {
+        "creation-method": "MEMBER_REFERRED",
+        "completion-date": null,
+        "submission-date": {
+        "value": 1456951327337
+        },
+        "last-modified-date": {
+        "value": 1519493486728
+        },
+        "claimed": true,
+        "source": null,
+        "deactivation-date": null,
+        "verified-email": true,
+        "verified-primary-email": true
+    },
+    "person": {
+        "last-modified-date": {
+        "value": 1519493469738
+        },
+        "name": {
+        "created-date": {
+            "value": 1460669254582
+        },
+        "last-modified-date": {
+            "value": 1460669254582
+        },
+        "given-names": {
+            "value": "Patricia"
+        },
+        "family-name": {
+            "value": "Lawrence"
+        },
+        "credit-name": null,
+        "source": null,
+        "visibility": "PUBLIC",
+        "path": "0000-0001-6796-198X"
+        },
+        "other-names": {
+        "last-modified-date": null,
+        "other-name": [],
+        "path": "/0000-0001-6796-198X/other-names"
+        },
+        "biography": {
+        "created-date": {
+            "value": 1460669254583
+        },
+        "last-modified-date": {
+            "value": 1460669254583
+        },
+        "content": null,
+        "visibility": "PUBLIC",
+        "path": "/0000-0001-6796-198X/biography"
+        },
+        "researcher-urls": {
+        "last-modified-date": null,
+        "researcher-url": [],
+        "path": "/0000-0001-6796-198X/researcher-urls"
+        },
+        "emails": {
+        "last-modified-date": {
+            "value": 1519493469738
+        },
+        "email": [
+            {
+            "created-date": {
+                "value": 1456951327661
+            },
+            "last-modified-date": {
+                "value": 1519493469738
+            },
+            "source": {
+                "source-orcid": {
+                "uri": "https://sandbox.orcid.org/0000-0001-6796-198X",
+                "path": "0000-0001-6796-198X",
+                "host": "sandbox.orcid.org"
                 },
-                "group-type": null,
-                "orcid-activities": {
-                    "affiliations": null,
-                    "orcid-works": {
-                        "scope": null,
-                        "orcid-work": [
-                            {
-                                "put-code": "394644",
-                                "work-title": {
-                                    "subtitle": null,
-                                    "title": {
-                                        "value": "titlepaper"
-                                    }
-                                },
-                                "visibility": "PUBLIC",
-                                "work-type": "CONFERENCE_PAPER",
-                                "url": null,
-                                "work-contributors": {
-                                    "contributor": [
-                                        {
-                                            "contributor-attributes": {},
-                                            "credit-name": {
-                                                "value": "myname",
-                                                "visibility": "PUBLIC"
-                                            }
-                                        }
-                                    ]
-                                },
-                                "work-source": {
-                                    "path": "0000-0001-6796-198X",
-                                    "host": "sandbox.orcid.org",
-                                    "uri": "http://sandbox.orcid.org/...98X",
-                                    "value": null
-                                }
-                            }
-                        ]
-                    }
-                },
-                "orcid": null,
-                "client-type": null,
-                "orcid-history": {
-                    "last-modified-date": {
-                        "value": 1406058219693
-                    },
-                    "creation-method": "WEBSITE",
-                    "submission-date": {
-                        "value": 1405935036511
-                    },
-                    "visibility": null,
-                    "source": null,
-                    "claimed": {
-                        "value": true
-                    }
-                },
-                "type": "USER",
-                "orcid-preferences": {
-                    "locale": "EN"
-                },
-                "orcid-identifier": {
-                    "path": "0000-0001-6796-198X",
-                    "host": "sandbox.orcid.org",
-                    "uri": "http://sandbox.orcid.org/0000-0001-6796-198X",
-                    "value": null
+                "source-client-id": null,
+                "source-name": {
+                "value": "Patricia Lawrence"
                 }
+            },
+            "email": "lawrencepatricia@mailinator.com",
+            "path": null,
+            "visibility": "PUBLIC",
+            "verified": true,
+            "primary": true,
+            "put-code": null
             }
-        }""")
+        ],
+        "path": "/0000-0001-6796-198X/email"
+        },
+        "addresses": {
+        "last-modified-date": null,
+        "address": [],
+        "path": "/0000-0001-6796-198X/address"
+        },
+        "keywords": {
+        "last-modified-date": null,
+        "keyword": [],
+        "path": "/0000-0001-6796-198X/keywords"
+        },
+        "external-identifiers": {
+        "last-modified-date": null,
+        "external-identifier": [],
+        "path": "/0000-0001-6796-198X/external-identifiers"
+        },
+        "path": "/0000-0001-6796-198X/person"
+    },
+    "activities-summary": {
+        "last-modified-date": {
+        "value": 1513777479628
+        },
+        "educations": {
+        "last-modified-date": {
+            "value": 1459957293365
+        },
+        "education-summary": [
+            {
+            "created-date": {
+                "value": 1459957293365
+            },
+            "last-modified-date": {
+                "value": 1459957293365
+            },
+            "source": {
+                "source-orcid": {
+                "uri": "https://sandbox.orcid.org/0000-0001-6796-198X",
+                "path": "0000-0001-6796-198X",
+                "host": "sandbox.orcid.org"
+                },
+                "source-client-id": null,
+                "source-name": {
+                "value": "Patricia Lawrence"
+                }
+            },
+            "department-name": null,
+            "role-title": null,
+            "start-date": null,
+            "end-date": null,
+            "organization": {
+                "name": "Polytech'Rambouillet",
+                "address": {
+                "city": "Rambouillet",
+                "region": null,
+                "country": "FR"
+                },
+                "disambiguated-organization": null
+            },
+            "visibility": "PUBLIC",
+            "put-code": 19996,
+            "path": "/0000-0001-6796-198X/education/19996"
+            }
+        ],
+        "path": "/0000-0001-6796-198X/educations"
+        },
+        "employments": {
+        "last-modified-date": {
+            "value": 1513777479628
+        },
+        "employment-summary": [
+            {
+            "created-date": {
+                "value": 1510399314937
+            },
+            "last-modified-date": {
+                "value": 1513777479628
+            },
+            "source": {
+                "source-orcid": {
+                "uri": "https://sandbox.orcid.org/0000-0001-6796-198X",
+                "path": "0000-0001-6796-198X",
+                "host": "sandbox.orcid.org"
+                },
+                "source-client-id": null,
+                "source-name": {
+                "value": "Patricia Lawrence"
+                }
+            },
+            "department-name": null,
+            "role-title": null,
+            "start-date": {
+                "year": {
+                "value": "2015"
+                },
+                "month": {
+                "value": "03"
+                },
+                "day": {
+                "value": "02"
+                }
+            },
+            "end-date": null,
+            "organization": {
+                "name": "École nationale supérieure de céramique industrielle",
+                "address": {
+                "city": "Limoges",
+                "region": null,
+                "country": "FR"
+                },
+                "disambiguated-organization": {
+                "disambiguated-organization-identifier": "105362",
+                "disambiguation-source": "RINGGOLD"
+                }
+            },
+            "visibility": "PUBLIC",
+            "put-code": 29138,
+            "path": "/0000-0001-6796-198X/employment/29138"
+            },
+            {
+            "created-date": {
+                "value": 1502366640610
+            },
+            "last-modified-date": {
+                "value": 1513777467282
+            },
+            "source": {
+                "source-orcid": {
+                "uri": "https://sandbox.orcid.org/0000-0001-6796-198X",
+                "path": "0000-0001-6796-198X",
+                "host": "sandbox.orcid.org"
+                },
+                "source-client-id": null,
+                "source-name": {
+                "value": "Patricia Lawrence"
+                }
+            },
+            "department-name": null,
+            "role-title": null,
+            "start-date": {
+                "year": {
+                "value": "2002"
+                },
+                "month": {
+                "value": "02"
+                },
+                "day": {
+                "value": "16"
+                }
+            },
+            "end-date": {
+                "year": {
+                "value": "2015"
+                },
+                "month": {
+                "value": "08"
+                },
+                "day": {
+                "value": "12"
+                }
+            },
+            "organization": {
+                "name": "University of Cambridge",
+                "address": {
+                "city": "Cambridge",
+                "region": "Cambridgeshire",
+                "country": "GB"
+                },
+                "disambiguated-organization": {
+                "disambiguated-organization-identifier": "2152",
+                "disambiguation-source": "RINGGOLD"
+                }
+            },
+            "visibility": "PUBLIC",
+            "put-code": 27562,
+            "path": "/0000-0001-6796-198X/employment/27562"
+            }
+        ],
+        "path": "/0000-0001-6796-198X/employments"
+        },
+        "fundings": {
+        "last-modified-date": null,
+        "group": [],
+        "path": "/0000-0001-6796-198X/fundings"
+        },
+        "peer-reviews": {
+        "last-modified-date": null,
+        "group": [],
+        "path": "/0000-0001-6796-198X/peer-reviews"
+        },
+        "works": {
+        "last-modified-date": {
+            "value": 1459957753077
+        },
+        "group": [
+            {
+            "last-modified-date": {
+                "value": 1459957753077
+            },
+            "external-ids": {
+                "external-id": []
+            },
+            "work-summary": [
+                {
+                "put-code": 583440,
+                "created-date": {
+                    "value": 1459957753047
+                },
+                "last-modified-date": {
+                    "value": 1459957753077
+                },
+                "source": {
+                    "source-orcid": {
+                    "uri": "https://sandbox.orcid.org/0000-0001-6796-198X",
+                    "path": "0000-0001-6796-198X",
+                    "host": "sandbox.orcid.org"
+                    },
+                    "source-client-id": null,
+                    "source-name": {
+                    "value": "Patricia Lawrence"
+                    }
+                },
+                "title": {
+                    "title": {
+                    "value": "Standard & Poor's fiscal methodology reviewed"
+                    },
+                    "subtitle": null,
+                    "translated-title": null
+                },
+                "external-ids": {
+                    "external-id": []
+                },
+                "type": "JOURNAL_ARTICLE",
+                "publication-date": {
+                    "year": {
+                    "value": "2001"
+                    },
+                    "month": {
+                    "value": "07"
+                    },
+                    "day": {
+                    "value": "14"
+                    },
+                    "media-type": null
+                },
+                "visibility": "PUBLIC",
+                "path": "/0000-0001-6796-198X/work/583440",
+                "display-index": "0"
+                }
+            ]
+            }
+        ],
+        "path": "/0000-0001-6796-198X/works"
+        },
+        "path": "/0000-0001-6796-198X/activities"
+    },
+    "path": "/0000-0001-6796-198X"
+    }
+        """)
 
     def get_login_response_json(self, with_refresh_token=True):
         # FIXME: This is not an actual response. I added this in order

--- a/allauth/socialaccount/providers/orcid/views.py
+++ b/allauth/socialaccount/providers/orcid/views.py
@@ -27,7 +27,7 @@ class OrcidOAuth2Adapter(OAuth2Adapter):
 
     authorize_url = 'https://{0}/oauth/authorize'.format(base_domain)
     access_token_url = 'https://{0}/oauth/token'.format(api_domain)
-    profile_url = 'https://{0}/v1.2/%s/orcid-profile'.format(api_domain)
+    profile_url = 'https://{0}/v2.1/%s/record'.format(api_domain)
 
     def complete_login(self, request, app, token, **kwargs):
         params = {}


### PR DESCRIPTION
ORCID v1.2 API will be shut down in a few days (https://groups.google.com/forum/#!topic/orcid-api-users/V_cPqOQ9QIs). This migrates the ORCID provider to the newest version of their API (v2.1).