### PR TITLE
Quickbooks custom Provider

### DIFF
--- a/allauth/socialaccount/providers/quickbooks/provider.py
+++ b/allauth/socialaccount/providers/quickbooks/provider.py
@@ -45,7 +45,11 @@ class QuickBooksOAuth2Provider(OAuth2Provider):
         return fields
 
     def get_default_scope(self):
-        scope = ['openid', 'com.intuit.quickbooks.accounting', 'profile', 'phone']
+        scope = ['openid',
+                 'com.intuit.quickbooks.accounting',
+                 'profile',
+                 'phone',
+                 ]
         if app_settings.QUERY_EMAIL:
             scope.append('email')
         return scope

--- a/allauth/socialaccount/providers/quickbooks/provider.py
+++ b/allauth/socialaccount/providers/quickbooks/provider.py
@@ -17,6 +17,7 @@ class QuickBooksAccount(ProviderAccount):
             name = first_name + ' ' + last_name
         return name
 
+
 class QuickBooksOAuth2Provider(OAuth2Provider):
     id = 'quickbooks'
     # Name is displayed to ordinary users -- don't include protocol
@@ -37,13 +38,14 @@ class QuickBooksOAuth2Provider(OAuth2Provider):
                           'givenName',
                           'familyName',
                           'email',
-                          'emailVerified',]
+                          'emailVerified',
+                          ]
         fields = self.get_settings().get('PROFILE_FIELDS',
                                          default_fields)
         return fields
 
     def get_default_scope(self):
-        scope = ['openid','com.intuit.quickbooks.accounting','profile','phone']
+        scope = ['openid', 'com.intuit.quickbooks.accounting', 'profile', 'phone']
         if app_settings.QUERY_EMAIL:
             scope.append('email')
         return scope
@@ -56,5 +58,6 @@ class QuickBooksOAuth2Provider(OAuth2Provider):
                     familynName=data.get('familyName'),
                     emailVerified=data.get('emailVerified'),
                     phoneNumber=data.get('phoneNumber'))
+
 
 provider_classes = [QuickBooksOAuth2Provider]

--- a/allauth/socialaccount/providers/quickbooks/provider.py
+++ b/allauth/socialaccount/providers/quickbooks/provider.py
@@ -1,0 +1,60 @@
+from allauth.socialaccount import app_settings
+from allauth.socialaccount.providers.base import (
+    ProviderAccount,
+    ProviderException,
+)
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class QuickbooksAccount(ProviderAccount):
+
+    def to_str(self):
+        dflt = super(QuickbooksAccount, self).to_str()
+        name = self.account.extra_data.get('name', dflt)
+        first_name = self.account.extra_data.get('givenName', None)
+        last_name = self.account.extra_data.get('familyName', None)
+        if first_name and last_name:
+            name = first_name + ' ' + last_name
+        return name
+
+class QuickbooksOAuth2Provider(OAuth2Provider):
+    id = 'quickbooks'
+    # Name is displayed to ordinary users -- don't include protocol
+    name = 'Quickbooks'
+    account_class = QuickbooksAccount
+
+    def extract_uid(self, data):
+        if 'sub' not in data:
+            raise ProviderException(
+                'QBO error', data
+            )
+        return str(data['sub'])
+
+    def get_profile_fields(self):
+        default_fields = ['address',
+                          'sub',
+                          'phoneNumber',
+                          'givenName',
+                          'familyName',
+                          'email',
+                          'emailVerified',]
+        fields = self.get_settings().get('PROFILE_FIELDS',
+                                         default_fields)
+        return fields
+
+    def get_default_scope(self):
+        scope = ['openid','com.intuit.quickbooks.accounting','profile','phone']
+        if app_settings.QUERY_EMAIL:
+            scope.append('email')
+        return scope
+
+    def extract_common_fields(self, data):
+        return dict(email=data.get('email'),
+                    address=data.get('address'),
+                    sub=data.get('sub'),
+                    givenName=data.get('givenName'),
+                    familynName=data.get('familyName'),
+                    emailVerified=data.get('emailVerified'),
+                    phoneNumber=data.get('phoneNumber'))
+
+provider_classes = [QuickbooksOAuth2Provider]

