### PR TITLE
feat(signal): Add post auth signal during social auth after token request

### DIFF
--- a/allauth/socialaccount/providers/oauth/views.py
+++ b/allauth/socialaccount/providers/oauth/views.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.urls import reverse
 
-from allauth.socialaccount import providers
+from allauth.socialaccount import providers, signals
 from allauth.socialaccount.helpers import (
     complete_social_login,
     render_authentication_error,
@@ -101,6 +101,11 @@ class OAuthCallbackView(OAuthView):
                 token=access_token['oauth_token'],
                 # .get() -- e.g. Evernote does not feature a secret
                 token_secret=access_token.get('oauth_token_secret', ''))
+            signals.post_authorization_response.send(sender=SocialLogin,
+                                                     request=request,
+                                                     socialapp=app,
+                                                     socialtoken=token,
+                                                     response=access_token)
             login = self.adapter.complete_login(request,
                                                 app,
                                                 token,

--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from allauth.exceptions import ImmediateHttpResponse
-from allauth.socialaccount import providers
+from allauth.socialaccount import providers, signals
 from allauth.socialaccount.helpers import (
     complete_social_login,
     render_authentication_error,
@@ -128,6 +128,11 @@ class OAuth2CallbackView(OAuth2View):
             access_token = client.get_access_token(request.GET['code'])
             token = self.adapter.parse_token(access_token)
             token.app = app
+            signals.post_authorization_response.send(sender=SocialLogin,
+                                                     request=request,
+                                                     socialapp=app,
+                                                     socialtoken=token,
+                                                     response=access_token)
             login = self.adapter.complete_login(request,
                                                 app,
                                                 token,

--- a/allauth/socialaccount/signals.py
+++ b/allauth/socialaccount/signals.py
@@ -21,5 +21,6 @@ social_account_removed = Signal(providing_args=["request", "socialaccount"])
 
 # Sent after the user has authorized access and allauth has obtained the
 # token information from the code supplied.
-post_authorization_response = Signal(providing_args=["request", "socialapp",
-                                                     "socialtoken", "response"])
+post_authorization_response = Signal(providing_args=[
+    "request", "socialapp", "socialtoken", "response"
+])

--- a/allauth/socialaccount/signals.py
+++ b/allauth/socialaccount/signals.py
@@ -18,3 +18,8 @@ social_account_updated = Signal(providing_args=["request", "sociallogin"])
 # Sent after a user disconnects a social account from their local
 # account.
 social_account_removed = Signal(providing_args=["request", "socialaccount"])
+
+# Sent after the user has authorized access and allauth has obtained the
+# token information from the code supplied.
+post_authorization_response = Signal(providing_args=["request", "socialapp",
+                                                     "socialtoken", "response"])

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -10,61 +10,83 @@ allauth.account
 
 
 - ``allauth.account.signals.user_logged_in(request, user)``
-    Sent when a user logs in.
+
+  Sent when a user logs in.
 
 - ``allauth.account.signals.user_logged_out(request, user)``
-    Sent when a user logs out.
+
+  Sent when a user logs out.
 
 - ``allauth.account.signals.user_signed_up(request, user)``
-    Sent when a user signs up for an account. This signal is
-    typically followed by a ``user_logged_in``, unless e-mail verification
-    prohibits the user to log in.
+
+  Sent when a user signs up for an account. This signal is
+  typically followed by a ``user_logged_in``, unless e-mail verification
+  prohibits the user to log in.
 
 - ``allauth.account.signals.password_set(request, user)``
-    Sent when a password has been successfully set for the first time.
+
+  Sent when a password has been successfully set for the first time.
 
 - ``allauth.account.signals.password_changed(request, user)``
-    Sent when a password has been successfully changed.
+
+  Sent when a password has been successfully changed.
 
 - ``allauth.account.signals.password_reset(request, user)``
-    Sent when a password has been successfully reset.
+
+  Sent when a password has been successfully reset.
 
 - ``allauth.account.signals.email_confirmed(request, email_address)``
-    Sent after the email address in the db was updated and set to confirmed.
+
+  Sent after the email address in the db was updated and set to confirmed.
 
 - ``allauth.account.signals.email_confirmation_sent(request, confirmation, signup)``
-    Sent right after the email confirmation is sent.
+
+  Sent right after the email confirmation is sent.
 
 - ``allauth.account.signals.email_changed(request, user, from_email_address, to_email_address)``
-    Sent when a primary email address has been changed.
+
+  Sent when a primary email address has been changed.
 
 - ``allauth.account.signals.email_added(request, user, email_address)``
-    Sent when a new email address has been added.
+
+  Sent when a new email address has been added.
 
 - ``allauth.account.signals.email_removed(request, user, email_address)``
-    Sent when an email address has been deleted.
+
+  Sent when an email address has been deleted.
 
 
 allauth.socialaccount
 ---------------------
 
 - ``allauth.socialaccount.signals.pre_social_login(request, sociallogin)``
-    Sent after a user successfully authenticates via a social provider,
-    but before the login is fully processed. This signal is emitted as
-    part of the social login and/or signup process, as well as when
-    connecting additional social accounts to an existing account. Access
-    tokens and profile information, if applicable for the provider, is
-    provided.
+
+  Sent after a user successfully authenticates via a social provider,
+  but before the login is fully processed. This signal is emitted as
+  part of the social login and/or signup process, as well as when
+  connecting additional social accounts to an existing account. Access
+  tokens and profile information, if applicable for the provider, is
+  provided.
 
 - ``allauth.socialaccount.signals.social_account_added(request, sociallogin)``
-    Sent after a user connects a social account to a their local account.
+
+  Sent after a user connects a social account to a their local account.
 
 - ``allauth.socialaccount.signals.social_account_updated(request, sociallogin)``
-    Sent after a social account has been updated. This happens when a user
-    logs in using an already connected social account, or completes a `connect`
-    flow for an already connected social account. Useful if you need to
-    unpack extra data for social accounts as they are updated.
+
+  Sent after a social account has been updated. This happens when a user
+  logs in using an already connected social account, or completes a `connect`
+  flow for an already connected social account. Useful if you need to
+  unpack extra data for social accounts as they are updated.
 
 - ``allauth.socialaccount.signals.social_account_removed(request, socialaccount)``
-    Sent after a user disconnects a social account from their local
-    account.
+
+  Sent after a user disconnects a social account from their local
+  account.
+
+- ``allauth.socialaccount.signals.post_authorization_response(request, socialapp, socialtoken, response)``
+
+  Sent after a user authorizes access and is sent back to your callback url.
+  Allauth uses the code supplied and obtains the token information.
+  response is the dict containing the response information
+  i.e. access/refresh token, scopes, expiry...etc.


### PR DESCRIPTION
Some providers do not return all information during the callback and must be obtained through the authorization call using the code supplied.

There is currently no way to obtain that response information other than to re-create the provider as a custom provider and override the view where complete_login is called.

My instance of this is needing to confirm scopes were granted or not. Google returns the scopes at the same time as the auth code so I was able to use a pre_social_login signal which has the response object. Microsoft Graph and Windows Live only returns scopes in the auth response.