### PR TITLE
feat(battlenet): added Region parameter to provider settings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Jannis Leidel
 Jannis Vajen
 Jeff Triplett
 Jerome Leclanche
+Jesse Gerard Brands
 Jiyoon Ha
 Joe Vanderstelt
 John Bazik

--- a/allauth/socialaccount/providers/battlenet/views.py
+++ b/allauth/socialaccount/providers/battlenet/views.py
@@ -14,6 +14,8 @@ Resources:
 """
 import requests
 
+from django.conf import settings
+
 from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
@@ -89,12 +91,21 @@ class BattleNetOAuth2Adapter(OAuth2Adapter):
 
     @property
     def battlenet_region(self):
+        # Check by URI query parameter first.
         region = self.request.GET.get("region", "").lower()
         if region == Region.SEA:
             # South-East Asia uses the same region as US everywhere
             return Region.US
         if region in self.valid_regions:
             return region
+
+        # Second, check the provider settings.
+        region = getattr(settings, 'SOCIALACCOUNT_PROVIDERS', {}).get(
+            'battlenet', {}).get('REGION', 'us')
+
+        if region in self.valid_regions:
+            return region
+
         return Region.US
 
     @property

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -176,6 +176,27 @@ which will accept the ``#`` character using the ``ACCOUNT_USERNAME_VALIDATORS``
 setting. Such a validator is available in
 ``socialaccount.providers.battlenet.validators.BattletagUsernameValidator``.
 
+The following Battle.net settings are available:
+
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'facebook': {
+            'SCOPE': ['wow.profile', 'sc2.profile'],
+            'REGION': 'us',
+        }
+    }
+
+SCOPE:
+    Scope can be an array of the following options: ``wow.profile`` allows
+    access to the user's World of Warcraft characters. ``sc2.profile`` allows
+    access to the user's StarCraft 2 profile. The default setting is ``[]``.
+
+REGION:
+    Either ``apac``, ``cn``, ``eu``, ``kr``, ``sea``, ``tw`` or ``us``
+
+    Sets the default region to use, can be overriden using query parameters
+    in the URL, for example: ``?region=eu``. Defaults to ``us``.
 
 Bitbucket
 ---------


### PR DESCRIPTION
Added:

- Provider setting to specify default Region. This is more convenient than setting the query parameter every time, which is prone to user error. The preference now is; query parameter (unchanged) > setting (added) > default fallback (unchanged)
- Added documentation for the Battle.net provider for this new setting.
- Also documented available scopes while I was at it, since that wasn't explicitly documented yet.

Rationale:
For a lot of use cases, the Battle.net API will only be used by users from primarily a single region (for example, a website for a World of Warcraft guild), setting a default would be convenient for such applications. The query parameter is useful, but one must take care to make sure its uniformly specified everywhere the link is placed.

More sensible is to override the default when this is required instead.

Comments:
First time making a pull request, hope it's all good.