### PR TITLE
Fixed 'NoneType' object has no attribute 'strip'

### DIFF
--- a/allauth/socialaccount/providers/microsoft/provider.py
+++ b/allauth/socialaccount/providers/microsoft/provider.py
@@ -11,6 +11,7 @@ class MicrosoftGraphAccount(ProviderAccount):
         if not name is None:
             if name.strip() != '':
                 return name
+            return name
         return super(MicrosoftGraphAccount, self).to_str()
 
 

--- a/allauth/socialaccount/providers/microsoft/provider.py
+++ b/allauth/socialaccount/providers/microsoft/provider.py
@@ -11,6 +11,7 @@ class MicrosoftGraphAccount(ProviderAccount):
         if not name is None:
             if name.strip() != '':
                 return name
+        else:
             return name
         return super(MicrosoftGraphAccount, self).to_str()
 

--- a/allauth/socialaccount/providers/microsoft/provider.py
+++ b/allauth/socialaccount/providers/microsoft/provider.py
@@ -8,8 +8,8 @@ class MicrosoftGraphAccount(ProviderAccount):
 
     def to_str(self):
         name = self.account.extra_data.get('displayName')
-        if not name is None:
-            if name.strip() != '':
+        if name:
+            name.strip() != ''
                 return name
         else:
             return name

--- a/allauth/socialaccount/providers/microsoft/provider.py
+++ b/allauth/socialaccount/providers/microsoft/provider.py
@@ -8,10 +8,7 @@ class MicrosoftGraphAccount(ProviderAccount):
 
     def to_str(self):
         name = self.account.extra_data.get('displayName')
-        if name:
-            name.strip() != ''
-                return name
-        else:
+        if name and name.strip() != '':
             return name
         return super(MicrosoftGraphAccount, self).to_str()
 

--- a/allauth/socialaccount/providers/microsoft/provider.py
+++ b/allauth/socialaccount/providers/microsoft/provider.py
@@ -8,8 +8,9 @@ class MicrosoftGraphAccount(ProviderAccount):
 
     def to_str(self):
         name = self.account.extra_data.get('displayName')
-        if name.strip() != '':
-            return name
+        if not name is None:
+            if name.strip() != '':
+                return name
         return super(MicrosoftGraphAccount, self).to_str()
 
 


### PR DESCRIPTION
Hi, i found a bug when accessing the page {% url 'socialaccount_connections' %} (/social/connections/) it gave me a 'NoneType' object has no attribute 'strip' and the culprit is provider.py. The problem is that this file calls the strip() function on a null value and python being python doesn't like it ;) The solution i found is quite simple, in the provider.py file the MicrosoftGraphAccount class should be updated from this:

`class MicrosoftGraphAccount(ProviderAccount): def to_str(self): name = self.account.extra_data.get('displayName') if name.strip() != '': return name return super(MicrosoftGraphAccount, self).to_str()`

to this:

`class MicrosoftGraphAccount(ProviderAccount): def to_str(self): name = self.account.extra_data.get('displayName') if not name is None: if name.strip() != '': return name return super(MicrosoftGraphAccount, self).to_str()`

That's it !
