### PR TITLE
feat(discord): Added verified email detection for Discord provider

### DIFF
--- a/allauth/socialaccount/providers/discord/provider.py
+++ b/allauth/socialaccount/providers/discord/provider.py
@@ -1,6 +1,6 @@
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
-
+from allauth.account.models import EmailAddress
 
 class DiscordAccount(ProviderAccount):
     def to_str(self):
@@ -25,6 +25,15 @@ class DiscordProvider(OAuth2Provider):
 
     def get_default_scope(self):
         return ['email', 'identify']
+
+    def extract_email_addresses(self, data):
+        ret = []
+        email = data.get('email')
+        if email and data.get('verified'):
+            ret.append(EmailAddress(email=email,
+                       verified=True,
+                       primary=True))
+        return ret
 
 
 provider_classes = [DiscordProvider]


### PR DESCRIPTION
Discord performs email verification, and indicates this in the extra data returned by their OAuth2 API. 

[Discord API documentation](https://discordapp.com/developers/docs/resources/user#user-object): 

![image](https://user-images.githubusercontent.com/17376331/55709264-ca945600-599c-11e9-8421-a20d49b35337.png)

I also tested this by looking at the API data returned for my own already-verified account, and looking at the API data returned for a new test account that I created with an email address entered but not verified. As you can see in the screenshot below, you are unable to add a phone number to the account or enable 2FA until after your email has been verified. 

![image](https://user-images.githubusercontent.com/17376331/55709400-10e9b500-599d-11e9-9478-ece062a390cb.png)

The `extract_email_addresses` code is copied from the `google` adapter and modified just to change which key to `get` from the `data`. 
