### PR TITLE
Fix a serious error in German translation

### DIFF
--- a/allauth/locale/de/LC_MESSAGES/django.po
+++ b/allauth/locale/de/LC_MESSAGES/django.po
@@ -105,7 +105,7 @@ msgstr "E-Mail (optional)"
 
 #: account/forms.py:345
 msgid "You must type the same email each time."
-msgstr "Du musst zweimal dasselbe Passwort eingeben."
+msgstr "Du musst zweimal dieselbe E-Mail-Adresse eingeben."
 
 #: account/forms.py:368 account/forms.py:477
 msgid "Password (again)"


### PR DESCRIPTION
The German wording for "you must enter the same email twice" was "you must enter the same password twice", which can be really confusing for users.
This should probably be fixed on Transifex as well, but my request to join the de team on Transifex has not been answered yet.