### PR TITLE
fix(github): switch to header authorization

### DIFF
--- a/allauth/socialaccount/providers/github/views.py
+++ b/allauth/socialaccount/providers/github/views.py
@@ -26,20 +26,19 @@ class GitHubOAuth2Adapter(OAuth2Adapter):
     emails_url = '{0}/user/emails'.format(api_url)
 
     def complete_login(self, request, app, token, **kwargs):
-        params = {'access_token': token.token}
-        resp = requests.get(self.profile_url, params=params)
+        headers = {'Authorization': 'token {}'.format(token.token)}
+        resp = requests.get(self.profile_url, headers=headers)
         resp.raise_for_status()
         extra_data = resp.json()
         if app_settings.QUERY_EMAIL and not extra_data.get('email'):
-            extra_data['email'] = self.get_email(token)
+            extra_data['email'] = self.get_email(headers)
         return self.get_provider().sociallogin_from_response(
             request, extra_data
         )
 
-    def get_email(self, token):
+    def get_email(self, headers):
         email = None
-        params = {'access_token': token.token}
-        resp = requests.get(self.emails_url, params=params)
+        resp = requests.get(self.emails_url, headers=headers)
         resp.raise_for_status()
         emails = resp.json()
         if resp.status_code == 200 and emails:


### PR DESCRIPTION
- GitHub is deprecating authentication to their API using query params via the `access_token` query param **(UPDATE: latest email notification from GitHub stated that this will officially go away July 1st, 2020)**. An `Authorization: token TOKEN` header should be added to the request instead.
- see also https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#web-application-flow
- fixes #2457
