### PR TITLE
fix(Auth0): Support OIDC conformant clients as well

### DIFF
--- a/allauth/socialaccount/providers/auth0/provider.py
+++ b/allauth/socialaccount/providers/auth0/provider.py
@@ -18,6 +18,9 @@ class Auth0Provider(OAuth2Provider):
     name = 'Auth0'
     account_class = Auth0Account
 
+    def get_default_scope(self):
+        return ['openid', 'profile', 'email']
+
     def extract_uid(self, data):
         return str(data['id'])
 

--- a/allauth/socialaccount/providers/auth0/tests.py
+++ b/allauth/socialaccount/providers/auth0/tests.py
@@ -13,7 +13,7 @@ class Auth0Tests(OAuth2TestsMixin, TestCase):
                 "picture": "https://secure.gravatar.com/avatar/123",
                 "email": "mr.bob@your.Auth0.server.example.com",
                 "id": 2,
-                "user_id": 2,
+                "sub": 2,
                 "identities": [],
                 "name": "Mr Bob"
             }

--- a/allauth/socialaccount/providers/auth0/views.py
+++ b/allauth/socialaccount/providers/auth0/views.py
@@ -26,8 +26,8 @@ class Auth0OAuth2Adapter(OAuth2Adapter):
             'access_token': token.token
         }).json()
         extra_data = {
-            'user_id': extra_data['user_id'],
-            'id': extra_data['user_id'],
+            'user_id': extra_data['sub'],
+            'id': extra_data['sub'],
             'name': extra_data['name'],
             'email': extra_data['email']
         }


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure yo use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages). 
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] Javascript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`

Now Auth0 clients are OIDC compliant by default, so the response from `/userinfo` endpoint and the `id_token` includes only the [OpenID connect standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims).
Setting the default scopes *openid*, *profile* and *email* the user profile always will be OIDC compliant regardless if `OIDC conformant` is disabled in the client settings.