### PR TITLE
Add disqus social login provider

### DIFF
--- a/allauth/socialaccount/providers/disqus/provider.py
+++ b/allauth/socialaccount/providers/disqus/provider.py
@@ -11,7 +11,7 @@ class DisqusAccount(ProviderAccount):
         return self.account.extra_data.get('avatar', {}).get('permalink')
 
     def to_str(self):
-        dflt = super().to_str()
+        dflt = super(DisqusAccount, self).to_str()
         return self.account.extra_data.get('name', dflt)
 
 class DisqusProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/disqus/provider.py
+++ b/allauth/socialaccount/providers/disqus/provider.py
@@ -3,6 +3,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.app_settings import QUERY_EMAIL
 
+
 class DisqusAccount(ProviderAccount):
     def get_profile_url(self):
         return self.account.extra_data.get('profileUrl')
@@ -13,6 +14,7 @@ class DisqusAccount(ProviderAccount):
     def to_str(self):
         dflt = super(DisqusAccount, self).to_str()
         return self.account.extra_data.get('name', dflt)
+
 
 class DisqusProvider(OAuth2Provider):
     id = 'disqus'
@@ -41,5 +43,6 @@ class DisqusProvider(OAuth2Provider):
         if email:
             ret.append(EmailAddress(email=email, verified=True, primary=True))
         return ret
+
 
 provider_classes = [DisqusProvider]

--- a/allauth/socialaccount/providers/disqus/provider.py
+++ b/allauth/socialaccount/providers/disqus/provider.py
@@ -1,0 +1,45 @@
+from allauth.account.models import EmailAddress
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.app_settings import QUERY_EMAIL
+
+class DisqusAccount(ProviderAccount):
+    def get_profile_url(self):
+        return self.account.extra_data.get('profileUrl')
+
+    def get_avatar_url(self):
+        return self.account.extra_data.get('avatar', {}).get('permalink')
+
+    def to_str(self):
+        dflt = super().to_str()
+        return self.account.extra_data.get('name', dflt)
+
+class DisqusProvider(OAuth2Provider):
+    id = 'disqus'
+    name = 'Disqus'
+    account_class = DisqusAccount
+
+    def get_default_scope(self):
+        scope = ['read']
+        if QUERY_EMAIL:
+            scope += ['email']
+        return scope
+
+    def extract_uid(self, data):
+        return str(data['id'])
+
+    def extract_common_fields(self, data):
+        return {
+            'username': data.get('username'),
+            'email': data.get('email'),
+            'name': data.get('name'),
+        }
+
+    def extract_email_addresses(self, data):
+        ret = []
+        email = data.get('email')
+        if email:
+            ret.append(EmailAddress(email=email, verified=True, primary=True))
+        return ret
+
+provider_classes = [DisqusProvider]

--- a/allauth/socialaccount/providers/disqus/provider.py
+++ b/allauth/socialaccount/providers/disqus/provider.py
@@ -1,7 +1,7 @@
 from allauth.account.models import EmailAddress
-from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
-from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.app_settings import QUERY_EMAIL
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class DisqusAccount(ProviderAccount):

--- a/allauth/socialaccount/providers/disqus/tests.py
+++ b/allauth/socialaccount/providers/disqus/tests.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-from importlib import import_module
-from requests.exceptions import HTTPError
-
-from django.conf import settings
 from django.contrib.auth.models import User
-from django.core import mail
-from django.test.client import RequestFactory
 from django.test.utils import override_settings
-from django.urls import reverse
 
 from allauth.account import app_settings as account_settings
-from allauth.account.adapter import get_adapter
-from allauth.account.models import EmailAddress, EmailConfirmation
-from allauth.account.signals import user_signed_up
-from allauth.socialaccount.models import SocialAccount, SocialToken
+from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.tests import OAuth2TestsMixin
-from allauth.tests import MockedResponse, TestCase, patch
+from allauth.tests import MockedResponse, TestCase
 
 from .provider import DisqusProvider
 
