### PR TITLE
Add CERN OAuth2 provider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,6 +92,7 @@ Patrick Paul
 Paulo Eduardo Neves
 Peter Bittner
 Peter Rowlands
+Peter Stein
 Rabi Alam
 Radek Czajka
 Rense VanderHoek

--- a/allauth/socialaccount/providers/cern/provider.py
+++ b/allauth/socialaccount/providers/cern/provider.py
@@ -1,0 +1,34 @@
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class CernAccount(ProviderAccount):
+    def to_str(self):
+        dflt = super(CernAccount, self).to_str()
+        return self.account.extra_data.get('name', dflt)
+
+
+class CernProvider(OAuth2Provider):
+    id = 'cern'
+    name = 'Cern'
+    account_class = CernAccount
+
+    def get_auth_params(self, request, action):
+        data = super(CernProvider, self).get_auth_params(request, action)
+        data['scope'] = 'read:user'
+        return data
+
+    def extract_uid(self, data):
+        return str(data.get('id'))
+
+    def extract_common_fields(self, data):
+        return dict(
+            email=data.get('email'),
+            username=data.get('username'),
+            first_name=data.get('first_name'),
+            last_name=data.get('last_name'),
+            name=data.get('name')
+        )
+
+
+provider_classes = [CernProvider]

--- a/allauth/socialaccount/providers/cern/tests.py
+++ b/allauth/socialaccount/providers/cern/tests.py
@@ -1,0 +1,25 @@
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
+
+from .provider import CernProvider
+
+
+class CernTests(OAuth2TestsMixin, TestCase):
+    provider_id = CernProvider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(200, """
+        {
+            "name":"Max Mustermann",
+            "username":"mmuster",
+            "id":8173921,
+            "personid":924225,
+            "email":"max.mustermann@cern.ch",
+            "first_name":"Max",
+            "last_name":"Mustermann",
+            "identityclass":"CERN Registered",
+            "federation":"CERN",
+            "phone":null,
+            "mobile":null
+        }
+        """)

--- a/allauth/socialaccount/providers/cern/urls.py
+++ b/allauth/socialaccount/providers/cern/urls.py
@@ -1,0 +1,6 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+
+from .provider import CernProvider
+
+
+urlpatterns = default_urlpatterns(CernProvider)

--- a/allauth/socialaccount/providers/cern/views.py
+++ b/allauth/socialaccount/providers/cern/views.py
@@ -1,0 +1,33 @@
+import requests
+
+from allauth.socialaccount.providers.oauth2.views import (
+    OAuth2Adapter,
+    OAuth2CallbackView,
+    OAuth2LoginView,
+)
+
+from .provider import CernProvider
+
+
+class CernOAuth2Adapter(OAuth2Adapter):
+    provider_id = CernProvider.id
+    access_token_url = 'https://oauth.web.cern.ch/OAuth/Token'
+    authorize_url = 'https://oauth.web.cern.ch/OAuth/Authorize'
+    profile_url = 'https://oauthresource.web.cern.ch/api/User'
+    groups_url = 'https://oauthresource.web.cern.ch/api/Groups'
+
+    supports_state = False
+    redirect_uri_protocol = 'https'
+
+    def complete_login(self, request, app, token, **kwargs):
+        headers = {'Authorization': 'Bearer {0}'.format(token.token)}
+        user_response = requests.get(self.profile_url, headers=headers)
+        groups_response = requests.get(self.groups_url, headers=headers)
+        extra_data = user_response.json()
+        extra_data.update(groups_response.json())
+        return self.get_provider().sociallogin_from_response(request,
+                                                             extra_data)
+
+
+oauth2_login = OAuth2LoginView.adapter_view(CernOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(CernOAuth2Adapter)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -58,6 +58,7 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
         'allauth.socialaccount.providers.bitbucket',
         'allauth.socialaccount.providers.bitbucket_oauth2',
         'allauth.socialaccount.providers.bitly',
+        'allauth.socialaccount.providers.cern',
         'allauth.socialaccount.providers.coinbase',
         'allauth.socialaccount.providers.dataporten',
         'allauth.socialaccount.providers.daum',

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -63,6 +63,8 @@ Supported Providers
 
 - Box (OAuth2)
 
+- CERN (OAuth2)
+
 - Dataporten (OAuth2)
 
 - Daum (OAuth2)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -191,9 +191,17 @@ Development callback URL
     http://localhost:8000/accounts/box/login/callback/
 
 
+CERN
+----
+App registration (get your key and secret here)
+    https://sso-management.web.cern.ch/OAuth/RegisterOAuthClient.aspx
+
+CERN OAuth2 Documentation
+    https://espace.cern.ch/authentication/CERN%20Authentication/OAuth.aspx
+
+
 Dataporten
 ----------
-
 App registration (get your key and secret here)
     https://docs.dataporten.no/docs/gettingstarted/
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.bitbucket_oauth2',
     'allauth.socialaccount.providers.bitly',
     'allauth.socialaccount.providers.box',
+    'allauth.socialaccount.providers.cern',
     'allauth.socialaccount.providers.coinbase',
     'allauth.socialaccount.providers.dataporten',
     'allauth.socialaccount.providers.daum',


### PR DESCRIPTION
This PR adds [CERN](https://home.cern/) OAuth2 support. 
It is already being actively used by physicists around the world in a CERN project I am working on.
Merging this into the django-allauth repository would enable other developers at CERN to easily integrate CERN single sign-on in their projects.