### PR TITLE
Handle user.email=None case when generating password token

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -39,7 +39,7 @@ class EmailAwarePasswordResetTokenGenerator(PasswordResetTokenGenerator):
             EmailAwarePasswordResetTokenGenerator, self)._make_hash_value(
                 user, timestamp)
         sync_user_email_addresses(user)
-        emails = set([user.email])
+        emails = set([user.email] if user.email else [])
         emails.update(
             EmailAddress.objects
             .filter(user=user)


### PR DESCRIPTION
When `user.email` equals `None` they're not able to reset their password because of a bug in `EmailAwarePasswordResetTokenGenerator`. This tiny PR fixes it.

People still able to reset their password even if they don't have an email address on django's `user`, but they have it on django allauth's `EmailsAddress`

[Commit](https://github.com/pennersr/django-allauth/commit/3fe584e1a3998e244e608d097ca4fececa77aa30#diff-3b9310d6e2c9a729f9c65c16647b3e1aR47) where the issue was introduced

Thanks
