### PR TITLE
Fix unique username error message

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -268,7 +268,13 @@ class DefaultAccountAdapter(object):
                     username_field).error_messages.get('unique')
                 if not error_message:
                     error_message = self.error_messages['username_taken']
-                raise forms.ValidationError(error_message)
+                raise forms.ValidationError(
+                    error_message,
+                    params={
+                        'model_name': user_model.__name__,
+                        'field_label': username_field,
+                    }
+                )
         return username
 
     def clean_email(self, email):


### PR DESCRIPTION
Fix to prevent `%(model_name)s with this %(field_label)s already exists` error message.
Mentioned in #1469 and #1602 