### PR TITLE
Bugfix: UUIDField pk - allow confirm email login

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,6 +86,7 @@ Mauro Stettler
 Morgante Pell
 Nariman Gharib
 Niklas A Emanuelsson
+Pavel Savchenko
 Patrick Paul
 Paulo Eduardo Neves
 Peter Bittner

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,7 +1,13 @@
 0.37.0 (unreleased)
 *******************
 
+Note worthy changes
+-------------------
+
 - The Battle.net login backend now recognizes ``apac`` as a valid region.
+
+- User model using a ``UUIDField`` as it's primary key can now be logged
+  in upon email confirmation (if using ``ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION``)
 
 
 0.36.0 (2018-05-08)

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1100,7 +1100,7 @@ class UtilsTests(TestCase):
         with patch('allauth.account.utils.get_user_model') as mocked_gum:
             mocked_gum.return_value = UUIDUser
             self.assertEqual(url_str_to_user_pk(self.user_id),
-                             self.user_id)
+                             uuid.UUID(self.user_id))
 
     def test_pk_to_url_string_identifies_UUID_as_stringlike(self):
         user = UUIDUser(

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import json
 import uuid
 from datetime import timedelta
+
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser, AnonymousUser
@@ -28,7 +29,7 @@ from allauth.utils import get_user_model, get_username_max_length
 from . import app_settings
 from .adapter import get_adapter
 from .auth_backends import AuthenticationBackend
-from .signals import user_logged_out, user_logged_in
+from .signals import user_logged_in, user_logged_out
 from .utils import (
     filter_users_by_username,
     url_str_to_user_pk,
@@ -1177,7 +1178,7 @@ class ConfirmationViewTests(TestCase):
                        ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION=True)
     @patch('allauth.account.views.perform_login')
     @patch('allauth.account.utils.get_user_model', return_value=UUIDUser)
-    def test_login_on_confirm_uuid_user(self, mock_get_user_model, mock_perform_login):
+    def test_login_on_confirm_uuid_user(self, mocked_gum, mock_perform_login):
         user = UUIDUser(
             is_active=True,
             email='john@example.com',
@@ -1202,4 +1203,4 @@ class ConfirmationViewTests(TestCase):
                 reverse('account_confirm_email',
                         args=[key]))
 
-        mock_perform_login.assert_called()
+        assert mock_perform_login.called

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -422,7 +422,7 @@ def url_str_to_user_pk(s):
     else:
         pk_field = User._meta.pk
     if issubclass(type(pk_field), models.UUIDField):
-        return s
+        return pk_field.to_python(s)
     try:
         pk_field.to_python('a')
         pk = s

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 	django20: Django>=2.0a1,<2.1
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
 commands =
-	coverage run manage.py test allauth {posargs}
+	coverage run manage.py test {posargs:allauth}
 	coverage report
 	coverage html
 


### PR DESCRIPTION
Prior to this fix, a user that used a UUIDField primary key would not be logged in due to the failing comparison of user pk with the "stashed" pk.