### PR TITLE
default raise http error in 'Naver', 'Kakao" social auth provider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Griffith Rees
 Guilhem Saurel
 Guillaume Vincent
 Guoyu Hao
+Haesung Park
 Hatem Nassrat
 Hyunwoo Shim
 J. Erm

--- a/allauth/socialaccount/providers/kakao/views.py
+++ b/allauth/socialaccount/providers/kakao/views.py
@@ -18,6 +18,7 @@ class KakaoOAuth2Adapter(OAuth2Adapter):
     def complete_login(self, request, app, token, **kwargs):
         headers = {'Authorization': 'Bearer {0}'.format(token.token)}
         resp = requests.get(self.profile_url, headers=headers)
+        resp.raise_for_status()
         extra_data = resp.json()
         return self.get_provider().sociallogin_from_response(request,
                                                              extra_data)

--- a/allauth/socialaccount/providers/naver/views.py
+++ b/allauth/socialaccount/providers/naver/views.py
@@ -18,6 +18,7 @@ class NaverOAuth2Adapter(OAuth2Adapter):
     def complete_login(self, request, app, token, **kwargs):
         headers = {'Authorization': 'Bearer {0}'.format(token.token)}
         resp = requests.get(self.profile_url, headers=headers)
+        resp.raise_for_status()
         extra_data = resp.json().get('response')
         return self.get_provider().sociallogin_from_response(request,
                                                              extra_data)


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com). // not to me
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
When requesting oauth provider Naver or Kakao, if there is an error such as incorrect token length, 'resp' generates an error.
However, if you look at the Naver and Kakao views, it will not check this and try to extract `uid` or any data from the response and generate 500 error.
As with other provider views, I think we need the `resp.raise_for_status()` for check error.

thanks :) 
