### PR TITLE
fix(signup): form autofocus use setting logic

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -119,3 +119,4 @@ Will Ross
 William Li
 Yuri Kriachko
 Yaroslav Muravsky
+Adam Faur

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -11,6 +11,8 @@ Note worthy changes
 
 - New providers: Disqus.
 
+- Signup form determines autofocus based on ACCOUNT_AUTHENTICATION_METHOD.
+
 
 0.36.0 (2018-05-08)
 *******************

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -257,15 +257,38 @@ def _base_signup_form_class():
 
 
 class BaseSignupForm(_base_signup_form_class()):
-    username = forms.CharField(label=_("Username"),
-                               min_length=app_settings.USERNAME_MIN_LENGTH,
-                               widget=forms.TextInput(
-                                   attrs={'placeholder':
-                                          _('Username'),
-                                          'autofocus': 'autofocus'}))
-    email = forms.EmailField(widget=forms.TextInput(
-        attrs={'type': 'email',
-               'placeholder': _('E-mail address')}))
+    username_widget = forms.TextInput(attrs={'placeholder': _('Username')})
+    email_widget = forms.TextInput(
+            attrs={
+                'type': 'email',
+                'placeholder': _('E-mail address')})
+
+    if app_settings.AUTHENTICATION_METHOD == AuthenticationMethod.EMAIL:
+        email_widget = forms.TextInput(
+                attrs={
+                    'type': 'email',
+                    'placeholder': _('E-mail address'),
+                    'autofocus': 'autofocus'})
+    elif app_settings.AUTHENTICATION_METHOD == AuthenticationMethod.USERNAME:
+        username_widget = forms.TextInput(
+                attrs={
+                    'placeholder': _('Username'),
+                    'autofocus': 'autofocus'})
+    else:
+        assert app_settings.AUTHENTICATION_METHOD \
+                == AuthenticationMethod.USERNAME_EMAIL
+        email_widget = forms.TextInput(
+                attrs={
+                    'type': 'email',
+                    'placeholder': _('E-mail address'),
+                    'autofocus': 'autofocus'})
+
+    username = forms.CharField(
+            label=_("Username"),
+            min_length=app_settings.USERNAME_MIN_LENGTH,
+            widget=username_widget)
+
+    email = forms.EmailField(widget=email_widget)
 
     def __init__(self, *args, **kwargs):
         email_required = kwargs.pop('email_required',


### PR DESCRIPTION
Login forms currently autofocus based on the `ACCOUNT_AUTHENTICATION_METHOD` setting.
The Signup form is currently not making a determination based on this. 

- Login Form Logic: https://github.com/pennersr/django-allauth/blob/330bf899dd77046fd0510221f3c12e69eb2bc64d/allauth/account/forms.py#L110-L131
- Docs: https://django-allauth.readthedocs.io/en/latest/configuration.html?highlight=ACCOUNT_AUTHENTICATION_METHOD

The signup form field order places email before username. 

- Signup Form Field Order Logic: https://github.com/pennersr/django-allauth/blob/330bf899dd77046fd0510221f3c12e69eb2bc64d/allauth/account/forms.py#L283-L289

In the case of `ACCOUNT_AUTHENTICATION_METHOD = 'username_email'` the email field would display first but autofocus would be on the username field.

This PR addresses this problem by allowing the correct field to obtain autofocus based on your settings.

