### PR TITLE
fix(accounts): respect ACCOUNT_EMAIL_VERIFICATION for new mail addresses

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -447,10 +447,12 @@ class AddEmailForm(UserForm):
         return value
 
     def save(self, request):
+        confirm = (app_settings.EMAIL_VERIFICATION !=
+                   app_settings.EmailVerificationMethod.NONE)
         return EmailAddress.objects.add_email(request,
                                               self.user,
                                               self.cleaned_data["email"],
-                                              confirm=True)
+                                              confirm=confirm)
 
 
 class ChangePasswordForm(PasswordVerificationMixin, UserForm):

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -815,7 +815,29 @@ class EmailFormTests(TestCase):
             verified=False,
             primary=False)
         self.assertTemplateUsed(resp,
+                                'account/email/email_confirmation_message.txt')
+        self.assertTemplateUsed(resp,
                                 'account/messages/email_confirmation_sent.txt')
+
+    @override_settings(ACCOUNT_EMAIL_VERIFICATION='none')
+    def test_add_no_confirmation(self):
+        resp = self.client.post(
+            reverse('account_email'),
+            {'action_add': '',
+             'email': 'john3@example.org'})
+        EmailAddress.objects.get(
+            email="john3@example.org",
+            user=self.user,
+            verified=False,
+            primary=False)
+        self.assertTemplateNotUsed(
+            resp,
+            'account/email/email_confirmation_message.txt'
+        )
+        self.assertTemplateNotUsed(
+            resp,
+            'account/messages/email_confirmation_sent.txt'
+        )
 
     def test_ajax_get(self):
         resp = self.client.get(

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -388,12 +388,15 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 
     def form_valid(self, form):
         email_address = form.save(self.request)
-        get_adapter(self.request).add_message(
-            self.request,
-            messages.INFO,
-            'account/messages/'
-            'email_confirmation_sent.txt',
-            {'email': form.cleaned_data["email"]})
+        confirm_email_sent = (app_settings.EMAIL_VERIFICATION !=
+                              app_settings.EmailVerificationMethod.NONE)
+        if confirm_email_sent:
+            get_adapter(self.request).add_message(
+                self.request,
+                messages.INFO,
+                'account/messages/'
+                'email_confirmation_sent.txt',
+                {'email': form.cleaned_data["email"]})
         signals.email_added.send(sender=self.request.user.__class__,
                                  request=self.request,
                                  user=self.request.user,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -50,8 +50,8 @@ ACCOUNT_EMAIL_REQUIRED (=False)
   The user is required to hand over an e-mail address when signing up.
 
 ACCOUNT_EMAIL_VERIFICATION (="optional")
-  Determines the e-mail verification method during signup -- choose
-  one of ``"mandatory"``, ``"optional"``, or ``"none"``.
+  Determines the e-mail verification method during signup and adding mail
+  addresses -- choose one of ``"mandatory"``, ``"optional"``, or ``"none"``.
   
   Setting this to `"mandatory"` requires `ACCOUNT_EMAIL_REQUIRED` to be `True`
   


### PR DESCRIPTION
# Submitting Pull Requests

As a user, adding a new email address currently yields a confirmation email, even if `ACCOUNT_EMAIL_VERIFICATION` is `none`. This fixes the behavior to respect the settings and only send mails for `optional` and `mandatory`.

Comes with tests and docs.

In case you'd like to see anything changed, please let me know. Thank you!

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com). **N/A**
 - [x] If your changes are significant, please update `ChangeLog.rst`. **N/A**
 - [x] Feel free to add yourself to `AUTHORS`. **N/A**
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [x] Make sure unit tests are available. **N/A**
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`. **N/A**
- [x] Add documentation to `docs/providers.rst`. **N/A**
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`. **N/A**
