### PR TITLE
fix(twitch): Retrieve correct profile image

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,6 +74,7 @@ Jesse Gerard Brands
 Jihoon Park
 Jiyoon Ha
 Joe Vanderstelt
+Joel Fernandes
 John Bazik
 John Whitlock
 Jonas Aule

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,6 +6,9 @@ Note worthy changes
 
 - New provider: Yandex (OAuth2)
 
+- Fixed Twitch ``get_avatar_url()`` method to use the profile picture retrieved
+  by new user details endpoint introduced in version 0.40.0.
+
 
 0.41.0 (2019-12-18)
 *******************

--- a/allauth/socialaccount/providers/twitch/provider.py
+++ b/allauth/socialaccount/providers/twitch/provider.py
@@ -7,7 +7,10 @@ class TwitchAccount(ProviderAccount):
         return 'http://twitch.tv/' + self.account.extra_data.get('login')
 
     def get_avatar_url(self):
-        return self.account.extra_data.get('logo')
+        # We're using `logo` as a failback for legacy profiles retrieved
+        # with the old https://api.twitch.tv/kraken/user endpoint.
+        logo = self.account.extra_data.get('logo')
+        return self.account.extra_data.get('profile_image_url', logo)
 
     def to_str(self):
         dflt = super(TwitchAccount, self).to_str()


### PR DESCRIPTION
This PR fixes an issue with the Twitch provider where it fails to return a profile picture for accounts registered after version 0.40.0.

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
