### PR TITLE
fix(forms): Remove hardcoded size of textinputs

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -422,7 +422,6 @@ class AddEmailForm(UserForm):
         required=True,
         widget=forms.TextInput(
             attrs={"type": "email",
-                   "size": "30",
                    "placeholder": _('E-mail address')}))
 
     def clean_email(self):
@@ -491,7 +490,6 @@ class ResetPasswordForm(forms.Form):
         required=True,
         widget=forms.TextInput(attrs={
             "type": "email",
-            "size": "30",
             "placeholder": _("E-mail address"),
         })
     )


### PR DESCRIPTION
Was trying to style forms and found that these fields have hardcoded size, while other inputs don't