### PR TITLE
Added 201_created to oauth2/client.py.

### DIFF
--- a/allauth/socialaccount/providers/oauth2/client.py
+++ b/allauth/socialaccount/providers/oauth2/client.py
@@ -73,7 +73,7 @@ class OAuth2Client(object):
             auth=auth)
 
         access_token = None
-        if resp.status_code == 200:
+        if resp.status_code in [200, 201]:
             # Weibo sends json via 'text/plain;charset=UTF-8'
             if (resp.headers['content-type'].split(
                     ';')[0] == 'application/json' or resp.text[:2] == '{"'):


### PR DESCRIPTION
# Submitting Pull Requests
Rationale: 
  - Some providers like "Medium" returns 201_created on the response for access_token issuing. 
## General

 - [x] Make sure yo use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages). 
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] Javascript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`