@@ -35,7 +26,9 @@ class DisqusTests(OAuth2TestsMixin, TestCase):
                             email="raymond.penners@example.com"):
         return MockedResponse(200, """
               {"response": {"name": "%s",
-               "avatar": {"permalink": "https://lh5.googleusercontent.com/photo.jpg"},
+               "avatar": {
+                "permalink": "https://lh5.googleusercontent.com/photo.jpg"
+               },
                "email": "%s",
                "profileUrl": "https://plus.google.com/108204268033311374519",
                "id": "108204268033311374519" }}
@@ -64,4 +57,3 @@ class DisqusTests(OAuth2TestsMixin, TestCase):
         self.assertEqual(EmailAddress.objects.filter(
             user=user,
             email=email).count(), 1)
-

--- a/allauth/socialaccount/providers/disqus/tests.py
+++ b/allauth/socialaccount/providers/disqus/tests.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from importlib import import_module
+from requests.exceptions import HTTPError
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core import mail
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from allauth.account import app_settings as account_settings
+from allauth.account.adapter import get_adapter
+from allauth.account.models import EmailAddress, EmailConfirmation
+from allauth.account.signals import user_signed_up
+from allauth.socialaccount.models import SocialAccount, SocialToken
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase, patch
+
+from .provider import DisqusProvider
+
+
+@override_settings(
+    SOCIALACCOUNT_AUTO_SIGNUP=True,
+    ACCOUNT_SIGNUP_FORM_CLASS=None,
+    ACCOUNT_EMAIL_VERIFICATION=account_settings
+    .EmailVerificationMethod.MANDATORY)
+class DisqusTests(OAuth2TestsMixin, TestCase):
+    provider_id = DisqusProvider.id
+
+    def get_mocked_response(self,
+                            name='Raymond Penners',
+                            email="raymond.penners@example.com"):
+        return MockedResponse(200, """
+              {"response": {"name": "%s",
+               "avatar": {"permalink": "https://lh5.googleusercontent.com/photo.jpg"},
+               "email": "%s",
+               "profileUrl": "https://plus.google.com/108204268033311374519",
+               "id": "108204268033311374519" }}
+        """ % (name, email))
+
+    def test_account_connect(self):
+        email = "user@example.com"
+        user = User.objects.create(username='user',
+                                   is_active=True,
+                                   email=email)
+        user.set_password('test')
+        user.save()
+        EmailAddress.objects.create(user=user,
+                                    email=email,
+                                    primary=True,
+                                    verified=True)
+        self.client.login(username=user.username,
+                          password='test')
+        self.login(self.get_mocked_response(), process='connect')
+        # Check if we connected...
+        self.assertTrue(SocialAccount.objects.filter(
+            user=user,
+            provider=DisqusProvider.id).exists())
+        # For now, we do not pick up any new e-mail addresses on connect
+        self.assertEqual(EmailAddress.objects.filter(user=user).count(), 1)
+        self.assertEqual(EmailAddress.objects.filter(
+            user=user,
+            email=email).count(), 1)
+

--- a/allauth/socialaccount/providers/disqus/urls.py
+++ b/allauth/socialaccount/providers/disqus/urls.py
@@ -1,0 +1,5 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+
+from .provider import DisqusProvider
+
+urlpatterns = default_urlpatterns(DisqusProvider)

--- a/allauth/socialaccount/providers/disqus/urls.py
+++ b/allauth/socialaccount/providers/disqus/urls.py
@@ -2,4 +2,5 @@ from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
 
 from .provider import DisqusProvider
 
+
 urlpatterns = default_urlpatterns(DisqusProvider)

--- a/allauth/socialaccount/providers/disqus/views.py
+++ b/allauth/socialaccount/providers/disqus/views.py
@@ -8,6 +8,7 @@ from allauth.socialaccount.providers.oauth2.views import (
 
 from .provider import DisqusProvider
 
+
 class DisqusOAuth2Adapter(OAuth2Adapter):
     provider_id = DisqusProvider.id
     access_token_url = 'https://disqus.com/api/oauth/2.0/access_token/'
@@ -16,14 +17,16 @@ class DisqusOAuth2Adapter(OAuth2Adapter):
     scope_delimiter = ','
 
     def complete_login(self, request, app, token, **kwargs):
-        resp = requests.get(self.profile_url,
-                params={'access_token': token.token,
-                        'api_key': app.client_id, 'api_secret': app.secret})
+        resp = requests.get(self.profile_url, params={
+                            'access_token': token.token,
+                            'api_key': app.client_id,
+                            'api_secret': app.secret})
         resp.raise_for_status()
 
         extra_data = resp.json().get('response')
 
-        login = self.get_provider().sociallogin_from_response(request, extra_data)
+        login = self.get_provider()\
+            .sociallogin_from_response(request, extra_data)
         return login
 
 

--- a/allauth/socialaccount/providers/disqus/views.py
+++ b/allauth/socialaccount/providers/disqus/views.py
@@ -1,0 +1,31 @@
+import requests
+
+from allauth.socialaccount.providers.oauth2.views import (
+    OAuth2Adapter,
+    OAuth2CallbackView,
+    OAuth2LoginView,
+)
+
+from .provider import DisqusProvider
+
+class DisqusOAuth2Adapter(OAuth2Adapter):
+    provider_id = DisqusProvider.id
+    access_token_url = 'https://disqus.com/api/oauth/2.0/access_token/'
+    authorize_url = 'https://disqus.com/api/oauth/2.0/authorize/'
+    profile_url = 'https://disqus.com/api/3.0/users/details.json'
+    scope_delimiter = ','
+
+    def complete_login(self, request, app, token, **kwargs):
+        resp = requests.get(self.profile_url,
+                params={'access_token': token.token,
+                        'api_key': app.client_id, 'api_secret': app.secret})
+        resp.raise_for_status()
+
+        extra_data = resp.json().get('response')
+
+        login = self.get_provider().sociallogin_from_response(request, extra_data)
+        return login
+
+
+oauth2_login = OAuth2LoginView.adapter_view(DisqusOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(DisqusOAuth2Adapter)

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -67,6 +67,8 @@ Supported Providers
 
 - Douban (OAuth2)
 
+- Disqus (OAuth2)
+
 - Doximity (OAuth2)
 
 - Dropbox (OAuth, OAuth2)

--- a/test_settings.py
+++ b/test_settings.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.daum',
     'allauth.socialaccount.providers.digitalocean',
     'allauth.socialaccount.providers.discord',
+    'allauth.socialaccount.providers.disqus',
     'allauth.socialaccount.providers.douban',
     'allauth.socialaccount.providers.doximity',
     'allauth.socialaccount.providers.draugiem',


### PR DESCRIPTION
This adds disqus as a login social provider. The details of the disqus authentication can be read [here](https://disqus.com/api/docs/auth/). It's based on the oauth2 provider.