### PR TITLE
fix(amazon): Fix Amazon API profile url

### DIFF
--- a/allauth/socialaccount/providers/amazon/views.py
+++ b/allauth/socialaccount/providers/amazon/views.py
@@ -13,7 +13,7 @@ class AmazonOAuth2Adapter(OAuth2Adapter):
     provider_id = AmazonProvider.id
     access_token_url = 'https://api.amazon.com/auth/o2/token'
     authorize_url = 'http://www.amazon.com/ap/oa'
-    profile_url = 'https://www.amazon.com/ap/user/profile'
+    profile_url = 'https://api.amazon.com/user/profile'
     supports_state = False
     redirect_uri_protocol = 'https'
 


### PR DESCRIPTION
Amazon has changed the URL for the profile endpoint. Source: https://developer.amazon.com/docs/login-with-amazon/obtain-customer-profile.html#call-profile-endpoint

This PR updates the profile endpoint URL in `AmazonOAuth2Adapter`. 
