### PR TITLE
Issue 1968 social account event brite does not work

### DIFF
--- a/allauth/socialaccount/providers/eventbrite/provider.py
+++ b/allauth/socialaccount/providers/eventbrite/provider.py
@@ -32,7 +32,7 @@ class EventbriteProvider(OAuth2Provider):
     def extract_common_fields(self, data):
         """Extract fields from a basic user query."""
         email = None
-        for curr_email in data.get("email", []):
+        for curr_email in data.get("emails", []):
             email = email or curr_email.get("email")
             if curr_email.get("verified", False) and \
                     curr_email.get("primary", False):

--- a/allauth/socialaccount/providers/eventbrite/provider.py
+++ b/allauth/socialaccount/providers/eventbrite/provider.py
@@ -1,7 +1,7 @@
 """Customise Provider classes for Eventbrite API v3."""
+from allauth.account.models import EmailAddress
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
-from allauth.account.models import EmailAddress
 
 
 class EventbriteAccount(ProviderAccount):
@@ -34,7 +34,8 @@ class EventbriteProvider(OAuth2Provider):
         email = None
         for curr_email in data.get("email", []):
             email = email or curr_email.get("email")
-            if curr_email.get("verified", False) and curr_email.get("primary", False):
+            if curr_email.get("verified", False) and \
+                    curr_email.get("primary", False):
                 email = curr_email.get("email")
 
         return dict(
@@ -49,10 +50,10 @@ class EventbriteProvider(OAuth2Provider):
     def extract_email_addresses(self, data):
         addresses = []
         for email in data.get("emails", []):
-            addresses.append(EmailAddress(email=email.get("email"), 
-                                          verified=email.get("verfified"), 
+            addresses.append(EmailAddress(email=email.get("email"),
+                                          verified=email.get("verfified"),
                                           primary=email.get("primary")))
-        
+
         return addresses
 
 

--- a/allauth/socialaccount/providers/eventbrite/provider.py
+++ b/allauth/socialaccount/providers/eventbrite/provider.py
@@ -1,6 +1,7 @@
 """Customise Provider classes for Eventbrite API v3."""
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from allauth.account.models import EmailAddress
 
 
 class EventbriteAccount(ProviderAccount):
@@ -30,14 +31,29 @@ class EventbriteProvider(OAuth2Provider):
 
     def extract_common_fields(self, data):
         """Extract fields from a basic user query."""
+        email = None
+        for curr_email in data.get("email", []):
+            email = email or curr_email.get("email")
+            if curr_email.get("verified", False) and curr_email.get("primary", False):
+                email = curr_email.get("email")
+
         return dict(
-            emails=data.get('emails'),
+            email=email,
             id=data.get('id'),
             name=data.get('name'),
             first_name=data.get('first_name'),
             last_name=data.get('last_name'),
             image_url=data.get('image_url')
         )
+
+    def extract_email_addresses(self, data):
+        addresses = []
+        for email in data.get("emails", []):
+            addresses.append(EmailAddress(email=email.get("email"), 
+                                          verified=email.get("verfified"), 
+                                          primary=email.get("primary")))
+        
+        return addresses
 
 
 provider_classes = [EventbriteProvider]

--- a/allauth/socialaccount/providers/eventbrite/tests.py
+++ b/allauth/socialaccount/providers/eventbrite/tests.py
@@ -14,11 +14,11 @@ class EventbriteTests(OAuth2TestsMixin, TestCase):
     def get_mocked_response(self):
         """Test authentication with an non-null image_id"""
         return MockedResponse(200, """{
-            "emails": {
+            "emails": [{
                 "email": "test@example.com",
                 "verified": "True",
                 "primary": "True"
-            },
+            }],
             "id": "999999999",
             "name": "Andrew Godwin",
             "first_name": "Andrew",


### PR DESCRIPTION
had a typo
`data.get("email") ==> data.get("emails")`