### PR TITLE
feat(gitlab): Set the default scope to read_user

### DIFF
--- a/allauth/socialaccount/providers/gitlab/provider.py
+++ b/allauth/socialaccount/providers/gitlab/provider.py
@@ -21,6 +21,9 @@ class GitLabProvider(OAuth2Provider):
     name = 'GitLab'
     account_class = GitLabAccount
 
+    def get_default_scope(self):
+        return ['read_user']
+
     def extract_uid(self, data):
         return str(data['id'])
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -661,14 +661,15 @@ authentication provider as described in GitLab docs at
 http://doc.gitlab.com/ce/integration/oauth_provider.html
 
 The following GitLab settings are available, if unset https://gitlab.com will
-be used.
+be used, with a ``read_user`` scope.
 
 GITLAB_URL:
     Override endpoint to request an authorization and access token. For your
     private GitLab server you use: ``https://your.gitlab.server.tld``
 
 SCOPE:
-    The ``read_user`` scope is required for the login procedure.
+    The ``read_user`` scope is required for the login procedure, and is the default.
+    If more access is required, the scope should be set here.
 
 Example:
 
@@ -677,7 +678,7 @@ Example:
     SOCIALACCOUNT_PROVIDERS = {
         'gitlab': {
             'GITLAB_URL': 'https://your.gitlab.server.tld',
-            'SCOPE': ['read_user'],
+            'SCOPE': ['api'],
         },
     }
 


### PR DESCRIPTION
This permit to handle gitlab as easily as the other providers.

By default, if no scope is provided, it default to use 'api',
which seems overkill for simple authentication.

# Submitting Pull Requests

## General

 - [X] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [X] All Python code must be 100% pep8 and isort clean.
 - [X] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [X] If your changes are significant, please update `ChangeLog.rst`.
 - [X] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
