### PR TITLE
Fixed potentially faulty if statement

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -357,9 +357,9 @@ def sync_user_email_addresses(user):
 
 
 def filter_users_by_username(*username):
-    if not app_settings.PRESERVE_USERNAME_CASING:
+    if app_settings.PRESERVE_USERNAME_CASING:
         qlist = [
-            Q(**{app_settings.USER_MODEL_USERNAME_FIELD + '__iexact': u})
+            Q(**{app_settings.USER_MODEL_USERNAME_FIELD + '__exact': u})
             for u in username]
         q = qlist[0]
         for q2 in qlist[1:]:

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -357,7 +357,7 @@ def sync_user_email_addresses(user):
 
 
 def filter_users_by_username(*username):
-    if app_settings.PRESERVE_USERNAME_CASING:
+    if not app_settings.PRESERVE_USERNAME_CASING:
         qlist = [
             Q(**{app_settings.USER_MODEL_USERNAME_FIELD + '__iexact': u})
             for u in username]


### PR DESCRIPTION
The ```PRESERVE_USERNAME_CASING``` - when True - ran  a case insensitive search on username. 
I propose changing the if statement so that such a search would only be done when ```PRESERVE_USERNAME_CASING``` is False

This potential bug was discovered when allauth started throwing errors in our app where both  'Bob' and 'bob'  would throw a 
``` MultipleObjectsReturned: get() returned more than one User -- it returned 2! ``` error during a failed login.

