### PR TITLE
Update signature of dispatch() as per Django conventions

### DIFF
--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -91,7 +91,7 @@ class OAuth2View(object):
 
 
 class OAuth2LoginView(OAuth2View):
-    def dispatch(self, request):
+    def dispatch(self, request, *args, **kwargs):
         provider = self.adapter.get_provider()
         app = provider.get_app(self.request)
         client = self.get_client(request, app)
@@ -110,7 +110,7 @@ class OAuth2LoginView(OAuth2View):
 
 
 class OAuth2CallbackView(OAuth2View):
-    def dispatch(self, request):
+    def dispatch(self, request, *args, **kwargs ):
         if 'error' in request.GET or 'code' not in request.GET:
             # Distinguish cancel from error
             auth_error = request.GET.get('error', None)


### PR DESCRIPTION
The dispatch function in Django's generic class based views accepts *args
and *kwargs as arguments. Modify the signature of dispatch() in
OAuth2LoginView and OAuth2CallbackView.