--- a/allauth/socialaccount/providers/quickbooks/provider.py
+++ b/allauth/socialaccount/providers/quickbooks/provider.py
@@ -6,10 +6,10 @@ from allauth.socialaccount.providers.base import (
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
-class QuickbooksAccount(ProviderAccount):
+class QuickBooksAccount(ProviderAccount):
 
     def to_str(self):
-        dflt = super(QuickbooksAccount, self).to_str()
+        dflt = super(QuickBooksAccount, self).to_str()
         name = self.account.extra_data.get('name', dflt)
         first_name = self.account.extra_data.get('givenName', None)
         last_name = self.account.extra_data.get('familyName', None)
@@ -17,11 +17,11 @@ class QuickbooksAccount(ProviderAccount):
             name = first_name + ' ' + last_name
         return name
 
-class QuickbooksOAuth2Provider(OAuth2Provider):
+class QuickBooksOAuth2Provider(OAuth2Provider):
     id = 'quickbooks'
     # Name is displayed to ordinary users -- don't include protocol
-    name = 'Quickbooks'
-    account_class = QuickbooksAccount
+    name = 'QuickBooks'
+    account_class = QuickBooksAccount
 
     def extract_uid(self, data):
         if 'sub' not in data:
@@ -57,4 +57,4 @@ class QuickbooksOAuth2Provider(OAuth2Provider):
                     emailVerified=data.get('emailVerified'),
                     phoneNumber=data.get('phoneNumber'))
 
-provider_classes = [QuickbooksOAuth2Provider]
+provider_classes = [QuickBooksOAuth2Provider]

--- a/allauth/socialaccount/providers/quickbooks/test.py
+++ b/allauth/socialaccount/providers/quickbooks/test.py
@@ -1,0 +1,19 @@
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
+
+from .provider import QuickbooksOAuth2Provider
+
+
+class QuickbooksOAuth2Tests(OAuth2TestsMixin, TestCase):
+    provider_id = QuickbooksOAuth2Provider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(200, """
+{       "sub": "d8752092-0f2b-4b6e-86ef-6b72f2457a00", 
+        "emailVerified": true, 
+        "familyName": "Mckeeman", 
+        "phoneNumber": "+1 4156694355", 
+        "givenName": "Darren", 
+        "phoneNumberVerified": true, 
+        "email": "darren@blocklight.io"}
+""")

--- a/allauth/socialaccount/providers/quickbooks/test.py
+++ b/allauth/socialaccount/providers/quickbooks/test.py
@@ -9,11 +9,11 @@ class QuickBooksOAuth2Tests(OAuth2TestsMixin, TestCase):
 
     def get_mocked_response(self):
         return MockedResponse(200, """
-{       "sub": "d8752092-0f2b-4b6e-86ef-6b72f2457a00", 
-        "emailVerified": true, 
-        "familyName": "Mckeeman", 
-        "phoneNumber": "+1 4156694355", 
-        "givenName": "Darren", 
-        "phoneNumberVerified": true, 
+{       "sub": "d8752092-0f2b-4b6e-86ef-6b72f2457a00",
+        "emailVerified": true,
+        "familyName": "Mckeeman",
+        "phoneNumber": "+1 4156694355",
+        "givenName": "Darren",
+        "phoneNumberVerified": true,
         "email": "darren@blocklight.io"}
 """)

--- a/allauth/socialaccount/providers/quickbooks/test.py
+++ b/allauth/socialaccount/providers/quickbooks/test.py
@@ -1,11 +1,11 @@
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
 
