### PR TITLE
fix(i18n): Fixed incorrect translation entry

### DIFF
--- a/allauth/locale/pl/LC_MESSAGES/django.po
+++ b/allauth/locale/pl/LC_MESSAGES/django.po
@@ -564,7 +564,7 @@ msgstr "Hasło zostało ustawione."
 
 #: templates/account/messages/primary_email_set.txt:2
 msgid "Primary e-mail address set."
-msgstr "Ustaw podstawowy adres e-mail."
+msgstr "Podstawowy adres e-mail został ustawiony."
 
 #: templates/account/messages/unverified_primary_email.txt:2
 msgid "Your primary e-mail address must be verified."


### PR DESCRIPTION
Hi, thanks for great library. I noticed error in polish translations:
_"Primary e-mail address set"_ is translated as _"Ustaw podstawowy adres e-mail."_ 
which means something like 
_"Please set your primary e-mail address."_

I changed it to _"Podstawowy adres e-mail został ustawiony."_  This is similar to 
```
#: templates/account/messages/password_set.txt:2
msgid "Password successfully set."
msgstr "Hasło zostało ustawione."
```


