### PR TITLE
Add allauth.urls.provider_urlpatterns

### DIFF
--- a/allauth/urls.py
+++ b/allauth/urls.py
@@ -12,6 +12,8 @@ urlpatterns = [url(r'^', include('allauth.account.urls'))]
 if app_settings.SOCIALACCOUNT_ENABLED:
     urlpatterns += [url(r'^social/', include('allauth.socialaccount.urls'))]
 
+# Provider urlpatterns, as separate attribute (for reusability).
+provider_urlpatterns = []
 for provider in providers.registry.get_list():
     try:
         prov_mod = import_module(provider.get_package() + '.urls')
@@ -19,4 +21,5 @@ for provider in providers.registry.get_list():
         continue
     prov_urlpatterns = getattr(prov_mod, 'urlpatterns', None)
     if prov_urlpatterns:
-        urlpatterns += prov_urlpatterns
+        provider_urlpatterns += prov_urlpatterns
+urlpatterns += provider_urlpatterns


### PR DESCRIPTION
This is useful to reuse them without the other urlpatterns.