### PR TITLE
feat(socialaccount) Add Sharefile provider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ Roberto Novaes
 Rod Xavier Bondoc
 Roman Tomjak
 Roumen Antonov
+Ryan Jarvis
 Ryan Verner
 Sam Solomon
 Sanghyeok Lee

--- a/allauth/socialaccount/providers/sharefile/provider.py
+++ b/allauth/socialaccount/providers/sharefile/provider.py
@@ -1,0 +1,27 @@
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class ShareFileAccount(ProviderAccount):
+    def to_str(self):
+        dflt = super(ShareFileAccount, self).to_str()
+        return self.account.extra_data.get('name', dflt)
+
+
+class ShareFileProvider(OAuth2Provider):
+    id = 'sharefile'
+    name = 'ShareFile'
+    account_class = ShareFileAccount
+
+    def extract_uid(self, data):
+        return str(data.get('Id', ''))
+
+    def extract_common_fields(self, data):
+        return dict(
+            email=data.get('Email', ''),
+            username=data.get('Username', ''),
+            name=data.get('FullName', ''),
+        )
+
+
+provider_classes = [ShareFileProvider]

--- a/allauth/socialaccount/providers/sharefile/tests.py
+++ b/allauth/socialaccount/providers/sharefile/tests.py
@@ -1,0 +1,25 @@
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
+
+from .provider import ShareFileProvider
+
+
+class ShareFileTests(OAuth2TestsMixin, TestCase):
+    provider_id = ShareFileProvider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(200, """
+        {"access_token": "12345678abcdef", 
+         "refresh_token": "12345678abcdef",
+         "token_type": "bearer", 
+         "expires_in": 28800,
+         "appcp": "sharefile.com", 
+         "apicp": "sharefile.com", 
+         "subdomain": "example",
+         "access_files_folders": true, 
+         "modify_files_folders": true, 
+         "admin_users": true, 
+         "admin_accounts": true, 
+         "change_my_settings": true,
+          "web_app_login": true}
+        """)

--- a/allauth/socialaccount/providers/sharefile/urls.py
+++ b/allauth/socialaccount/providers/sharefile/urls.py
@@ -1,0 +1,4 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+from .provider import ShareFileProvider
+
+urlpatterns = default_urlpatterns(ShareFileProvider)

--- a/allauth/socialaccount/providers/sharefile/views.py
+++ b/allauth/socialaccount/providers/sharefile/views.py
@@ -1,0 +1,31 @@
+import requests
+
+from allauth.socialaccount import app_settings
+from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter, OAuth2CallbackView, OAuth2LoginView
+from .provider import ShareFileProvider
+
+
+class ShareFileOAuth2Adapter(OAuth2Adapter):
+    provider_id = ShareFileProvider.id
+    settings = app_settings.PROVIDERS.get(provider_id, {})
+    subdomain = settings.get('SUBDOMAIN', 'secure')
+    apicp = settings.get('APICP', 'sharefile.com')
+
+    provider_default_url = settings.get('DEFAULT_URL', 'https://secure.sharefile.com')
+    provider_default_api_url = 'https://{subdomain}.sf-api.com'.format(subdomain=subdomain)
+    provider_api_version = 'v3'
+
+    access_token_url = 'https://{subdomain}.{apicp}/oauth/token'.format(subdomain=subdomain, apicp=apicp)
+    refresh_token_url = 'https://{subdomain}.{apicp}/oauth/token'.format(subdomain=subdomain, apicp=apicp)
+    authorize_url = '{provider_default_url}/oauth/authorize'.format(provider_default_url=provider_default_url)
+    profile_url = '{provider_default_api_url}/sf/{provider_api_version}/Users'.format(provider_default_api_url=provider_default_api_url,
+                                                                                      provider_api_version=provider_api_version)
+
+    def complete_login(self, request, app, token, response):
+        headers = {"Authorization": "Bearer {}" .format(token.token)}
+        extra_data = requests.get(self.profile_url, headers=headers).json()
+        return self.get_provider().sociallogin_from_response(request, extra_data)
+
+
+oauth2_login = OAuth2LoginView.adapter_view(ShareFileOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(ShareFileOAuth2Adapter)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -103,6 +103,7 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
         'allauth.socialaccount.providers.pinterest',
         'allauth.socialaccount.providers.reddit',
         'allauth.socialaccount.providers.robinhood',
+        'allauth.socialaccount.providers.sharefile',
         'allauth.socialaccount.providers.shopify',
         'allauth.socialaccount.providers.slack',
         'allauth.socialaccount.providers.soundcloud',

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -145,6 +145,8 @@ Supported Providers
 
 - Salesforce (OAuth2)
 
+- ShareFile (OAuth2)
+
 - Shopify (OAuth2)
 
 - Slack (OAuth2)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -661,7 +661,8 @@ Registering an application:
 By default, you will have access to the openid, profile, and offline_access
 scopes.  With the offline_access scope, the API will provide you with a
 refresh token.  For additional scopes, see the Globus API docs:
-    https://docs.globus.org/api/auth/reference/
+
+ https://docs.globus.org/api/auth/reference/
 
 .. code-block:: python
 
@@ -1142,7 +1143,7 @@ SCOPE:
     https://developers.pinterest.com/docs/api/overview/#scopes
 
 QuickBooks
-------
+----------
 
 App registration (get your key and secret here)
     https://developers.intuit.com/v2/ui#/app/startcreate
@@ -1219,6 +1220,38 @@ To Use:
 - Create a Social application in Django admin, with client id,
   client key, and login_url (in "key" field)
 
+ShareFile
+---------
+
+The following ShareFile settings are available.
+  https://api.sharefile.com/rest/
+
+SUBDOMAIN:
+ Subdomain of your organization with ShareFile.  This is required.
+
+ Example:
+      ``test`` for ``https://test.sharefile.com``
+
+APICP:
+ Defaults to ``secure``.  Refer to the ShareFile documentation if you
+ need to change this value.
+
+DEFAULT_URL:
+ Defaults to ``https://secure.sharefile.com``  Refer to the ShareFile
+ documentation if you need to change this value.
+
+
+Example:
+
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+    'sharefile': {
+        'SUBDOMAIN': 'TEST',
+        'APICP': 'sharefile.com',
+        'DEFAULT_URL': 'https://secure.sharefile.com',
+                 }
+    }
 
 Shopify
 -------
