### PR TITLE
Add the ability to have maximum length for username

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -176,6 +176,13 @@ class AppSettings(object):
         return self._setting("USERNAME_MIN_LENGTH", 1)
 
     @property
+    def USERNAME_MAX_LENGTH(self):
+        """
+        Maximum username Length
+        """
+        return self._setting("USERNAME_MAX_LENGTH", 150)
+
+    @property
     def USERNAME_BLACKLIST(self):
         """
         List of usernames that are not allowed

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -62,10 +62,11 @@ def _generate_unique_username_base(txts, regex=None):
 
 
 def get_username_max_length():
-    from .account.app_settings import USER_MODEL_USERNAME_FIELD
+    from .account.app_settings import USER_MODEL_USERNAME_FIELD, USERNAME_MAX_LENGTH
     if USER_MODEL_USERNAME_FIELD is not None:
         User = get_user_model()
-        max_length = User._meta.get_field(USER_MODEL_USERNAME_FIELD).max_length
+        user_model_max_length = User._meta.get_field(USER_MODEL_USERNAME_FIELD).max_length
+        max_length = min(user_model_max_length, USERNAME_MAX_LENGTH)
     else:
         max_length = 0
     return max_length

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -198,6 +198,9 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD (="username")
 ACCOUNT_USERNAME_MIN_LENGTH (=1)
   An integer specifying the minimum allowed length of a username.
 
+ACCOUNT_USERNAME_MAX_LENGTH (=150)
+  An integer specifying the maximum allowed length of a username.
+
 ACCOUNT_USERNAME_REQUIRED (=True)
   The user is required to enter a username when signing up. Note that
   the user will be asked to do so even if

--- a/example/example/local_settings.example
+++ b/example/example/local_settings.example
@@ -56,6 +56,9 @@
 # An integer specifying the minimum allowed length of a username.
 # ACCOUNT_USERNAME_MIN_LENGTH = 1
 
+# An integer specifying the maximum allowed length of a username.
+# ACCOUNT_USERNAME_MAX_LENGTH = 150
+
 # The user is required to enter a username when signing up. Note that the
 # user will be asked to do so even if ACCOUNT_AUTHENTICATION_METHOD is set
 # to email. Set to False when you do not wish to prompt the user to enter a


### PR DESCRIPTION
I read this [question](https://stackoverflow.com/q/50548685/6086865) on Stack Overflow about customizing the maximum length of the `username` field in the signup form. I found it frustrating that you have to customize the `User` model and change the `username` field `max_length` or to override the `SignupForm` to do such a simple thing.

I added a new setting: `ACCOUNT_USERNAME_MAX_LENGTH` that allows customizing the username's maximum length easily without making any conflicts with the maximum length defined in the `User` model.

`ACCOUNT_USERNAME_MAX_LENGTH` will be only used if its value is less than the `max_length` defined in the `username` field of the `User` model. 