### PR TITLE
fix(templates): Don't HTML-escape plain text emails

### DIFF
--- a/allauth/templates/account/email/email_confirmation_message.txt
+++ b/allauth/templates/account/email/email_confirmation_message.txt
@@ -3,6 +3,7 @@
 You're receiving this e-mail because user {{ user_display }} has given yours as an e-mail address to connect their account.
 
 To confirm this is correct, go to {{ activate_url }}
-{% endblocktrans %}{% endautoescape %}
+{% endblocktrans %}
 {% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you from {{ site_name }}!
 {{ site_domain }}{% endblocktrans %}
+{% endautoescape %}

--- a/allauth/templates/account/email/password_reset_key_message.txt
+++ b/allauth/templates/account/email/password_reset_key_message.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
+{% load i18n %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from {{ site_name }}!
 
 You're receiving this e-mail because you or someone else has requested a password for your user account.
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
@@ -9,3 +9,4 @@ It can be safely ignored if you did not request a password reset. Click the link
 
 {% endif %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you for using {{ site_name }}!
 {{ site_domain }}{% endblocktrans %}
+{% endautoescape %}


### PR DESCRIPTION
This affects, for example, site names containing "&".