### PR TITLE
fix(baidu): Fixed baidu's get_profile_url bug.

### DIFF
--- a/allauth/socialaccount/providers/baidu/provider.py
+++ b/allauth/socialaccount/providers/baidu/provider.py
@@ -4,9 +4,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class BaiduAccount(ProviderAccount):
     def get_profile_url(self):
-        return (
-            'https://openapi.baidu.com'
-            '/rest/2.0/passport/users/getLoggedInUser')
+        return "http://www.baidu.com/p/" + self.account.extra_data.get('uname')
 
     def get_avatar_url(self):
         return (


### PR DESCRIPTION
Old: The function always return fixed url `https://openapi.baidu.com//rest/2.0/passport/users/getLoggedInUser`. This is not the correct url point to user's profile page.

New: `https://www.baidu.com/p/<uname>/` Is the correct user's profile page. Like https://www.baidu.com/p/seieewkx.