### PR TITLE
chore: ci: Travis: use dist=xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # https://travis-ci.org/pennersr/django-allauth
-sudo: false
+dist: xenial
 language: python
 
 python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ python: "3.6"
 env:
   matrix:
    - TOXENV=py27-django111
-   - TOXENV=py34-django111
    - TOXENV=py35-django111
    - TOXENV=py36-django111
-   - TOXENV=py34-django20
    - TOXENV=py35-django20
    - TOXENV=py36-django20
    - TOXENV=py35-django21
@@ -33,6 +31,13 @@ matrix:
       env: TOXENV=py35-django21
     - python: "3.5"
       env: TOXENV=py35-django22
+
+    - python: "3.4"
+      env: TOXENV=py34-django111
+      dist: trusty
+    - python: "3.4"
+      env: TOXENV=py34-django20
+      dist: trusty
   exclude:
     - python: "3.6"
       env: TOXENV=py35-django111


### PR DESCRIPTION
This is good in general (more recent), and likely to fix builds with
Django 2.2, which currently fail:

> django.core.exceptions.ImproperlyConfigured: SQLite 3.8.3 or later is
> required (found 3.8.2).