### PR TITLE
 add simple support to SITE_ID for email

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -296,8 +296,8 @@ class DefaultAccountAdapter(object):
         validate_password(password, user)
         return password
 
-    def validate_unique_email(self, email):
-        if email_address_exists(email):
+    def validate_unique_email(self, email, site=None):
+        if email_address_exists(email, site=site):
             raise forms.ValidationError(self.error_messages['email_taken'])
         return email
 

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -22,7 +22,7 @@ class AppSettings(object):
                 self.AuthenticationMethod.EMAIL) or self.EMAIL_REQUIRED
         # If login includes email, login must be unique
         assert (self.AUTHENTICATION_METHOD ==
-                self.AuthenticationMethod.USERNAME) or self.UNIQUE_EMAIL
+                self.AuthenticationMethod.USERNAME) or self.UNIQUE_EMAIL or self.EMAIL_SITE_ID
         assert (self.EMAIL_VERIFICATION !=
                 self.EmailVerificationMethod.MANDATORY) \
             or self.EMAIL_REQUIRED

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -22,7 +22,8 @@ class AppSettings(object):
                 self.AuthenticationMethod.EMAIL) or self.EMAIL_REQUIRED
         # If login includes email, login must be unique
         assert (self.AUTHENTICATION_METHOD ==
-                self.AuthenticationMethod.USERNAME) or self.UNIQUE_EMAIL or self.EMAIL_SITE_ID
+                self.AuthenticationMethod.USERNAME) or self.UNIQUE_EMAIL or \
+            self.EMAIL_SITE_ID
         assert (self.EMAIL_VERIFICATION !=
                 self.EmailVerificationMethod.MANDATORY) \
             or self.EMAIL_REQUIRED

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -122,6 +122,14 @@ class AppSettings(object):
         return self._setting("UNIQUE_EMAIL", True)
 
     @property
