### PR TITLE
Add app_label to EmailAddress and EmailConfirmation

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -33,6 +33,7 @@ class EmailAddress(models.Model):
     class Meta:
         verbose_name = _("email address")
         verbose_name_plural = _("email addresses")
+        app_label = "allauth.account"
         if not app_settings.UNIQUE_EMAIL:
             unique_together = [("user", "email")]
 
@@ -90,6 +91,7 @@ class EmailConfirmation(models.Model):
     class Meta:
         verbose_name = _("email confirmation")
         verbose_name_plural = _("email confirmations")
+        app_label = "allauth.account"
 
     def __str__(self):
         return "confirmation for %s" % self.email_address


### PR DESCRIPTION
Without app_label, in python3.7 and Django 2.2,
`RuntimeError: Model class allauth.account.models.EmailConfirmation
doesn't declare an explicit app_label and isn't in an application in
INSTALLED_APPS.` and `RuntimeError: Model class allauth.account.models.EmailAddress doesn't
declare an explicit app_label and isn't in an application in
INSTALLED_APPS.` errors are shown

# Submitting Pull Requests

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
