### PR TITLE
fix(globus): Fixed extract_uid

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -7,6 +7,12 @@ Note worthy changes
 - The ``linkedin_oauth2`` provider now gracefully deals with old V1
   data that might still be present in ``SocialAccount.extra_data``.
 
+Backwards incompatible changes
+------------------------------
+
+- The ``globus`` provider's ``extract_uid`` now uses the openid
+  required field ``sub`` instead of the ``create_time`` field.
+
 
 0.39.0 (2019-02-26)
 *******************

--- a/allauth/socialaccount/providers/globus/provider.py
+++ b/allauth/socialaccount/providers/globus/provider.py
@@ -22,7 +22,11 @@ class GlobusProvider(OAuth2Provider):
     account_class = GlobusAccount
 
     def extract_uid(self, data):
-        return str(data.get('create_time'))
+        if 'sub' not in data:
+            raise ProviderException(
+                'Globus OAuth error', data
+            )
+        return str(data['sub'])
 
     def extract_common_fields(self, data):
         return dict(


### PR DESCRIPTION
# Description

Globus provider's `uid` was resolving to `None` which caused problems in my application. I've updated the `extract_uid` method to properly obtain the field `sub` (a requirement of all OpenConnect providers) and verified that this resolves the problem.

---

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
