### PR TITLE
fix(kakao): common field and profile image

### DIFF
--- a/allauth/socialaccount/providers/kakao/provider.py
+++ b/allauth/socialaccount/providers/kakao/provider.py
@@ -25,10 +25,9 @@ class KakaoProvider(OAuth2Provider):
         return str(data['id'])
 
     def extract_common_fields(self, data):
-        email = data['kakao_account'].get('email')
         nickname = data['properties'].get('nickname')
 
-        return dict(email=email, username=nickname)
+        return dict(username=nickname)
 
     def extract_email_addresses(self, data):
         ret = []

--- a/allauth/socialaccount/providers/kakao/provider.py
+++ b/allauth/socialaccount/providers/kakao/provider.py
@@ -8,7 +8,7 @@ class KakaoAccount(ProviderAccount):
     def properties(self):
         return self.account.extra_data.get('properties')
 
-    def get_avatar_url(self):
+    def get_profile_url(self):
         return self.properties.get('profile_image')
 
     def to_str(self):


### PR DESCRIPTION
# Submitting Pull Requests

Kakao no longer offers email as a required field. So it is strange that email is in the common_field.
And kakao provides profile image url but we are using it as avatar url.

## General

 - [ ] Make sure yo use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages). 
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must be 100% pep8 and isort clean.
 - [ ] Javascript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`
