### PR TITLE
Documentation improvements on Forms page

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Christopher Grebs
 Daniel Eriksson
 Daniel Widerin
 David Ascher
+David Cain
 David Evans
 David Friedman
 Egor Poderyagin

--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -1,7 +1,7 @@
 Forms
 =====
 
-The following forms can be overridden as needed.
+The following forms can be overridden as needed in order to:
 
 - Add extra fields for extra required information
 - Override save to add extra functionality on save
@@ -10,7 +10,7 @@ Overriding Save
 ---------------
 
 If you decide to add fields to a form, you will need to
-manually save the custom fields data.
+manually save the custom fields' data.
 
 ACCOUNT_FORMS
 -------------
@@ -25,7 +25,7 @@ Default Settings::
         'set_password': 'allauth.account.forms.SetPasswordForm',
         'reset_password': 'allauth.account.forms.ResetPasswordForm',
         'reset_password_from_key': 'allauth.account.forms.ResetPasswordKeyForm',
-        'disconnect': `allauth.socialaccount.forms.DisconnectForm`,
+        'disconnect': 'allauth.socialaccount.forms.DisconnectForm',
     }
 
 login (``allauth.account.forms.LoginForm``)
@@ -66,7 +66,7 @@ Used on `account_signup <views.html#signup-account-signup>`__ view.
 
         def save(self, request):
 
-            # Ensure you call the parent classes save.
+            # Ensure you call the parent class's save.
             # .save() returns a User object.
             user = super(MyCustomSignupForm, self).save(request)
 
@@ -91,8 +91,8 @@ Used on `account_email <views.html#e-mails-management-account-email>`__ view.
 
         def save(self):
 
-            # Ensure you call the parent classes save.
-            # .save() returns a allauth.account.models.EmailAddress object.
+            # Ensure you call the parent class's save.
+            # .save() returns an allauth.account.models.EmailAddress object.
             email_address_obj = super(MyCustomAddEmailForm, self).save()
 
             # Add your own processing here.
@@ -120,7 +120,7 @@ Used on `account_change_password <views.html#password-management>`__ view.
 
         def save(self):
 
-            # Ensure you call the parent classes save
+            # Ensure you call the parent class's save.
             # .save() does not return anything
             super(MyCustomChangePasswordForm, self).save()
 
@@ -146,7 +146,7 @@ Used on `account_set_password <views.html#password-management>`__ view.
 
         def save(self):
 
-            # Ensure you call the parent classes save
+            # Ensure you call the parent class's save.
             # .save() does not return anything
             super(MyCustomSetPasswordForm, self).save()
 
@@ -172,7 +172,7 @@ Used on `account_reset_password <views.html#password-reset-account-reset-passwor
 
         def save(self):
 
-            # Ensure you call the parent classes save
+            # Ensure you call the parent class's save.
             # .save() returns a string containing the email address supplied
             email_address = super(MyCustomResetPasswordForm, self).save()
 
@@ -183,7 +183,7 @@ Used on `account_reset_password <views.html#password-reset-account-reset-passwor
 
 You have access to the following:
 
-- ``self.users`` is a list of all possible User objects with matching email address
+- ``self.users`` is a list of all possible User objects with matching email address.
 
 ``settings.py``::
 
@@ -203,13 +203,13 @@ Used on `account_reset_password <views.html#password-reset-account-reset-passwor
 
             # Add your own processing here.
 
-            # Ensure you call the parent classes save
+            # Ensure you call the parent class's save.
             # .save() does not return anything
             super(MyCustomResetPasswordKeyForm, self).save()
 
 You have access to the following:
 
-- ``self.user`` is the User object
+- ``self.user`` is the User object.
 
 ``settings.py``::
 
@@ -238,7 +238,7 @@ with a social account and needs to create an account.
 
         def save(self):
 
-            # Ensure you call the parent classes save.
+            # Ensure you call the parent class's save.
             # .save() returns a User object.
             user = super(MyCustomSocialSignupForm, self).save()
 
@@ -270,7 +270,7 @@ Used on socialaccount_connections view, used when removing a social account.
             # Add your own processing here if you do need access to the
             # socialaccount being deleted.
 
-            # Ensure you call the parent classes save.
+            # Ensure you call the parent class's save.
             # .save() does not return anything
             super(MyCustomSocialDisconnectForm, self).save()
 
@@ -280,10 +280,10 @@ Used on socialaccount_connections view, used when removing a social account.
 You have access to the following:
 
 - ``self.request`` is the request object
-- ``self.accounts`` is a list containing all of the users SocialAccount objects.
-- ``self.cleaned_data['account']`` contains the socialaccount being deleted. .save()
-  issues the delete so if you need access to the socialaccount beforehand, move your
-  code before .save()
+- ``self.accounts`` is a list containing all of the user's SocialAccount objects.
+- ``self.cleaned_data['account']`` contains the socialaccount being deleted. ``.save()``
+  issues the delete. So if you need access to the socialaccount beforehand, move your
+  code before ``.save()``.
 
 ``settings.py``::
 


### PR DESCRIPTION
Just some small touch-ups!

- Use proper single quotes in code sample
- Add apostrophes to possessives
- Consistently use periods at the end of sentences
- Use code formatting when referring to `save` method