### PR TITLE
fix(battlenet): Update provider urls

### DIFF
--- a/allauth/socialaccount/providers/battlenet/views.py
+++ b/allauth/socialaccount/providers/battlenet/views.py
@@ -105,12 +105,6 @@ class BattleNetOAuth2Adapter(OAuth2Adapter):
         return "https://%s.battle.net" % (region)
 
     @property
-    def battlenet_api_url(self):
-        if self.battlenet_region == "cn":
-            return "https://api.battlenet.com.cn"
-        return "https://%s.api.battle.net" % (self.battlenet_region)
-
-    @property
     def access_token_url(self):
         return self.battlenet_base_url + "/oauth/token"
 
@@ -120,7 +114,7 @@ class BattleNetOAuth2Adapter(OAuth2Adapter):
 
     @property
     def profile_url(self):
-        return self.battlenet_api_url + "/account/user"
+        return self.battlenet_base_url + "/oauth/userinfo"
 
     def complete_login(self, request, app, token, **kwargs):
         params = {"access_token": token.token}

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -151,10 +151,10 @@ Battle.net
 ----------
 
 The Battle.net OAuth2 authentication documentation
-    https://dev.battle.net/docs/read/oauth
+    https://develop.battle.net/documentation/guides/using-oauth
 
-Register your app here (Mashery account required)
-    https://dev.battle.net/apps/register
+Register your app here (Blizzard account required)
+    https://develop.battle.net/access/clients/create
 
 Development callback URL
     https://localhost:8000/accounts/battlenet/login/callback/


### PR DESCRIPTION
The Battle.net provider URLs have [recently changed][1]. Users will have to update their API keys by creating an application in the new [Battle.net developer portal][2].

With regards to release planning, the old endpoints will be turned off on January 6th. In addition the new endpoints require new API keys to be obtained, but all user ids will still be applicable.

This touched  #2125 in so far that it just updates the URLs instead of provisioning a fully new provider.

[1]: https://develop.battle.net/documentation/guides/migration-guide
[2]: https://develop.battle.net/

# Submitting Pull Requests

## General

 - [x] Make sure yo use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages). 
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] ~~Javascript code should adhere to [StandardJS](https://standardjs.com).~~
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
~~In case you add a new provider:~~