### PR TITLE
fix(twitch): Add missing client ID header

### DIFF
--- a/allauth/socialaccount/providers/twitch/tests.py
+++ b/allauth/socialaccount/providers/twitch/tests.py
@@ -1,3 +1,6 @@
+from django.test.client import RequestFactory
+from django.urls import reverse
+
 from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from allauth.socialaccount.tests import OAuth2TestsMixin
@@ -5,10 +8,6 @@ from allauth.tests import MockedResponse, TestCase, mocked_response
 
 from .provider import TwitchProvider
 from .views import TwitchOAuth2Adapter
-
-
-class MockObject(object):
-    pass
 
 
 class TwitchTests(OAuth2TestsMixin, TestCase):
@@ -86,8 +85,12 @@ class TwitchTests(OAuth2TestsMixin, TestCase):
         we can check that the specific erros are raised before
         they are caught and rendered to generic error HTML
         """
-        request = MockObject()
-        app = MockObject()
+        request = RequestFactory().get(
+            reverse(self.provider.id + '_login'),
+            {'process': 'login'},
+        )
+        adapter = TwitchOAuth2Adapter(request)
+        app = adapter.get_provider().get_app(request)
         token = SocialToken(token='this-is-my-fake-token')
 
         with mocked_response(resp_mock):

--- a/allauth/socialaccount/providers/twitch/views.py
+++ b/allauth/socialaccount/providers/twitch/views.py
@@ -17,7 +17,10 @@ class TwitchOAuth2Adapter(OAuth2Adapter):
     profile_url = 'https://api.twitch.tv/helix/users'
 
     def complete_login(self, request, app, token, **kwargs):
-        headers = {'Authorization': 'Bearer {}'.format(token.token)}
+        headers = {
+            'Authorization': 'Bearer {}'.format(token.token),
+            'Client-ID': app.client_id,
+        }
         response = requests.get(self.profile_url, headers=headers)
 
         data = response.json()


### PR DESCRIPTION
This PR fixes the Twitch provider's `complete_login` method, which otherwise throws an exception.

Background: [Twitch is changing their API](https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916?u=beheh) to require the `Client-ID` for all endpoints, including the profile URL endpoint. This change is going fully into effect on May 11th, and since May 1st Twitch is performing scheduled windows where this is in effect already.

Without this PR the OAuth login does not complete and instead throws the following error:

```
[twitch] Authentication error: 'unknown' (exception=OAuth2Error('Twitch API Error: Unauthorized (Client ID and OAuth token do not match)',))
```

I've tested the PR in my production application and this seems to fix it.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] ~~JavaScript code should adhere to [StandardJS](https://standardjs.com).~~
 - [ ] ~~If your changes are significant, please update `ChangeLog.rst`.~~
 - [ ] ~~Feel free to add yourself to `AUTHORS`.~~