### PR TITLE
fix: Django 3.0 Deprecation warning for is_safe_url

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -5,6 +5,7 @@ import json
 import time
 import warnings
 
+import django
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -36,6 +37,11 @@ from ..utils import (
     import_attribute,
 )
 from . import app_settings
+
+if django.VERSION >= (3, 0):
+    from django.utils.http import url_has_allowed_host_and_scheme
+else:
+    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
 
 
 class DefaultAccountAdapter(object):
@@ -412,8 +418,7 @@ class DefaultAccountAdapter(object):
                        'first_name', 'last_name', 'email'])
 
     def is_safe_url(self, url):
-        from django.utils.http import is_safe_url
-        return is_safe_url(url, allowed_hosts=None)
+        return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         """Constructs the email confirmation (activation) url.


### PR DESCRIPTION
Fix this warning on Django 3.0:

```
/.../lib/python3.7/site-packages/allauth/account/adapter.py:416: RemovedInDjango40Warning: django.utils.http.is_safe_url() is deprecated in favor of url_has_allowed_host_and_scheme().
    return is_safe_url(url, allowed_hosts=None)
```

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
n/a
