### PR TITLE
Improve docs of SOCIALACCOUNT_PROVIDERS

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -252,6 +252,36 @@ SOCIALACCOUNT_FORMS (={})
 SOCIALACCOUNT_PROVIDERS (= dict)
   Dictionary containing provider specific settings.
 
+  The 'APP' section for each provider is generic to all providers and
+  can also be specified in the database using a ``SocialApp`` model
+  instance instead of here. All other sections are provider-specific and
+  are documented in the `for each provider separately
+  <providers.html>`__.
+
+  Example::
+
+      SOCIALACCOUNT_PROVIDERS = {
+	'google': {
+	    # For each OAuth based provider, either add a ``SocialApp``
+	    # (``socialaccount`` app) containing the required client
+	    # credentials, or list them here:
+	    'APP': {
+		'client_id': '123',
+		'secret': '456',
+		'key': ''
+	    },
+            # These are provider-specific settings that can only be
+            # listed here:
+	    'SCOPE': [
+		'profile',
+		'email',
+	    ],
+	    'AUTH_PARAMS': {
+		'access_type': 'online',
+	    }
+	 }
+      }
+
 SOCIALACCOUNT_QUERY_EMAIL (=ACCOUNT_EMAIL_REQUIRED)
   Request e-mail address from 3rd party account provider? E.g. using
   OpenID AX, or the Facebook "email" permission.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -176,4 +176,4 @@ and follow these steps:
 - Add a ``Site`` for your domain, matching ``settings.SITE_ID`` (``django.contrib.sites`` app).
 - For each OAuth based provider, either add a ``SocialApp`` (``socialaccount``
   app) containing the required client credentials, or, make make sure that these are
-  configured via the ``SOCIALACCOUNT_PROVIDERS[<provider>]['APP']`` setting.
+  configured via the ``SOCIALACCOUNT_PROVIDERS[<provider>]['APP']`` setting (see example above).

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -837,11 +837,15 @@ Optionally, you can specify the scope to use as follows:
         }
     }
 
-By default, ``profile`` scope is required, and optionally ``email`` scope
-depending on whether or not ``SOCIALACCOUNT_QUERY_EMAIL`` is enabled.
+By default (if you do not specify ``SCOPE``), ``profile`` scope is
+requested, and optionally ``email`` scope depending on whether or not
+``SOCIALACCOUNT_QUERY_EMAIL`` is enabled.
 
 You must set ``AUTH_PARAMS['access_type']`` to ``offline`` in order to
-receive a refresh token on first login and on reauthentication requests.
+receive a refresh token on first login and on reauthentication requests
+(which is needed to refresh authentication tokens in the background,
+without involving the user's browser). When unspecified, Google defaults
+to ``online``.
 
 
 Instagram


### PR DESCRIPTION
While trying to set up allauth, I could not quickly find out how to configure SOCIALACCOUNT_PROVIDERS. This PR makes things a bit more explicit.