### PR TITLE
chore(socialaccount): use cls in class method

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -214,7 +214,7 @@ class SocialLogin(object):
         for ea in data['email_addresses']:
             email_address = deserialize_instance(EmailAddress, ea)
             email_addresses.append(email_address)
-        ret = SocialLogin()
+        ret = cls()
         ret.token = token
         ret.account = account
         ret.user = user


### PR DESCRIPTION
This is a tiny commit. Changing `SocialLogin()` to `cls()` gives more flexibility to the code. For example, if I want to inherit `SocialLogin` class, (which indeed is my use case) I should copy-and-paste `deserialize()` function and manually change `ret = SocialLogin()` part for the new subclass in order to obtain the desired class instance.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