@@ -1331,48 +1364,54 @@ Stripe
 
 You register your OAUth2 app via the Connect->Settings page of the Stripe
 dashboard:
-	https://dashboard.stripe.com/account/applications/settings
+
+ https://dashboard.stripe.com/account/applications/settings
 
 This page will provide you with both a Development and Production `client_id`.
 
 You can also register your OAuth2 app callback on the Settings page in the
 "Website URL" box, e.g.:
-    http://example.com/accounts/stripe/login/callback/
+
+ http://example.com/accounts/stripe/login/callback/
 
 However, the OAuth2 secret key is not on this page. The secret key is the same
 secret key that you use with the Stripe API generally. This can be found on the
 Stripe dashboard API page:
-	https://dashboard.stripe.com/account/apikeys
+
+ https://dashboard.stripe.com/account/apikeys
 
 See more in documentation
-    https://stripe.com/docs/connect/standalone-accounts
+ https://stripe.com/docs/connect/standalone-accounts
 
 
 Trello
 ------
 
 Register the application at
-    https://trello.com/app-key  
+
+ https://trello.com/app-key
+
 You get one application key per account.
 
-Save the "Key" to "Client id", the "Secret" to "Secret Key" and "Key" to the "Key" 
+Save the "Key" to "Client id", the "Secret" to "Secret Key" and "Key" to the "Key"
 field.
 
-Verify which scope you need at 
-    https://developers.trello.com/page/authorization
+Verify which scope you need at
+
+ https://developers.trello.com/page/authorization
+
 Need to change the default scope? Add or update the `trello` setting to
 `settings.py`
 
-```
-SOCIALACCOUNT_PROVIDERS = {
-    'trello': {
-        'AUTH_PARAMS': {
-            'scope': 'read,write',
-        },
-    },
-}    
-```
+.. code-block:: python
 
+  SOCIALACCOUNT_PROVIDERS = {
+      'trello': {
+          'AUTH_PARAMS': {
+              'scope': 'read,write',
+          },
+      },
+  }
 
 Twitch
 ------
@@ -1483,7 +1522,7 @@ Development callback URL
     http://localhost:8000/a
 
 Vimeo (OAuth 2)
------
+---------------
 
 App registration (get your key and secret here)
     https://developer.vimeo.com/apps

--- a/test_settings.py
+++ b/test_settings.py
@@ -113,6 +113,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.reddit',
     'allauth.socialaccount.providers.robinhood',
     'allauth.socialaccount.providers.salesforce',
+    'allauth.socialaccount.providers.sharefile',
     'allauth.socialaccount.providers.shopify',
     'allauth.socialaccount.providers.slack',
     'allauth.socialaccount.providers.soundcloud',


### PR DESCRIPTION
This adds a ShareFIle (https://www.sharefile.com/) Oauth2 provider.   We are currently using this in our app.  Was a pretty painless addition but let me know if there is something more needed to get this merged. 

Thanks for such a great library! 


## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers.rst`.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.
