### PR TITLE
fix(account): Prevent "oldpassword" POST parameter from leaking

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,6 +40,7 @@ David Friedman
 David Hummel
 Egor Poderyagin
 Eran Rundstein
+Eric Amador
 Eric Delord
 Fabio Caritas Barrionuevo da Luz
 Facundo Gaich

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -45,7 +45,8 @@ INTERNAL_RESET_SESSION_KEY = "_password_reset_key"
 
 
 sensitive_post_parameters_m = method_decorator(
-    sensitive_post_parameters('password', 'password1', 'password2'))
+    sensitive_post_parameters(
+        'oldpassword', 'password', 'password1', 'password2'))
 
 
 def _ajax_response(request, response, form=None, data=None):


### PR DESCRIPTION
Currently, if the ChangePasswordView has an uncaught exception, the value of the "oldpassword" form field will not be sanitized when it appears in error reporting logs/emails generated by Django (when `DEBUG` is False). This is obviously not ideal because the value of this form field is meant to contain the current password for a given user.

You can reproduce this in a default django/django-allauth installation by authenticating with a user, visiting /account/password/change, logging out of that users session while leaving the form open (say, logging out in a different browser tab), and then submitting the form. The resulting email report generated by Django will contain the unsanitized value of the "oldpassword" form field.

This commit adds "oldpassword" (which appears in the account
PasswordChangeView/ChangePasswordForm) to the list of
sensitive_post_parameters, ensuring the value of this form field will be
sanitized and not appear in plaintext in uncaught exception logs.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
