### PR TITLE
Fix: use new function, fallback to depricated one

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -138,6 +138,7 @@ Udi Oron
 Victor Semionov
 Volodymyr Yatsyk
 Vuong Nguyen
+Vlad Dmitrievich
 Wendy Edwards
 Will Gordon
 Will Ross

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -412,8 +412,12 @@ class DefaultAccountAdapter(object):
                        'first_name', 'last_name', 'email'])
 
     def is_safe_url(self, url):
-        from django.utils.http import is_safe_url
-        return is_safe_url(url, allowed_hosts=None)
+        try:
+            from django.utils.http import url_has_allowed_host_and_scheme
+        except ImportError:
+            from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
+
+        return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         """Constructs the email confirmation (activation) url.

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -28,7 +28,6 @@ from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
-from . import app_settings
 from ..utils import (
     build_absolute_uri,
     email_address_exists,
@@ -36,6 +35,7 @@ from ..utils import (
     get_user_model,
     import_attribute,
 )
+from . import app_settings
 
 
 class DefaultAccountAdapter(object):

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -28,6 +28,7 @@ from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
+from . import app_settings
 from ..utils import (
     build_absolute_uri,
     email_address_exists,
@@ -35,7 +36,6 @@ from ..utils import (
     get_user_model,
     import_attribute,
 )
-from . import app_settings
 
 
 class DefaultAccountAdapter(object):
@@ -415,7 +415,8 @@ class DefaultAccountAdapter(object):
         try:
             from django.utils.http import url_has_allowed_host_and_scheme
         except ImportError:
-            from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
+            from django.utils.http import \
+                is_safe_url as url_has_allowed_host_and_scheme
 
         return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
 


### PR DESCRIPTION
Newer Django versions has `url_has_allowed_host_and_scheme` function as replacement for deprecated`is_safe_url`.
I've added import check to use new one, if it exists and fallback for old one if necessary.
This patch will fix this warning:

```
RemovedInDjango40Warning: django.utils.http.is_safe_url() is deprecated in favor of url_has_allowed_host_and_scheme()
```
