### PR TITLE
Fix `deserialize_instance` in Django 3

### DIFF
--- a/allauth/socialaccount/fields.py
+++ b/allauth/socialaccount/fields.py
@@ -10,7 +10,7 @@ class JSONField(models.TextField):
     """Simple JSON field that stores python structures as JSON strings
     on database.
     """
-    if django.VERSION < (2, 0):
+    if django.VERSION < (3, 0):
         def from_db_value(self, value, expression, connection, context):
             return self.to_python(value)
     else:

--- a/allauth/tests.py
+++ b/allauth/tests.py
@@ -5,6 +5,7 @@ import json
 import requests
 from datetime import date, datetime
 
+import django
 from django.core.files.base import ContentFile
 from django.db import models
 from django.test import RequestFactory, TestCase
@@ -93,9 +94,14 @@ class BasicTests(TestCase):
         class SomeField(models.Field):
             def get_prep_value(self, value):
                 return 'somevalue'
-
-            def from_db_value(self, value, expression, connection, context):
-                return some_value
+            if django.VERSION < (3, 0):
+                def from_db_value(
+                    self, value, expression, connection, context
+                ):
+                    return some_value
+            else:
+                def from_db_value(self, value, expression, connection):
+                    return some_value
 
         class SomeModel(models.Model):
             dt = models.DateTimeField()

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -9,7 +9,6 @@ from collections import OrderedDict
 from urllib.parse import urlsplit
 
 import django
-
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -8,6 +8,8 @@ import unicodedata
 from collections import OrderedDict
 from urllib.parse import urlsplit
 
+import django
+
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
@@ -219,7 +221,12 @@ def deserialize_instance(model, data):
                     try:
                         # This is quite an ugly hack, but will cover most
                         # use cases...
-                        v = f.from_db_value(v, None, None, None)
+                        # The signature of `from_db_value` changed in Django 3
+                        # https://docs.djangoproject.com/en/3.0/releases/3.0/#features-removed-in-3-0
+                        if django.VERSION < (3, 0):
+                            v = f.from_db_value(v, None, None, None)
+                        else:
+                            v = f.from_db_value(v, None, None)
                     except Exception:
                         raise ImproperlyConfigured(
                             "Unable to auto serialize field '{}', custom"


### PR DESCRIPTION
I ran into issues with the `deserialize_instance` utility - for custom fields under Django3 it was still calling `from_db_value` with incorrect arguments. Specifically, the `context` parameter was [deprecated in Django 2](https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value) and [removed in Django 3](https://docs.djangoproject.com/en/3.0/releases/3.0/#features-removed-in-3-0).

The tests didn't reveal this as they define their own custom field and `from_db_value` method which does not vary based on the Django version.

There was some adjustment to the `JSONField` implementation to define a variable `from_db_value` signature based on Django version, but I think it possibly should have hinged on the actual removal of the `context` parameter rather than the deprecation of it (ie, Django version 3 rather than 2).

Curious to hear your thoughts!