### PR TITLE
fix(instagram): Updated to use new API

### DIFF
--- a/allauth/socialaccount/providers/instagram/provider.py
+++ b/allauth/socialaccount/providers/instagram/provider.py
@@ -9,9 +9,6 @@ class InstagramAccount(ProviderAccount):
     def get_profile_url(self):
         return self.PROFILE_URL + self.account.extra_data.get('username')
 
-    def get_avatar_url(self):
-        return self.account.extra_data.get('profile_picture')
-
     def to_str(self):
         dflt = super(InstagramAccount, self).to_str()
         return self.account.extra_data.get('username', dflt)
@@ -23,17 +20,16 @@ class InstagramProvider(OAuth2Provider):
     account_class = InstagramAccount
 
     def extract_extra_data(self, data):
-        return data.get('data', {})
+        return data
 
     def get_default_scope(self):
         return ['basic']
 
     def extract_uid(self, data):
-        return str(data['data']['id'])
+        return str(data['id'])
 
     def extract_common_fields(self, data):
-        return dict(username=data['data'].get('username'),
-                    name=data['data'].get('full_name'))
+        return dict(username=data.get('username'))
 
 
 provider_classes = [InstagramProvider]

--- a/allauth/socialaccount/providers/instagram/views.py
+++ b/allauth/socialaccount/providers/instagram/views.py
@@ -13,11 +13,12 @@ class InstagramOAuth2Adapter(OAuth2Adapter):
     provider_id = InstagramProvider.id
     access_token_url = 'https://api.instagram.com/oauth/access_token'
     authorize_url = 'https://api.instagram.com/oauth/authorize'
-    profile_url = 'https://api.instagram.com/v1/users/self'
+    profile_url = 'https://graph.instagram.com/me'
 
     def complete_login(self, request, app, token, **kwargs):
         resp = requests.get(self.profile_url,
-                            params={'access_token': token.token})
+                            params={'access_token': token.token,
+                                    'fields': ['id', 'username']})
         resp.raise_for_status()
         extra_data = resp.json()
         return self.get_provider().sociallogin_from_response(request,


### PR DESCRIPTION
This fixes the Instagram provider to work with the new Instagram API as
per the docs at https://developers.facebook.com/docs/instagram-basic-display-api

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
