### PR TITLE
fix(slack): Use proper identity endpoint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ James Thompson
 Jannis Leidel
 Jannis Vajen
 Jeff Triplett
+Jeremy Satterfield
 Jerome Leclanche
 Jiyoon Ha
 Joe Vanderstelt

--- a/allauth/socialaccount/providers/slack/provider.py
+++ b/allauth/socialaccount/providers/slack/provider.py
@@ -24,8 +24,9 @@ class SlackProvider(OAuth2Provider):
                           str(data.get('user').get('id')))
 
     def extract_common_fields(self, data):
-        return dict(name=data.get('name'),
-                    email=data.get('user').get('email', None))
+        user = data.get('user', {})
+        return {'name': user.get('name'),
+                'email': user.get('email', None)}
 
     def get_default_scope(self):
         return ['identify']

--- a/allauth/socialaccount/providers/slack/views.py
+++ b/allauth/socialaccount/providers/slack/views.py
@@ -15,7 +15,7 @@ class SlackOAuth2Adapter(OAuth2Adapter):
 
     access_token_url = 'https://slack.com/api/oauth.access'
     authorize_url = 'https://slack.com/oauth/authorize'
-    identity_url = 'https://slack.com/api/auth.test'
+    identity_url = 'https://slack.com/api/users.identity'
 
     def complete_login(self, request, app, token, **kwargs):
         extra_data = self.get_data(token.token)
@@ -33,20 +33,7 @@ class SlackOAuth2Adapter(OAuth2Adapter):
         if not resp.get('ok'):
             raise OAuth2Error()
 
-        # Fill in their generic info
-        info = {
-            'name': resp.get('user'),
-            'user': {
-                'name': resp.get('user'),
-                'id': resp.get('user_id')
-            },
-            'team': {
-                'name': resp.get('team'),
-                'id': resp.get('team_id')
-            }
-        }
-
-        return info
+        return resp
 
 
 oauth2_login = OAuth2LoginView.adapter_view(SlackOAuth2Adapter)


### PR DESCRIPTION
Using `users.identity` includes full user details rather than partial provided by `auth.test`

# Submitting Pull Requests

## General

 - [X] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [X] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [X] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
