### PR TITLE
 fix(discord): Switch to new API domain 

### DIFF
--- a/allauth/socialaccount/providers/discord/views.py
+++ b/allauth/socialaccount/providers/discord/views.py
@@ -10,9 +10,9 @@ from allauth.socialaccount.providers.oauth2.views import (
 
 class DiscordOAuth2Adapter(OAuth2Adapter):
     provider_id = DiscordProvider.id
-    access_token_url = 'https://discordapp.com/api/oauth2/token'
-    authorize_url = 'https://discordapp.com/api/oauth2/authorize'
-    profile_url = 'https://discordapp.com/api/users/@me'
+    access_token_url = 'https://discord.com/api/oauth2/token'
+    authorize_url = 'https://discord.com/api/oauth2/authorize'
+    profile_url = 'https://discord.com/api/users/@me'
 
     def complete_login(self, request, app, token, **kwargs):
         headers = {


### PR DESCRIPTION
This commit updates the URLs used by the Discord provider to match the new domain `https://discord.com` rather than the old one (`https://discordapp.com`).

The change was [announced](https://github.com/discord/discord-api-docs/issues/1585#issuecomment-623751530) on May 4th and the new domain is live and working right now. Merging can wait until the change is also present in the [Discord OAuth documentation](https://discord.com/developers/docs/topics/oauth2). Apparently it will only be enforced starting November 7th 2020, so there should be plenty of time.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] ~~JavaScript code should adhere to [StandardJS](https://standardjs.com).~~
 - [ ] ~~If your changes are significant, please update `ChangeLog.rst`.~~
 - [ ] ~~Feel free to add yourself to `AUTHORS`.~~