### PR TITLE
fix(azure): also use "userPrincipalName" as a common field for email

### DIFF
--- a/allauth/socialaccount/providers/azure/provider.py
+++ b/allauth/socialaccount/providers/azure/provider.py
@@ -37,6 +37,8 @@ class AzureProvider(OAuth2Provider):
 
     def extract_common_fields(self, data):
         email = data.get('mail')
+        if not email and 'userPrincipalName' in data:
+            email = data.get('userPrincipalName')
         return dict(email=email,
                     username=email,
                     last_name=data.get('surname'),


### PR DESCRIPTION
When attempting to sign up with azure, it was failing the "email required" step, because no "mail" property was sent along in extra_data. only "userPrincipalName".

see: https://docs.microsoft.com/en-us/azure/active-directory/connect/active-directory-aadconnect-userprincipalname