### PR TITLE
docs : add 'django.contrib.messages' to the required apps list

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,6 +41,7 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
         ...
         # The following apps are required:
         'django.contrib.auth',
+        'django.contrib.messages',
         'django.contrib.sites',
 
         'allauth',


### PR DESCRIPTION
'django.contrib.messages' albeit customisable, is quite fundamental to display useful warning messages.
