### PR TITLE
fix(translation): German spelling of personal pronouns

### DIFF
--- a/allauth/locale/de/LC_MESSAGES/django.po
+++ b/allauth/locale/de/LC_MESSAGES/django.po
@@ -133,7 +133,7 @@ msgstr "Neues Passwort (Wiederholung)"
 
 #: account/forms.py:466
 msgid "Please type your current password."
-msgstr "Bitte gib Dein aktuelles Passwort ein."
+msgstr "Bitte gib dein aktuelles Passwort ein."
 
 #: account/forms.py:504
 msgid "The e-mail address is not assigned to any user account"
@@ -379,7 +379,7 @@ msgid ""
 "You currently do not have any e-mail address set up. You should really add "
 "an e-mail address so you can receive notifications, reset your password, etc."
 msgstr ""
-"Du hast derzeit keine E-Mail-Adressen angegeben. Das solltest Du allerdings "
+"Du hast derzeit keine E-Mail-Adressen angegeben. Das solltest du allerdings "
 "tun, denn nur so können wir dich benachrichtigen und dein Passwort "
 "zurücksetzen."
 
@@ -446,7 +446,7 @@ msgstr ""
 #, python-format
 msgid "In case you forgot, your username is %(username)s."
 msgstr ""
-"Falls Du deinen Anmeldenamen vergessen haben solltest; er lautet "
+"Falls du deinen Anmeldenamen vergessen haben solltest; er lautet "
 "%(username)s."
 
 #: templates/account/email/password_reset_key_message.txt:10
@@ -502,9 +502,9 @@ msgid ""
 "up</a>\n"
 "for a %(site_name)s account and sign in below:"
 msgstr ""
-"Bitte melde Dich mit einem der folgenden Netzwerkkonten an, oder  <a \n"
-"href=\"%(signup_url)s\">registriere Dich auf %(site_name)s</a>, dann kannst "
-"Du Dich unten mit Deinem Konto anmelden:"
+"Bitte melde dich mit einem der folgenden Netzwerkkonten an, oder  <a \n"
+"href=\"%(signup_url)s\">registriere dich auf %(site_name)s</a>, dann kannst "
+"du dich unten mit deinem Konto anmelden:"
 
 #: templates/account/login.html:25
 msgid "or"
@@ -530,7 +530,7 @@ msgstr "Abmelden"
 
 #: templates/account/logout.html:10
 msgid "Are you sure you want to sign out?"
-msgstr "Bist Du sicher, dass du Dich abmelden möchtest?"
+msgstr "Bist du sicher, dass du dich abmelden möchtest?"
 
 #: templates/account/messages/cannot_delete_primary_email.txt:2
 #, python-format
@@ -559,7 +559,7 @@ msgstr "Erfolgreich als %(name)s angemeldet."
 
 #: templates/account/messages/logged_out.txt:2
 msgid "You have signed out."
-msgstr "Du hast Dich abgemeldet."
+msgstr "Du hast dich abgemeldet."
 
 #: templates/account/messages/password_changed.txt:2
 msgid "Password successfully changed."
@@ -599,8 +599,8 @@ msgid ""
 "Forgotten your password? Enter your e-mail address below, and we'll send you "
 "an e-mail allowing you to reset it."
 msgstr ""
-"Passwort vergessen? Gib Deine E-Mail-Adresse unten ein, dann schicken wir "
-"Dir einen Link, unter dem Du Dein Passwort zurücksetzen kannst."
+"Passwort vergessen? Gib deine E-Mail-Adresse unten ein, dann schicken wir "
+"dir einen Link, unter dem du dein Passwort zurücksetzen kannst."
 
 #: templates/account/password_reset.html:20
 msgid "Reset My Password"
@@ -616,7 +616,7 @@ msgid ""
 "We have sent you an e-mail. Please contact us if you do not receive it "
 "within a few minutes."
 msgstr ""
-"Wir haben Dir eine E-Mail geschickt. Bitte kontaktiere uns, wenn Du sie "
+"Wir haben Dir eine E-Mail geschickt. Bitte kontaktiere uns, wenn du sie "
 "nicht in ein paar Minuten erhalten hast."
 
 #: templates/account/password_reset_from_key.html:7
@@ -631,7 +631,7 @@ msgid ""
 "a>."
 msgstr ""
 "Der Link zum Zurücksetzen des Passworts war ungültig, womöglich wurde dieser "
-"Link bereits benutzt. Bitte lass Dein Passwort noch mal <a href="
+"Link bereits benutzt. Bitte lass dein Passwort noch mal <a href="
 "\"%(passwd_reset_url)s\">zurücksetzen</a>."
 
 #: templates/account/password_reset_from_key.html:17
@@ -716,7 +716,7 @@ msgid ""
 "verification. Please click on the link inside this e-mail. Please\n"
 "contact us if you do not receive it within a few minutes."
 msgstr ""
-"Wir haben Dir eine E-Mail geschickt, um Deine\n"
+"Wir haben Dir eine E-Mail geschickt, um deine\n"
 "Adresse zu verifizieren. Bitte klick auf den Link\n"
 "in der E-Mail. Wenn die E-Mail nicht in ein paar Minuten\n"
 "angekommen ist, gib uns bitte Bescheid."
@@ -755,7 +755,7 @@ msgstr "Konto-Verknüpfungen"
 msgid ""
 "You can sign in to your account using any of the following third party "
 "accounts:"
-msgstr "Du kannst Dich bei uns über folgende soziale Netzwerke anmelden:"
+msgstr "Du kannst dich bei uns über folgende soziale Netzwerke anmelden:"
 
 #: templates/socialaccount/connections.html:43
 msgid ""
@@ -779,7 +779,7 @@ msgid ""
 "\">sign in</a>."
 msgstr ""
 "Du hast die Anmeldung abgebrochen. Wenn das nur ein Versehen oder ein Fehler "
-"war, folge bitte diesem <a href=\"%(login_url)s\">Link</a> um Dich "
+"war, folge bitte diesem <a href=\"%(login_url)s\">Link</a> um dich "
 "anzumelden."
 
 #: templates/socialaccount/messages/account_connected.txt:2
@@ -802,7 +802,7 @@ msgid ""
 "You are about to use your %(provider_name)s account to login to\n"
 "%(site_name)s. As a final step, please complete the following form:"
 msgstr ""
-"Du verwendest Dein %(provider_name)s-Konto, um Dich bei\n"
+"Du verwendest dein %(provider_name)s-Konto, um dich bei\n"
 "%(site_name)s anzumelden. Zum Abschluss bitte das folgende Formular "
 "ausfüllen:"
 
@@ -830,4 +830,4 @@ msgstr ""
 #~ "gültige Adresse von %(user_display)s ist."
 
 #~ msgid "Thanks for using our site!"
-#~ msgstr "Danke, dass Du unsere Seite nutzt!"
+#~ msgstr "Danke, dass du unsere Seite nutzt!"


### PR DESCRIPTION
Although it was technically correct I'd like to change the
capitalization of personal pronouns, for three reasons:

- It is consistent now, all personal pronouns are capitalized the same way.
- The uppercase capitalization is acceptable for written literature, which
this project isn't.
- The uppercase capitalization is used by very old people, which are probably not
the target demographic of most of the projects using allauth

# Submitting Pull Requests

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
