### PR TITLE
TrelloProvider fixes

### DIFF
--- a/allauth/socialaccount/providers/trello/provider.py
+++ b/allauth/socialaccount/providers/trello/provider.py
@@ -26,6 +26,7 @@ class TrelloProvider(OAuthProvider):
         app = self.get_app(request)
         data['type'] = 'web_server'
         data['name'] = app.name
+        data['scope'] = self.get_scope(request)
         # define here for how long it will be, this can be configured on the
         # social app
         data['expiration'] = 'never'

--- a/allauth/socialaccount/providers/trello/provider.py
+++ b/allauth/socialaccount/providers/trello/provider.py
@@ -21,6 +21,13 @@ class TrelloProvider(OAuthProvider):
     def extract_uid(self, data):
         return data['id']
 
+    def extract_common_fields(self, data):
+        return dict(
+            email=data.get('email'),
+            username=data.get('username'),
+            name=data.get('name'),
+        )
+
     def get_auth_params(self, request, action):
         data = super(TrelloProvider, self).get_auth_params(request, action)
         app = self.get_app(request)

--- a/allauth/socialaccount/providers/trello/views.py
+++ b/allauth/socialaccount/providers/trello/views.py
@@ -1,6 +1,6 @@
 import requests
 
-from django.utils.http import urlencode, urlquote
+from django.utils.http import urlencode
 
 from allauth.socialaccount.providers.oauth.views import (
     OAuthAdapter,

--- a/allauth/socialaccount/providers/trello/views.py
+++ b/allauth/socialaccount/providers/trello/views.py
@@ -19,11 +19,8 @@ class TrelloOAuthAdapter(OAuthAdapter):
 
     def complete_login(self, request, app, token, response):
         # we need to get the member id and the other information
-        # check: https://developers.trello.com/advanced-reference/token
-        # https://api.trello.com/1/tokens/91a6408305c1e5ec1b0b306688bc2e2f8fe67abf6a2ecec38c17e5b894fcf866?key=[application_key]&token=[optional_auth_token]
-        info_url = '{base}{token}?{query}'.format(
-            base='https://api.trello.com/1/tokens/',
-            token=urlquote(token.token),
+        info_url = '{base}?{query}'.format(
+            base='https://api.trello.com/1/members/me',
             query=urlencode({
                 'key': app.key,
                 'token': response.get('oauth_token')}))


### PR DESCRIPTION
### fix(trello): Properly get user info

Add `extract_common_fields` to `TrelloProvider` to properly retrieve email (if available). Change Trello API endpoint to retrieve user email and not just member id. Requires "read,account" scope for Trello to get email (see below).


###  feat:  Use 'scope' in `TrelloProvider` auth params. Allows overriding from django settings
By default uses `get_default_scope()` that was already provided but was unused in TrelloProvider.  Allows overriding in settings e.g.

```
SOCIALACCOUNT_PROVIDERS = {
    'trello': {
        'SCOPE': 'read,account',
    },
}

```