+    def EMAIL_SITE_ID(self):
+        """
+        It define the link between user and associated site_id. If defined
+        EmailAddress.email is unique per site_id
+        """
+        return self._setting("EMAIL_SITE_ID", None)
+
+    @property
     def SIGNUP_EMAIL_ENTER_TWICE(self):
         """
         Signup email verification

--- a/allauth/account/auth_backends.py
+++ b/allauth/account/auth_backends.py
@@ -14,6 +14,7 @@ _stash = local()
 class AuthenticationBackend(ModelBackend):
 
     def authenticate(self, request, **credentials):
+        self.request = request
         ret = None
         if app_settings.AUTHENTICATION_METHOD == AuthenticationMethod.EMAIL:
             ret = self._authenticate_by_email(**credentials)
@@ -51,7 +52,7 @@ class AuthenticationBackend(ModelBackend):
         # and use username as fallback
         email = credentials.get('email', credentials.get('username'))
         if email:
-            for user in filter_users_by_email(email):
+            for user in filter_users_by_email(email, self.request):
                 if self._check_password(user, credentials["password"]):
                     return user
         return None

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -331,7 +331,7 @@ class BaseSignupForm(_base_signup_form_class()):
     def clean_email(self):
         value = self.cleaned_data['email']
         value = get_adapter().clean_email(value)
-        if value and app_settings.UNIQUE_EMAIL:
+        if value and app_settings.UNIQUE_EMAIL or app_settings.EMAIL_SITE_ID:
             value = self.validate_unique_email(value)
         return value
 

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -337,7 +337,7 @@ class BaseSignupForm(_base_signup_form_class()):
 
     def validate_unique_email(self, value):
         current_site = get_current_site(self.request)
-        return get_adapter().validate_unique_email(value, current_site)
+        return get_adapter().validate_unique_email(value, site=current_site)
 
     def clean(self):
         cleaned_data = super(BaseSignupForm, self).clean()

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -256,8 +256,9 @@ def setup_user_email(request, user, addresses):
 
     if app_settings.EMAIL_SITE_ID:
         current_site = get_current_site(request)
+        site_field = app_settings.EMAIL_SITE_ID
         assert not EmailAddress.objects.filter(user=user, **{
-            app_settings.EMAIL_SITE_ID:current_site}).exists()
+            site_field:current_site}).exists()
     else:
         assert not EmailAddress.objects.filter(user=user).exists()
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -213,6 +213,11 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
     def dispatch(self, request, *args, **kwargs):
         return super(SignupView, self).dispatch(request, *args, **kwargs)
 
+    def get_form_kwargs(self):
+        kwargs = super(SignupView, self).get_form_kwargs()
+        kwargs['request'] = self.request
+        return kwargs
+
     def get_form_class(self):
         return get_form_class(app_settings.FORMS, 'signup', self.form_class)
 
@@ -384,6 +389,7 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
     def get_form_kwargs(self):
         kwargs = super(EmailView, self).get_form_kwargs()
         kwargs["user"] = self.request.user
+        kwargs['request'] = self.request
         return kwargs
 
     def form_valid(self, form):
@@ -639,6 +645,11 @@ class PasswordResetView(AjaxCapableProcessFormViewMixin, FormView):
         return get_form_class(app_settings.FORMS,
                               'reset_password',
                               self.form_class)
+
+    def get_form_kwargs(self):
+        kwargs = super(PasswordResetView, self).get_form_kwargs()
+        kwargs['request'] = self.request
+        return kwargs
 
     def form_valid(self, form):
         form.save(self.request)

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -147,7 +147,10 @@ def email_address_exists(email, exclude_user=None, site=None):
             users = get_user_model().objects
             if exclude_user:
                 users = users.exclude(pk=exclude_user.pk)
-            q_dict[email_field + '__iexact'] = email
+            q_dict = {email_field + '__iexact': email}
+            if account_settings.EMAIL_SITE_ID and site is not None:
+                user_site = account_settings.EMAIL_SITE_ID.replace('user__', '')
+                q_dict[user_site] = site
             ret = users.filter(**q_dict).exists()
     return ret
 

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -133,8 +133,8 @@ def email_address_exists(email, exclude_user=None, site=None):
     from .account.models import EmailAddress
 
     q_dict = {}
-    if site is not None:
-        q_dict['site'] = site
+    if account_settings.EMAIL_SITE_ID and site is not None:
+        q_dict[str(account_settings.EMAIL_SITE_ID)] = site
 
     emailaddresses = EmailAddress.objects
     if exclude_user:

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -149,8 +149,8 @@ def email_address_exists(email, exclude_user=None, site=None):
                 users = users.exclude(pk=exclude_user.pk)
             q_dict = {email_field + '__iexact': email}
             if account_settings.EMAIL_SITE_ID and site is not None:
-                user_site = account_settings.EMAIL_SITE_ID.replace('user__', '')
-                q_dict[user_site] = site
+                u_site = account_settings.EMAIL_SITE_ID.replace('user__', '')
+                q_dict[u_site] = site
             ret = users.filter(**q_dict).exists()
     return ret
 


### PR DESCRIPTION
Use case:
We have one project with different domains, we would like to permit to users to use the same email to register across the domains. The email is unique per site. I was unable to find a simple solution with allauth, so this patch add the support.

If the variable EMAIL_SITE_ID is specified EmailAddress.email is no longer unique. filter_users_by_email verifies that the email is not already present for the same domain.

EMAIL_SITE_ID must contain the path to the field that contains the user's site_id.

For example:

class User(AbstractUser):
  account = models.ForeignKey('Account'...

class Account(models.Model):
  site = models.ForeignKey(Site, default=settings.SITE_ID, on_delete=models.CASCADE)

EMAIL_SITE_ID must contains 'user__account__site'

It was tested with this settings:
ACCOUNT_USER_MODEL_USERNAME_FIELD = 'username'
ACCOUNT_EMAIL_REQUIRED = True
ACCOUNT_USERNAME_REQUIRED = False
ACCOUNT_AUTHENTICATION_METHOD = 'email'
ACCOUNT_UNIQUE_EMAIL = False
ACCOUNT_USER_DISPLAY = 'user.email'

ACCOUNT_EMAIL_SITE_ID = 'user__account__site'

Please let me know if there are easier solutions
