### PR TITLE
Change SOCIALACCOUNT_PROVIDERS for Patreon

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1157,7 +1157,7 @@ The following Patreon settings are available:
 .. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
-        'paypal': {
+        'patreon': {
             'VERSION': 'v1',
             'SCOPE': ['pledges-to-me', 'users', 'my-campaign'],
         }


### PR DESCRIPTION
Silly typo: for Patreon should be "patreon", not "paypal". 💯
