### PR TITLE
fix(odnklassniki): Fixed profile url

### DIFF
--- a/allauth/socialaccount/providers/odnoklassniki/provider.py
+++ b/allauth/socialaccount/providers/odnoklassniki/provider.py
@@ -4,7 +4,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class OdnoklassnikiAccount(ProviderAccount):
     def get_profile_url(self):
-        return self.account.extra_data.get('link')
+        return 'https://ok.ru/profile/' + self.account.extra_data['uid']
 
     def get_avatar_url(self):
         ret = None


### PR DESCRIPTION
Response of users.getCurrentUser doesn't contain 'link' field:
https://apiok.ru/en/dev/methods/rest/users/users.getCurrentUser