### PR TITLE
Place code in code block to preserve quotes

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -59,7 +59,7 @@ machine you are developing on. Therefore, ``allauth`` is unable to send
 verification mails.
 
 You can work around this by adding the following line to
-``settings.py``:
+``settings.py``::
 
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 


### PR DESCRIPTION
on readthedocs a quote block will have any quotes (') substituted with apostrophes. Make quote block a codeblock to preserve quotes.