### PR TITLE
Change kakao's extra common field name from 'nickname' to 'username'

### DIFF
--- a/allauth/socialaccount/providers/kakao/provider.py
+++ b/allauth/socialaccount/providers/kakao/provider.py
@@ -28,7 +28,7 @@ class KakaoProvider(OAuth2Provider):
         email = data['kakao_account'].get('email')
         nickname = data['properties'].get('nickname')
 
-        return dict(email=email, nickname=nickname)
+        return dict(email=email, username=nickname)
 
     def extract_email_addresses(self, data):
         ret = []


### PR DESCRIPTION
In kakaoprovider, the key name of the extra common fields is 'nickname'. This looks a bit strange.