### PR TITLE
chore(tox): rename flake8 to checkqa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
    - TOXENV=py36-django22
    - TOXENV=py36-djangomaster
    - TOXENV=docs
-   - TOXENV=flake8
+   - TOXENV=checkqa
    - TOXENV=standardjs
 
 matrix:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 	py35-django{111,20,21,22}
 	py36-django{111,20,21,22,master}
 	docs
-	flake8
+	checkqa
 	standardjs
 
 [testenv]
@@ -32,13 +32,14 @@ whitelist_externals = make
 commands =
 	make -C {toxinidir}/docs html
 
-[testenv:flake8]
+[testenv:checkqa]
 skip_install = True
+ignore_errors = True
 deps =
 	flake8
 	isort
 commands =
-	flake8 --exclude=migrations {posargs:{toxinidir}/allauth}
+	flake8 {posargs:{toxinidir}/allauth}
 	isort --check-only --skip-glob '*/migrations/*' --recursive --diff {posargs:{toxinidir}/allauth}
 
 [testenv:standardjs]
@@ -50,3 +51,6 @@ commands =
 
 [coverage:run]
 include = allauth*
+
+[flake8]
+exclude = migrations


### PR DESCRIPTION
Also uses `ignore_errors = True` to keep going on errors, but still exit
non-zero if one command fails.