### PR TITLE
fix(gitlab): Add error handling to GitLab provider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,6 +90,7 @@ Justin Michalicek
 Justin Pogrob
 Kevin Dice
 Koichi Harakawa
+Kyle Harrison
 Lee Semel
 Luis Diego García
 Luiz Guilherme Pais dos Santos

--- a/allauth/socialaccount/providers/gitlab/tests.py
+++ b/allauth/socialaccount/providers/gitlab/tests.py
@@ -1,11 +1,18 @@
 # -*- coding: utf-8 -*-
+import json
+
+from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
+from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
+
+from .views import _check_errors
 
 
 class GitLabTests(OAuth2TestsMixin, TestCase):
     provider_id = GitLabProvider.id
+    _uid = 2
 
     def get_mocked_response(self):
         return MockedResponse(200, """
@@ -40,3 +47,54 @@ class GitLabTests(OAuth2TestsMixin, TestCase):
                 "website_url": ""
             }
         """)
+
+    def test_valid_response(self):
+        data = {"id": 12345}
+        response = MockedResponse(200, json.dumps(data))
+        self.assertEqual(_check_errors(response), data)
+
+    def test_invalid_data(self):
+        response = MockedResponse(200, json.dumps({}))
+        with self.assertRaises(OAuth2Error):
+            # No id, raises
+            _check_errors(response)
+
+    def test_account_invalid_response(self):
+        body = (
+            "403 Forbidden  - You (@domain.com) must accept the Terms of "
+            "Service in order to perform this action. Please access GitLab "
+            "from a web browser to accept these terms."
+            )
+        response = MockedResponse(403, body)
+
+        # GitLab allow users to login with their API and provides
+        # an error requiring the user to accept the Terms of Service.
+        # see: https://gitlab.com/gitlab-org/gitlab-foss/-/issues/45849
+        with self.assertRaises(OAuth2Error):
+            # no id, 4xx code, raises
+            _check_errors(response)
+
+    def test_error_response(self):
+        body = "403 Forbidden"
+        response = MockedResponse(403, body)
+
+        with self.assertRaises(OAuth2Error):
+            # no id, 4xx code, raises
+            _check_errors(response)
+
+    def test_invalid_response(self):
+        response = MockedResponse(200, json.dumps({}))
+        with self.assertRaises(OAuth2Error):
+            # No id, raises
+            _check_errors(response)
+
+    def test_bad_response(self):
+        response = MockedResponse(400, json.dumps({}))
+        with self.assertRaises(OAuth2Error):
+            # bad json, raises
+            _check_errors(response)
+
+    def test_extra_data(self):
+        self.login(self.get_mocked_response())
+        account = SocialAccount.objects.get(uid=str(self._uid))
+        self.assertEqual(account.extra_data["id"], self._uid)

--- a/allauth/socialaccount/providers/gitlab/views.py
+++ b/allauth/socialaccount/providers/gitlab/views.py
@@ -3,11 +3,44 @@ import requests
 
 from allauth.socialaccount import app_settings
 from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
+from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
     OAuth2LoginView,
 )
+
+
+def _check_errors(response):
+    #  403 error's are presented as user-facing errors
+    if response.status_code == 403:
+        msg = response.content
+        raise OAuth2Error("Invalid data from GitLab API: %r" % (msg))
+
+    try:
+        data = response.json()
+    except ValueError:  # JSONDecodeError on py3
+        raise OAuth2Error(
+            "Invalid JSON from GitLab API: %r" % (response.text)
+        )
+
+    if response.status_code >= 400 or "error" in data:
+        # For errors, we expect the following format:
+        # {"error": "error_name", "error_description": "Oops!"}
+        # For example, if the token is not valid, we will get:
+        # {"message": "status_code - message"}
+        error = data.get("error", "") or response.status_code
+        desc = data.get("error_description", "") or data.get("message", "")
+
+        raise OAuth2Error("GitLab error: %s (%s)" % (error, desc))
+
+    # The expected output from the API follows this format:
+    # {"id": 12345, ...}
+    if "id" not in data:
+        # If the id is not present, the output is not usable (no UID)
+        raise OAuth2Error("Invalid data from GitLab API: %r" % (data))
+
+    return data
 
 
 class GitLabOAuth2Adapter(OAuth2Adapter):
@@ -25,13 +58,14 @@ class GitLabOAuth2Adapter(OAuth2Adapter):
     )
 
     def complete_login(self, request, app, token, response):
-        extra_data = requests.get(self.profile_url, params={
+        response = requests.get(self.profile_url, params={
             'access_token': token.token
         })
+        data = _check_errors(response)
 
         return self.get_provider().sociallogin_from_response(
             request,
-            extra_data.json()
+            data
         )
 
 


### PR DESCRIPTION
### What's Changed

Adds error handling to the GitLab provider to raise an OAuth2Error instead of a KeyError's when GitLab returns a >= 400 response. 

I've attached my proposed changes. If you are willing to accept this change, I would be happy to complete any additional/required work to ensure all the changes meet all standards.

### Context

The following was identified when a user attempt to use social sign-on for GitLab (before they had accepted the GitLab Terms of Service). In this scenario, GitLab provides an error detailing the action required by the user in their [documentation](https://docs.gitlab.com/ee/api/README.html#authentication). 

As it was unhandled, this produced a KeyError when attempting to retrieve the `id` from the response. See attached screenshot from Sentry for context:

![Screenshot 2020-06-08 at 17 37 17](https://user-images.githubusercontent.com/1443700/84057071-0b2b9d00-a9af-11ea-863c-6e9fbc7f3441.png)

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 