### PR TITLE
fix(docs): remove links to deleted gajeshbhat Medium articles from FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -22,9 +22,6 @@ Here are a few third party resources to help you get started:
 - https://stackoverflow.com/questions/tagged/django-allauth
 - http://www.sarahhagstrom.com/2013/09/the-missing-django-allauth-tutorial/
 - https://github.com/aellerton/demo-allauth-bootstrap
-- https://medium.com/@gajeshbhat/django-allauth-setup-and-configuration-tutorial-63417bba339c
-- https://medium.com/@gajeshbhat/extending-and-customizing-django-allauth-eed206623a1a
-- https://medium.com/@gajeshbhat/django-allauth-social-login-tutorial-ad021c24d666
 
 I think I found a security issue... now what?
 *********************************************


### PR DESCRIPTION
All three gajeshbhat articles are reported as "410 The author deleted this Medium story."
