### PR TITLE
when changing password distinguish between empty password and incorrect password being given

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -462,9 +462,13 @@ class ChangePasswordForm(PasswordVerificationMixin, UserForm):
         self.fields['password1'].user = self.user
 
     def clean_oldpassword(self):
-        if not self.user.check_password(self.cleaned_data.get("oldpassword")):
+        old_password = self.cleaned_data.get("oldpassword")
+        if not old_password:
             raise forms.ValidationError(_("Please type your current"
                                           " password."))
+        if not self.user.check_password(old_password):
+            raise forms.ValidationError(_("The provided password is "
+                                          "not valid."))
         return self.cleaned_data["oldpassword"]
 
     def save(self):


### PR DESCRIPTION
Hi, 

At present, when the users changes password and inputs an invalid old password, he is not notified about it and instead gets a generic message "Please type your current password."

This pull request adds a more user-friendly error message for this case.