### PR TITLE
feat(socialaccount/providers): Add support for Figma login

### DIFF
--- a/allauth/socialaccount/providers/figma/provider.py
+++ b/allauth/socialaccount/providers/figma/provider.py
@@ -1,0 +1,38 @@
+from allauth.account.models import EmailAddress
+from allauth.socialaccount import providers
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class FigmaAccount(ProviderAccount):
+    def to_str(self):
+        return self.account.extra_data.get('handle', '')
+
+    def get_avatar_url(self):
+        return self.account.extra_data.get('img_url', '')
+
+
+class FigmaProvider(OAuth2Provider):
+    id = 'figma'
+    name = 'Figma'
+    account_class = FigmaAccount
+
+    def extract_uid(self, data):
+        return str(data['id'])
+
+    def extract_common_fields(self, data):
+        return {
+            'email': data.get('email'),
+            'name': data.get('handle'),
+        }
+
+    def extract_email_addresses(self, data):
+        email = EmailAddress(
+            email=data.get('email'),
+            primary=True,
+            verified=False,
+        )
+        return [email]
+
+
+providers.registry.register(FigmaProvider)

--- a/allauth/socialaccount/providers/figma/tests.py
+++ b/allauth/socialaccount/providers/figma/tests.py
@@ -1,0 +1,22 @@
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse
+from allauth.tests import TestCase
+
+from .provider import FigmaProvider
+
+
+class FigmaTests(OAuth2TestsMixin, TestCase):
+    provider_id = FigmaProvider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(
+            200,
+            """
+                {
+                  "id": "2600",
+                  "email": "johndoe@example.com",
+                  "handle": "John Doe",
+                  "img_url": "https://www.example.com/image.png"
+                }
+            """
+        )

--- a/allauth/socialaccount/providers/figma/urls.py
+++ b/allauth/socialaccount/providers/figma/urls.py
@@ -1,0 +1,6 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+
+from .provider import FigmaProvider
+
+
+urlpatterns = default_urlpatterns(FigmaProvider)

--- a/allauth/socialaccount/providers/figma/views.py
+++ b/allauth/socialaccount/providers/figma/views.py
@@ -1,0 +1,30 @@
+from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
+from allauth.socialaccount.providers.oauth2.views import OAuth2CallbackView
+from allauth.socialaccount.providers.oauth2.views import OAuth2LoginView
+import requests
+
+from .provider import FigmaProvider
+
+
+class FigmaOAuth2Adapter(OAuth2Adapter):
+    provider_id = FigmaProvider.id
+
+    authorize_url = 'https://www.figma.com/oauth'
+    access_token_url = 'https://www.figma.com/api/oauth/token'
+    userinfo_url = 'https://api.figma.com/v1/me'
+
+    def complete_login(self, request, app, token, **kwargs):
+        resp = requests.get(
+            self.userinfo_url,
+            headers={'Authorization': 'Bearer {0}'.format(token.token)}
+        )
+        resp.raise_for_status()
+        extra_data = resp.json()
+        return self.get_provider().sociallogin_from_response(
+            request,
+            extra_data
+        )
+
+
+oauth2_login = OAuth2LoginView.adapter_view(FigmaOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(FigmaOAuth2Adapter)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -75,6 +75,7 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
         'allauth.socialaccount.providers.evernote',
         'allauth.socialaccount.providers.facebook',
         'allauth.socialaccount.providers.feedly',
+        'allauth.socialaccount.providers.figma',
         'allauth.socialaccount.providers.fivehundredpx',
         'allauth.socialaccount.providers.flickr',
         'allauth.socialaccount.providers.foursquare',

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -91,6 +91,8 @@ Supported Providers
 
 - Feedly (OAuth2)
 
+- Figma (OAuth2)
+
 - Firefox Accounts (OAuth2)
 
 - Flickr (OAuth)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -552,6 +552,16 @@ Development callback URL
     add your site's actual domain to this section once it goes live.
 
 
+Figma
+------------------
+
+App registration (get your key and secret here)
+    https://www.figma.com/developers/apps
+
+Development callback URL
+    http://localhost:8000/accounts/figma/login/callback/
+
+
 Firefox Accounts
 ----------------
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -82,6 +82,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.eventbrite',
     'allauth.socialaccount.providers.facebook',
     'allauth.socialaccount.providers.feedly',
+    'allauth.socialaccount.providers.figma',
     'allauth.socialaccount.providers.fivehundredpx',
     'allauth.socialaccount.providers.flickr',
     'allauth.socialaccount.providers.foursquare',


### PR DESCRIPTION
This PR adds a provider for Figma login: https://www.figma.com/developers/api#authentication