### PR TITLE
Fix for #2343 (allow unconfigured providers)

### DIFF
--- a/allauth/socialaccount/providers/__init__.py
+++ b/allauth/socialaccount/providers/__init__.py
@@ -1,6 +1,4 @@
 import importlib
-import warnings
-
 from collections import OrderedDict
 
 from django.conf import settings
@@ -13,17 +11,9 @@ class ProviderRegistry(object):
 
     def get_list(self, request=None):
         self.load()
-        from ..models import SocialApp
-        providers = []
-        for provider_cls in self.provider_map.values():
-            try:
-                SocialApp.objects.get_current(provider_cls.id, request)
-                providers.append(provider_cls(request))
-            except SocialApp.DoesNotExist:
-                warnings.warn("No {} app configured: please"
-                              " add a SocialApp using the Django"
-                              " admin".format(provider_cls.name))
-        return providers
+        return [
+            provider_cls(request)
+            for provider_cls in self.provider_map.values()]
 
     def register(self, cls):
         self.provider_map[cls.id] = cls

--- a/allauth/socialaccount/providers/__init__.py
+++ b/allauth/socialaccount/providers/__init__.py
@@ -1,4 +1,6 @@
 import importlib
+import warnings
+
 from collections import OrderedDict
 
 from django.conf import settings
@@ -11,9 +13,17 @@ class ProviderRegistry(object):
 
     def get_list(self, request=None):
         self.load()
-        return [
-            provider_cls(request)
-            for provider_cls in self.provider_map.values()]
+        from ..models import SocialApp
+        providers = []
+        for provider_cls in self.provider_map.values():
+            try:
+                SocialApp.objects.get_current(provider_cls.id, request)
+                providers.append(provider_cls(request))
+            except SocialApp.DoesNotExist:
+                warnings.warn("No {} app configured: please"
+                              " add a SocialApp using the Django"
+                              " admin".format(provider_cls.name))
+        return providers
 
     def register(self, cls):
         self.provider_map[cls.id] = cls

--- a/allauth/socialaccount/templatetags/socialaccount.py
+++ b/allauth/socialaccount/templatetags/socialaccount.py
@@ -85,7 +85,7 @@ def get_social_accounts(user):
 @register.simple_tag(takes_context=True)
 def get_providers(context):
     """
-    Returns a list of social authentication providers.
+    Returns a list of configured social authentication providers.
 
     Usage: `{% get_providers as socialaccount_providers %}`.
 
@@ -95,11 +95,9 @@ def get_providers(context):
     configured_providers = []
     for provider in providers.registry.get_list():
         try:
-            # We try to get the SocialApp object to see if the provider is configured
             SocialApp.objects.get_current(provider.id, context['request'])
             configured_providers.append(provider)
         except SocialApp.DoesNotExist:
-            # We skip unconfigured providers
             pass
 
     return configured_providers


### PR DESCRIPTION
Quickfix for #2343 

This PR filters the list returned by ProviderRegistry.get_list to only return providers that are configured.

This prevents exceptions for unconfigured providers on the login page, as they will simply be ignored. This in turn allows adding several providers extensions to INSTALLED_APPS, and leaving it to the website manager to enable the providers he actually wants from django admin.

I made this as a very quick fix, and the code could probably be improved (e.g. import at the top), but I was getting an `AppRegistryNotReady` error and don't have time to investigate now.
