### PR TITLE
feat(oauth): Show an informative log when OAuthError is raised

### DIFF
--- a/allauth/socialaccount/providers/oauth/client.py
+++ b/allauth/socialaccount/providers/oauth/client.py
@@ -77,7 +77,9 @@ class OAuthClient(object):
                 raise OAuthError(
                     _('Invalid response while obtaining request token'
                       ' from "%s".') % get_token_prefix(
-                          self.request_token_url))
+                            self.request_token_url) +
+                    ' Response content: %s' % response.content.decode("utf-8")
+                )
             self.request_token = dict(parse_qsl(response.text))
             self.request.session['oauth_%s_request_token' % get_token_prefix(
                 self.request_token_url)] = self.request_token

--- a/allauth/socialaccount/providers/oauth/views.py
+++ b/allauth/socialaccount/providers/oauth/views.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from django.urls import reverse
 
 from allauth.socialaccount import providers
@@ -14,6 +16,9 @@ from allauth.socialaccount.providers.oauth.client import (
 )
 
 from ..base import AuthAction, AuthError
+
+
+logger = logging.getLogger(__name__)
 
 
 class OAuthAdapter(object):
@@ -69,6 +74,7 @@ class OAuthLoginView(OAuthView):
         try:
             return client.get_redirect(auth_url, auth_params)
         except OAuthError as e:
+            logger.exception('Error processing OAuth')
             return render_authentication_error(request,
                                                self.adapter.provider_id,
                                                exception=e)


### PR DESCRIPTION
This is similar to the way [facebook/views.py](https://github.com/pennersr/django-allauth/blob/41f84f5530b75431cfd4cf2b89cd805ced009e7d/allauth/socialaccount/providers/facebook/views.py) logs an exception.

This feature was requested on #2142.

Example log:
`allauth.socialaccount.providers.oauth.client.OAuthError: Invalid response while obtaining request token from "api.twitter.com". Response content: <?xml version="1.0" encoding="UTF-8"?><errors><error code="415">Callback URL not approved for this client application. Approved callback URLs can be adjusted in your application settings</error></errors>`