### PR TITLE
race condition fix

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -359,10 +359,14 @@ def sync_user_email_addresses(user):
                 and EmailAddress.objects.filter(email__iexact=email).exists():
             # Bail out
             return
-        EmailAddress.objects.create(user=user,
-                                    email=email,
-                                    primary=False,
-                                    verified=False)
+        EmailAddress.objects.get_or_create(
+            user=user,
+            email=email,
+            defaults={
+                'primary': False,
+                'verified': False
+            }
+        )
 
 
 def filter_users_by_username(*username):


### PR DESCRIPTION
## Refactored small piece of code in order to prevent possible race condition.

I'm having error like below:

![image](https://user-images.githubusercontent.com/1625053/57610569-ba622e80-7579-11e9-9635-a4467f95ea92.png)

Sql logs (blurred emails are the same on the screenshot):

![image](https://user-images.githubusercontent.com/1625053/57610716-fac1ac80-7579-11e9-9f89-0b37e8334714.png)

We can take advantage of django's `get_or_create` and prevent possible race condition, which I'm getting (see logs).