### PR TITLE
fix: openid form linking to 404 page, link to openidexplained

### DIFF
--- a/allauth/socialaccount/providers/openid/forms.py
+++ b/allauth/socialaccount/providers/openid/forms.py
@@ -6,7 +6,7 @@ class LoginForm(forms.Form):
     openid = forms.URLField(
         label=('OpenID'),
         help_text=(
-            'Get an <a href="http://openid.net/get-an-openid/">OpenID</a>'))
+            'Get an <a href="http://openidexplained.com/get">OpenID</a>'))
     next = forms.CharField(
         widget=forms.HiddenInput,
         required=False)


### PR DESCRIPTION
# Submitting Pull Requests

The current url points to a 404 page. I've searched the same website for a list of known providers to link to and cannot find one that explicitly states possible providers. 

openidexplained.com site does have a list with details and more information.

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.