### PR TITLE
Make return statement more concise

### DIFF
--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -80,12 +80,8 @@ class FacebookProvider(OAuth2Provider):
 
     def _get_locale_callable(self):
         settings = self.get_settings()
-        f = settings.get('LOCALE_FUNC')
-        if f:
-            f = import_callable(f)
-        else:
-            f = get_default_locale_callable()
-        return f
+        func = settings.get('LOCALE_FUNC')
+        return import_callable(func) if func else get_default_locale_callable()
 
     def get_locale_for_request(self, request):
         if not self._locale_callable_cache:


### PR DESCRIPTION
Explicit is better than implicit. (PEP 20)

- A single-line return statement introduces more clarity when it implements a single intent.
- Using single-letter variable names is discouraged by popular Python code linters.