### PR TITLE
fix(signals docs): update readability

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -10,76 +10,61 @@ allauth.account
 
 
 - ``allauth.account.signals.user_logged_in(request, user)``
-
-  Sent when a user logs in.
+    Sent when a user logs in.
 
 - ``allauth.account.signals.user_logged_out(request, user)``
-
-  Sent when a user logs out.
+    Sent when a user logs out.
 
 - ``allauth.account.signals.user_signed_up(request, user)``
-
-  Sent when a user signs up for an account. This signal is
-  typically followed by a ``user_logged_in``, unless e-mail verification
-  prohibits the user to log in.
+    Sent when a user signs up for an account. This signal is
+    typically followed by a ``user_logged_in``, unless e-mail verification
+    prohibits the user to log in.
 
 - ``allauth.account.signals.password_set(request, user)``
-
-  Sent when a password has been successfully set for the first time.
+    Sent when a password has been successfully set for the first time.
 
 - ``allauth.account.signals.password_changed(request, user)``
-
-  Sent when a password has been successfully changed.
+    Sent when a password has been successfully changed.
 
 - ``allauth.account.signals.password_reset(request, user)``
-
-  Sent when a password has been successfully reset.
+    Sent when a password has been successfully reset.
 
 - ``allauth.account.signals.email_confirmed(request, email_address)``
-
-  Sent after the email address in the db was updated and set to confirmed.
+    Sent after the email address in the db was updated and set to confirmed.
 
 - ``allauth.account.signals.email_confirmation_sent(request, confirmation, signup)``
-
-  Sent right after the email confirmation is sent.
+    Sent right after the email confirmation is sent.
 
 - ``allauth.account.signals.email_changed(request, user, from_email_address, to_email_address)``
-
-  Sent when a primary email address has been changed.
+    Sent when a primary email address has been changed.
 
 - ``allauth.account.signals.email_added(request, user, email_address)``
-
-  Sent when a new email address has been added.
+    Sent when a new email address has been added.
 
 - ``allauth.account.signals.email_removed(request, user, email_address)``
-
-  Sent when an email address has been deleted.
+    Sent when an email address has been deleted.
 
 
 allauth.socialaccount
 ---------------------
 
 - ``allauth.socialaccount.signals.pre_social_login(request, sociallogin)``
-
-  Sent after a user successfully authenticates via a social provider,
-  but before the login is fully processed. This signal is emitted as
-  part of the social login and/or signup process, as well as when
-  connecting additional social accounts to an existing account. Access
-  tokens and profile information, if applicable for the provider, is
-  provided.
+    Sent after a user successfully authenticates via a social provider,
+    but before the login is fully processed. This signal is emitted as
+    part of the social login and/or signup process, as well as when
+    connecting additional social accounts to an existing account. Access
+    tokens and profile information, if applicable for the provider, is
+    provided.
 
 - ``allauth.socialaccount.signals.social_account_added(request, sociallogin)``
-
-  Sent after a user connects a social account to a their local account.
+    Sent after a user connects a social account to a their local account.
 
 - ``allauth.socialaccount.signals.social_account_updated(request, sociallogin)``
-
-  Sent after a social account has been updated. This happens when a user
-  logs in using an already connected social account, or completes a `connect`
-  flow for an already connected social account. Useful if you need to
-  unpack extra data for social accounts as they are updated.
+    Sent after a social account has been updated. This happens when a user
+    logs in using an already connected social account, or completes a `connect`
+    flow for an already connected social account. Useful if you need to
+    unpack extra data for social accounts as they are updated.
 
 - ``allauth.socialaccount.signals.social_account_removed(request, socialaccount)``
-
-  Sent after a user disconnects a social account from their local
-  account.
+    Sent after a user disconnects a social account from their local
+    account.


### PR DESCRIPTION
It looked like explanation refers to the following bulleted line, while it belongs to preceding one. 
I don't like bold (seen on Github), hopefully readthedocs' theme will plain it out, but that's .rst