-from .provider import QuickbooksOAuth2Provider
+from .provider import QuickBooksOAuth2Provider
 
 
-class QuickbooksOAuth2Tests(OAuth2TestsMixin, TestCase):
-    provider_id = QuickbooksOAuth2Provider.id
+class QuickBooksOAuth2Tests(OAuth2TestsMixin, TestCase):
+    provider_id = QuickBooksOAuth2Provider.id
 
     def get_mocked_response(self):
         return MockedResponse(200, """

--- a/allauth/socialaccount/providers/quickbooks/urls.py
+++ b/allauth/socialaccount/providers/quickbooks/urls.py
@@ -1,6 +1,6 @@
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
 
-from .provider import QuickbooksOAuth2Provider
+from .provider import QuickBooksOAuth2Provider
 
 
-urlpatterns = default_urlpatterns(QuickbooksOAuth2Provider)
+urlpatterns = default_urlpatterns(QuickBooksOAuth2Provider)

--- a/allauth/socialaccount/providers/quickbooks/urls.py
+++ b/allauth/socialaccount/providers/quickbooks/urls.py
@@ -1,0 +1,6 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+
+from .provider import QuickbooksOAuth2Provider
+
+
+urlpatterns = default_urlpatterns(QuickbooksOAuth2Provider)

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -32,8 +32,7 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
     def get_user_info(self, token):
         auth_header = 'Bearer ' + token.token
         headers = {'Accept': 'application/json', 'Authorization': auth_header, 'accept': 'application/json'}
-        QBO_sandbox = getattr(app_settings, 'SOCIALACCOUNT_PROVIDERS', {}).get(
-            'quickbooks', {}).get('SANDBOX', False)
+        QBO_sandbox = self.get_provider().get_settings().get('SANDBOX', False)
         if QBO_sandbox:
             r = requests.get(self.profile_test, headers=headers)
         else:

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -32,7 +32,9 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
     def get_user_info(self, token):
         auth_header = 'Bearer ' + token.token
         headers = {'Accept': 'application/json', 'Authorization': auth_header, 'accept': 'application/json'}
-        if app_settings.PROVIDERS.quickbooks.SANDBOX:
+        QBO_sandbox = getattr(app_settings, 'SOCIALACCOUNT_PROVIDERS', {}).get(
+            'quickbooks', {}).get('SANDBOX', False)
+        if QBO_sandbox:
             r = requests.get(self.profile_test, headers=headers)
         else:
             r = requests.get(self.profile_url, headers=headers)

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -29,10 +29,10 @@ class QuickbooksOAuth2Adapter(OAuth2Adapter):
 
 
     def get_user_info(self, token):
-        from config.settings import QBO_TEST
+        from django.conf import settings
         auth_header = 'Bearer ' + token.token
         headers = {'Accept': 'application/json', 'Authorization': auth_header, 'accept': 'application/json'}
-        if QBO_TEST:
+        if settings.QBO_TEST:
             r = requests.get(self.profile_test, headers=headers)
         else:
             r = requests.get(self.profile_url, headers=headers)

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -1,0 +1,45 @@
+import requests
+import json
+
+from allauth.socialaccount.providers.oauth2.views import (
+    OAuth2Adapter,
+    OAuth2CallbackView,
+    OAuth2LoginView,
+)
+
+from .provider import QuickbooksOAuth2Provider
+
+
+class QuickbooksOAuth2Adapter(OAuth2Adapter):
+    provider_id = QuickbooksOAuth2Provider.id
+    access_token_url = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'
+    authorize_url = 'https://appcenter.intuit.com/connect/oauth2'
+    profile_test = 'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
+    profile_url = 'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
+    # See:
+    # http://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token?page=1 # noqa
+    profile_url_method = 'GET'
+    access_token_method = 'POST'
+
+    def complete_login(self, request, app, token, **kwargs):
+        resp = self.get_user_info(token)
+        extra_data = resp
+        return self.get_provider().sociallogin_from_response(
+            request, extra_data)
+
+
+    def get_user_info(self, token):
+        from config.settings import QBO_TEST
+        auth_header = 'Bearer ' + token.token
+        headers = {'Accept': 'application/json', 'Authorization': auth_header, 'accept': 'application/json'}
+        if QBO_TEST:
+            r = requests.get(self.profile_test, headers=headers)
+        else:
+            r = requests.get(self.profile_url, headers=headers)
+        status_code = r.status_code
+        response = json.loads(r.text)
+        return response
+
+
+oauth2_login = OAuth2LoginView.adapter_view(QuickbooksOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(QuickbooksOAuth2Adapter)

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -17,7 +17,7 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
     authorize_url = \
         'https://appcenter.intuit.com/connect/oauth2'
     profile_test = \
-        'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
+    'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
     profile_url = \
         'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
     profile_url_method = 'GET'
@@ -28,7 +28,6 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
         extra_data = resp
         return self.get_provider().sociallogin_from_response(
             request, extra_data)
-
 
     def get_user_info(self, token):
         auth_header = 'Bearer ' + token.token

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -16,8 +16,7 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
         'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'
     authorize_url = \
         'https://appcenter.intuit.com/connect/oauth2'
-    profile_test = \
-        'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
+    profile_test = 'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo' # NOQA
     profile_url = \
         'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
     profile_url_method = 'GET'

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -17,7 +17,7 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
     authorize_url = \
         'https://appcenter.intuit.com/connect/oauth2'
     profile_test = \
-    'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
+        'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
     profile_url = \
         'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
     profile_url_method = 'GET'

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -1,12 +1,11 @@
-import requests
 import json
+import requests
 
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
     OAuth2LoginView,
 )
-
 from .provider import QuickBooksOAuth2Provider
 
 

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -12,10 +12,14 @@ from .provider import QuickBooksOAuth2Provider
 
 class QuickBooksOAuth2Adapter(OAuth2Adapter):
     provider_id = QuickBooksOAuth2Provider.id
-    access_token_url = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'
-    authorize_url = 'https://appcenter.intuit.com/connect/oauth2'
-    profile_test = 'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
-    profile_url = 'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
+    access_token_url = \
+        'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'
+    authorize_url = \
+        'https://appcenter.intuit.com/connect/oauth2'
+    profile_test = \
+        'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
+    profile_url = \
+        'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
     profile_url_method = 'GET'
     access_token_method = 'POST'
 
@@ -28,7 +32,10 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
 
     def get_user_info(self, token):
         auth_header = 'Bearer ' + token.token
-        headers = {'Accept': 'application/json', 'Authorization': auth_header, 'accept': 'application/json'}
+        headers = {'Accept': 'application/json',
+                   'Authorization': auth_header,
+                   'accept': 'application/json'
+                   }
         QBO_sandbox = self.get_provider().get_settings().get('SANDBOX', False)
         if QBO_sandbox:
             r = requests.get(self.profile_test, headers=headers)

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -1,12 +1,13 @@
 import json
 import requests
 
-from .provider import QuickBooksOAuth2Provider
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
     OAuth2LoginView,
 )
+
+from .provider import QuickBooksOAuth2Provider
 
 
 class QuickBooksOAuth2Adapter(OAuth2Adapter):

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -1,12 +1,12 @@
 import json
 import requests
 
+from .provider import QuickBooksOAuth2Provider
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
     OAuth2LoginView,
 )
-from .provider import QuickBooksOAuth2Provider
 
 
 class QuickBooksOAuth2Adapter(OAuth2Adapter):

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -1,7 +1,6 @@
 import requests
 import json
 
-from allauth.socialaccount import app_settings
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
@@ -17,8 +16,6 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
     authorize_url = 'https://appcenter.intuit.com/connect/oauth2'
     profile_test = 'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
     profile_url = 'https://accounts.platform.intuit.com/v1/openid_connect/userinfo'
-    # See:
-    # http://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token?page=1 # noqa
     profile_url_method = 'GET'
     access_token_method = 'POST'
 
@@ -37,7 +34,7 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
             r = requests.get(self.profile_test, headers=headers)
         else:
             r = requests.get(self.profile_url, headers=headers)
-        status_code = r.status_code
+#        status_code = r.status_code
         response = json.loads(r.text)
         return response
 

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -1,17 +1,18 @@
 import requests
 import json
 
+from allauth.socialaccount import app_settings
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
     OAuth2LoginView,
 )
 
-from .provider import QuickbooksOAuth2Provider
+from .provider import QuickBooksOAuth2Provider
 
 
-class QuickbooksOAuth2Adapter(OAuth2Adapter):
-    provider_id = QuickbooksOAuth2Provider.id
+class QuickBooksOAuth2Adapter(OAuth2Adapter):
+    provider_id = QuickBooksOAuth2Provider.id
     access_token_url = 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer'
     authorize_url = 'https://appcenter.intuit.com/connect/oauth2'
     profile_test = 'https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo'
@@ -29,10 +30,9 @@ class QuickbooksOAuth2Adapter(OAuth2Adapter):
 
 
     def get_user_info(self, token):
-        from django.conf import settings
         auth_header = 'Bearer ' + token.token
         headers = {'Accept': 'application/json', 'Authorization': auth_header, 'accept': 'application/json'}
-        if settings.QBO_TEST:
+        if app_settings.PROVIDERS.quickbooks.SANDBOX:
             r = requests.get(self.profile_test, headers=headers)
         else:
             r = requests.get(self.profile_url, headers=headers)
@@ -41,5 +41,5 @@ class QuickbooksOAuth2Adapter(OAuth2Adapter):
         return response
 
 
-oauth2_login = OAuth2LoginView.adapter_view(QuickbooksOAuth2Adapter)
-oauth2_callback = OAuth2CallbackView.adapter_view(QuickbooksOAuth2Adapter)
+oauth2_login = OAuth2LoginView.adapter_view(QuickBooksOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(QuickBooksOAuth2Adapter)

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -129,6 +129,8 @@ Supported Providers
 
 - Pinterest (OAuth2)
 
+- QuickBooks (OAuth2)
+
 - Reddit (OAuth2)
 
 - Salesforce (OAuth2)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1071,6 +1071,25 @@ SCOPE:
     For a full list of scope options, see
     https://developers.pinterest.com/docs/api/overview/#scopes
 
+QuickBooks
+------
+
+App registration (get your key and secret here)
+    https://developers.intuit.com/v2/ui#/app/startcreate
+
+Development callback URL
+    http://localhost:8000/accounts/quickbooks/login/callback/
+
+You can specify sandbox mode by adding the following to the SOCIALACCOUNT_PROVIDERS in your settings.
+
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'quickbooks': {
+            'SANDBOX': TRUE,
+        }
+    }
+
 
 Reddit
 ------
@@ -1101,6 +1120,10 @@ you will risk additional rate limiting in your application.
             'USER_AGENT': 'django:myappid:1.0 (by /u/yourredditname)',
         }
     }
+
+
+
+
 
 
 Salesforce

--- a/test_settings.py
+++ b/test_settings.py
@@ -104,6 +104,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.paypal',
     'allauth.socialaccount.providers.persona',
     'allauth.socialaccount.providers.pinterest',
+    'allauth.socialaccount.providers.quickbooks',
     'allauth.socialaccount.providers.reddit',
     'allauth.socialaccount.providers.robinhood',
     'allauth.socialaccount.providers.salesforce',

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
 
 [testenv:flake8]
 skip_install = True
+max-line-length=90
 deps =
 	flake8
 	isort

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,6 @@ commands =
 
 [testenv:flake8]
 skip_install = True
-max-line-length=90
 deps =
 	flake8
 	isort


### PR DESCRIPTION
This is a custom provider I wrote to do oauth2 auth with Intuit Quickbooks and Payments APIs. 

It requires that you set a QBO_TEST variable in your settings file. If it's true, it uses the sandbox URL. If not, it assume production and tries that URL. In my system this file is at config.settings.base, probably need help making that more generic. But it works. 