### PR TITLE
feat(providers): Retrieve providers enabled on the site

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Benjamin Jorand
 Biel Massot
 Björn Andersson
 Bojan Mihelac
+Brad Luczywo
 Bruno Alla
 Chris Beaven
 Chris Davis

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,13 @@
+0.43.0 (2020-05-27)
+*******************
+
+Note worthy changes
+-------------------
+
+- Added ``get_site_providers`` method to provide the ability to only list
+  providers that are enabled for a specific site.
+
+
 0.42.0 (2020-05-24)
 *******************
 

--- a/allauth/socialaccount/providers/__init__.py
+++ b/allauth/socialaccount/providers/__init__.py
@@ -24,13 +24,10 @@ class ProviderRegistry(object):
             sites__id=getattr(site, 'id', None)
         ).values_list('provider', flat=True)
 
-        for provider_cls in self.provider_map.values():
-            provider = provider_cls(request)
-
-            if provider.id in site_provider_ids:
-                providers.append(provider)
-
-        return providers
+        return [
+            provider_cls(request)
+            for provider_cls in self.provider_map.values()
+            if provider_cls.id in site_provider_ids]
 
     def register(self, cls):
         self.provider_map[cls.id] = cls

--- a/allauth/socialaccount/providers/__init__.py
+++ b/allauth/socialaccount/providers/__init__.py
@@ -15,6 +15,23 @@ class ProviderRegistry(object):
             provider_cls(request)
             for provider_cls in self.provider_map.values()]
 
+    def get_site_list(self, site, request=None):
+        from allauth.socialaccount.models import SocialApp
+
+        self.load()
+        providers = []
+        site_provider_ids = SocialApp.objects.filter(
+            sites__id=getattr(site, 'id', None)
+        ).values_list('provider', flat=True)
+
+        for provider_cls in self.provider_map.values():
+            provider = provider_cls(request)
+
+            if provider.id in site_provider_ids:
+                providers.append(provider)
+
+        return providers
+
     def register(self, cls):
         self.provider_map[cls.id] = cls
 

--- a/allauth/socialaccount/templatetags/socialaccount.py
+++ b/allauth/socialaccount/templatetags/socialaccount.py
@@ -89,6 +89,19 @@ def get_providers():
     Usage: `{% get_providers as socialaccount_providers %}`.
 
     Then within the template context, `socialaccount_providers` will hold
-    a list of social providers configured for the current site.
+    a list of social providers configured for the current installation.
     """
     return providers.registry.get_list()
+
+
+@register.simple_tag
+def get_site_providers(site):
+    """
+    Returns a list of social authentication providers enabled for `site`.
+
+    Usage: `{% get_site_providers site as socialaccount_providers %}`.
+
+    Then within the template context, `socialaccount_providers` will hold
+    a list of social providers configured for the current site.
+    """
+    return providers.registry.get_site_list(site=site)


### PR DESCRIPTION
# Details of this change

The list of providers does not account for the fact that some sites may have an individual provider turned off. Instead, every site gets the full list of providers installed rather than just the ones that are enabled.

This adds a new method for getting only providers that are specifically enabled for the site.

It seems to me that this would have been the intended behavior all along, so it might be preferable to make this the default behavior. That might also inspire changes to `socialaccount.providers.ProviderRegistry.load()` to not load _everything_ from `INSTALLED_APPS`.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
