### PR TITLE
fix(vk): Bump VK API version to 5.95

### DIFF
--- a/allauth/socialaccount/providers/vk/provider.py
+++ b/allauth/socialaccount/providers/vk/provider.py
@@ -37,7 +37,7 @@ class VKProvider(OAuth2Provider):
         return scope
 
     def extract_uid(self, data):
-        return str(data['uid'])
+        return str(data['id'])
 
     def extract_common_fields(self, data):
         return dict(email=data.get('email'),

--- a/allauth/socialaccount/providers/vk/tests.py
+++ b/allauth/socialaccount/providers/vk/tests.py
@@ -15,7 +15,7 @@ class VKTests(OAuth2TestsMixin, TestCase):
 "photo": "http://vk.com/images/camera_c.gif", "sex": 2,
 "photo_medium": "http://vk.com/images/camera_b.gif", "relation": "0",
 "timezone": 1, "photo_big": "http://vk.com/images/camera_a.gif",
-"uid": 219004864, "universities": [], "city": "1430", "first_name": "Raymond",
+"id": 219004864, "universities": [], "city": "1430", "first_name": "Raymond",
 "faculty_name": "", "online": 1, "counters": {"videos": 0, "online_friends": 0,
 "notes": 0, "audios": 0, "photos": 0, "followers": 0, "groups": 0,
 "user_videos": 0, "albums": 0, "friends": 0}, "home_phone": "", "faculty": 0,

--- a/allauth/socialaccount/providers/vk/views.py
+++ b/allauth/socialaccount/providers/vk/views.py
@@ -42,7 +42,7 @@ class VKOAuth2Adapter(OAuth2Adapter):
     def complete_login(self, request, app, token, **kwargs):
         uid = kwargs['response'].get('user_id')
         params = {
-            'v': '3.0',
+            'v': '5.95',
             'access_token': token.token,
             'fields': ','.join(USER_FIELDS),
         }


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 
 ## Provider Specifics
VK API v3 got deprecated. Details: https://vk.com/dev/version_update_2.0
There could be some changes around extra fields, this just bumps version to latest, and makes sure login works