### PR TITLE
Add LinkedIn provider error handling when the response is missing the 'id'

### DIFF
--- a/allauth/socialaccount/providers/linkedin_oauth2/provider.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/provider.py
@@ -1,5 +1,8 @@
 from allauth.socialaccount import app_settings
-from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.base import (
+    ProviderAccount,
+    ProviderException,
+)
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
@@ -34,6 +37,11 @@ class LinkedInOAuth2Provider(OAuth2Provider):
     account_class = LinkedInOAuth2Account
 
     def extract_uid(self, data):
+        if 'id' not in data:
+            raise ProviderException(
+                'LinkedIn encountered an internal error while logging in. \
+                Please try again.'
+            )
         return str(data['id'])
 
     def get_profile_fields(self):


### PR DESCRIPTION
Due to reliability issues from the LinkedIn API, occasionally the response will contain a HTTP 500 error ("Internal service error") and have no `id` attribute. This fix will gracefully raise a ProviderException and return the authentication_error template. 