### PR TITLE
fix(facebook): don't raise ImproperlyConfigured in media_js()

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,12 @@
 0.41.0 (Unreleased)
 *******************
 
+Note worthy changes
+-------------------
+
+- The ``facebook`` provider no longer raises ``ImproperlyConfigured``
+  within ``{% providers_media_js %}`` when it is not configured.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -2,7 +2,6 @@ import json
 import string
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import get_token
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -157,9 +156,10 @@ class FacebookProvider(OAuth2Provider):
         try:
             app = self.get_app(request)
         except SocialApp.DoesNotExist:
-            raise ImproperlyConfigured("No Facebook app configured: please"
-                                       " add a SocialApp using the Django"
-                                       " admin")
+            # It's a problem that Facebook isn't configured; but don't raise
+            # an error. Other providers don't raise errors when they're missing
+            # SocialApps in media_js().
+            return ''
 
         def abs_uri(name):
             return request.build_absolute_uri(reverse(name))

--- a/allauth/socialaccount/providers/facebook/tests.py
+++ b/allauth/socialaccount/providers/facebook/tests.py
@@ -82,6 +82,14 @@ class FacebookTests(OAuth2TestsMixin, TestCase):
         script = provider.media_js(request)
         self.assertTrue('"appId": "app123id"' in script)
 
+    def test_media_js_when_not_configured(self):
+        provider = providers.registry.by_id(FacebookProvider.id)
+        provider.get_app(None).delete()
+        request = RequestFactory().get(reverse('account_login'))
+        request.session = {}
+        script = provider.media_js(request)
+        self.assertEqual(script, '')
+
     def test_login_by_token(self):
         resp = self.client.get(reverse('account_login'))
         with patch('allauth.socialaccount.providers.facebook.views'


### PR DESCRIPTION
Other providers don't raise when SocialApp does not exist. There's a
sensible alternate action (return ""), and it avoids the stack trace
mentioned in #2343.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.