### PR TITLE
Issue 2235 password value sent back on response

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -64,14 +64,20 @@ class PasswordVerificationMixin(object):
 
 
 class PasswordField(forms.CharField):
+    _render_value = False
 
     def __init__(self, *args, **kwargs):
-        render_value = kwargs.pop('render_value',
+        self._render_value = kwargs.pop('render_value',
                                   app_settings.PASSWORD_INPUT_RENDER_VALUE)
-        kwargs['widget'] = forms.PasswordInput(render_value=render_value,
+        kwargs['widget'] = forms.PasswordInput(render_value=self._render_value,
                                                attrs={'placeholder':
                                                       kwargs.get("label")})
         super(PasswordField, self).__init__(*args, **kwargs)
+
+    def prepare_value(self, value):
+        if self._render_value:
+            return value
+        return None
 
 
 class SetPasswordField(PasswordField):

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -67,8 +67,9 @@ class PasswordField(forms.CharField):
     _render_value = False
 
     def __init__(self, *args, **kwargs):
-        self._render_value = kwargs.pop('render_value',
-                                  app_settings.PASSWORD_INPUT_RENDER_VALUE)
+        self._render_value = kwargs.pop(
+                           'render_value',
+                           app_settings.PASSWORD_INPUT_RENDER_VALUE)
         kwargs['widget'] = forms.PasswordInput(render_value=self._render_value,
                                                attrs={'placeholder':
                                                       kwargs.get("label")})

--- a/allauth/socialaccount/providers/linkedin_oauth2/views.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/views.py
@@ -27,7 +27,7 @@ class LinkedInOAuth2Adapter(OAuth2Adapter):
         fields = self.get_provider().get_profile_fields()
         url = self.profile_url + ':(%s)?format=json' % ','.join(fields)
         resp = requests.get(url, params={'oauth2_access_token': token.token})
-        resp.raise_for_status()        
+        resp.raise_for_status()
         return resp.json()
 
 


### PR DESCRIPTION
fixes issue #2235 
added attribute to `PasswordField` that keeps boolean of `render_value` and overrided `prepare_value` to respect the `render_value` and return `None` if value should not be rendered