### PR TITLE
feat(socialaccount): Add Facebook additional scope (re)requesting

### DIFF
--- a/allauth/socialaccount/providers/base.py
+++ b/allauth/socialaccount/providers/base.py
@@ -15,6 +15,7 @@ class AuthProcess(object):
 class AuthAction(object):
     AUTHENTICATE = 'authenticate'
     REAUTHENTICATE = 'reauthenticate'
+    REREQUEST = 'rerequest'
 
 
 class AuthError(object):

--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -65,7 +65,11 @@ class FacebookProvider(OAuth2Provider):
                 kwargs.get('process') or AuthProcess.LOGIN)
             action = "'%s'" % escapejs(
                 kwargs.get('action') or AuthAction.AUTHENTICATE)
-            js = "allauth.facebook.login(%s, %s, %s)" % (next, action, process)
+            scope = "'%s'" % escapejs(
+                kwargs.get('scope', '')
+            )
+            js = "allauth.facebook.login(%s, %s, %s, %s)" % (
+                next, action, process, scope)
             ret = "javascript:%s" % (urlquote(js),)
         else:
             assert method == 'oauth2'
@@ -114,6 +118,8 @@ class FacebookProvider(OAuth2Provider):
                                                             action)
         if action == AuthAction.REAUTHENTICATE:
             ret['auth_type'] = 'reauthenticate'
+        elif action == AuthAction.REREQUEST:
+            ret['auth_type'] = 'rerequest'
         return ret
 
     def get_init_params(self, request, app):

--- a/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
+++ b/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
@@ -56,15 +56,18 @@
     onInit: function () {
     },
 
-    login: function (nextUrl, action, process) {
+    login: function (nextUrl, action, process, scope) {
       var self = this
       if (!fbInitialized) {
-        var url = this.opts.loginUrl + '?next=' + encodeURIComponent(nextUrl) + '&action=' + encodeURIComponent(action) + '&process=' + encodeURIComponent(process)
+        var url = this.opts.loginUrl + '?next=' + encodeURIComponent(nextUrl) + '&action=' + encodeURIComponent(action) + '&process=' + encodeURIComponent(process) + '&scope=' + encodeURIComponent(scope)
         setLocationHref(url)
         return
       }
-      if (action === 'reauthenticate') {
+      if (action === 'reauthenticate' || action === 'rerequest') {
         this.opts.loginOptions.auth_type = action
+      }
+      if (scope != '') {
+        this.opts.loginOptions.scope = scope
       }
 
       FB.login(function (response) {

--- a/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
+++ b/allauth/socialaccount/providers/facebook/static/facebook/js/fbconnect.js
@@ -66,7 +66,7 @@
       if (action === 'reauthenticate' || action === 'rerequest') {
         this.opts.loginOptions.auth_type = action
       }
-      if (scope != '') {
+      if (scope !== '') {
         this.opts.loginOptions.scope = scope
       }
 


### PR DESCRIPTION
Added the ability to override default permission scopes as well as declare the `rerequest` auth type for Facebook.

The scope override is needed in the case that you want to request additional permissions beyond those you originally requested (i.e. those defined in `SOCIALACCOUNT_PROVIDERS`) as well as in the case that you want to re-request a permission the user previously declined, in which case you also need to be able to set the `auth_type` to `rerequest` (see [Re-asking for Declined Permissions](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#reaskperms) in the Facebook Login docs).

I'm happy to also update the docs and tests for this change but wanted to see if there was any feedback before doing so.