### PR TITLE
fix(account): add reset_password link to password_change.html

### DIFF
--- a/allauth/templates/account/password_change.html
+++ b/allauth/templates/account/password_change.html
@@ -10,6 +10,7 @@
     <form method="POST" action="{% url 'account_change_password' %}" class="password_change">
         {% csrf_token %}
         {{ form.as_p }}
+        <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
         <button type="submit" name="action">{% trans "Change Password" %}</button>
     </form>
 {% endblock %}

--- a/example/example/templates/bootstrap/allauth/account/password_change.html
+++ b/example/example/templates/bootstrap/allauth/account/password_change.html
@@ -12,6 +12,7 @@
         {{ password_change_form|bootstrap }}
         <div class="form-actions">
           <button class="btn btn-primary" type="submit" name="action">{% trans "Change Password" %}</button>
+          <a class="btn" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
         </div>
     </form>
 {% endblock %}

--- a/example/example/templates/uniform/allauth/account/password_change.html
+++ b/example/example/templates/uniform/allauth/account/password_change.html
@@ -6,12 +6,13 @@
 
 {% block content %}
     <h1>{% trans "Change Password" %}</h1>
-    
+
     <form method="POST" action="" class="password_change uniForm">
         {% csrf_token %}
         <fieldset class="inlineLabels">
             {{ password_change_form|as_uni_form }}
              <div class = "buttonHolder">
+                 <a class="button secondaryAction" href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>
                  <button type="submit" name="action">{% trans "Change Password" %}</button>
             </div>
         </fieldset>


### PR DESCRIPTION
This is to help users who cannot remember their current password. It may not be obvious to users that to change their password, they would have to log out, and then find the "forgot password" link. This provides a link so that they don't have to do that.