### PR TITLE
Replace `is_safe_url` with `url_has_allowed_host_and_scheme`

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -412,8 +412,13 @@ class DefaultAccountAdapter(object):
                        'first_name', 'last_name', 'email'])
 
     def is_safe_url(self, url):
-        from django.utils.http import is_safe_url
-        return is_safe_url(url, allowed_hosts=None)
+        # Fall back to `is_safe_url` for Django < 3.
+        try:
+            from django.utils.http import url_has_allowed_host_and_scheme
+        except ImportError:
+            from django.utils.http import \
+                is_safe_url as url_has_allowed_host_and_scheme
+        return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         """Constructs the email confirmation (activation) url.


### PR DESCRIPTION
Django 3 renames the `is_safe_url` to `url_has_allowed_host_and_scheme`. This implementation should support both, however. See https://docs.djangoproject.com/en/3.0/releases/3.0/#id3.