### PR TITLE
Replace assert by RuntimeError

### DIFF
--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -72,10 +72,11 @@ class FacebookProvider(OAuth2Provider):
             js = "allauth.facebook.login(%s, %s, %s, %s)" % (
                 next, action, process, scope)
             ret = "javascript:%s" % (urlquote(js),)
-        else:
-            assert method == 'oauth2'
+        elif method == 'oauth2':
             ret = super(FacebookProvider, self).get_login_url(request,
                                                               **kwargs)
+        else:
+            raise RuntimeError('Invalid method specified: %s' % method)
         return ret
 
     def _get_locale_callable(self):


### PR DESCRIPTION
Assert statements should not be used in production code.

- We should understand asserts as "comments that don't become outdated".
- Optimized Python code will have assert statements stripped out. (Try `python -O script.py`)

The intent of the original code was to ensure a value, hence `if`, and abort by raising an Exception otherwise.