### PR TITLE
fix(facebook) added comma delimiter to remove social login failure and invalid scopes when scopes are valid

### DIFF
--- a/allauth/socialaccount/providers/facebook/views.py
+++ b/allauth/socialaccount/providers/facebook/views.py
@@ -59,7 +59,7 @@ class FacebookOAuth2Adapter(OAuth2Adapter):
             GRAPH_API_VERSION))
 
     settings = app_settings.PROVIDERS.get(provider_id, {})
-
+    scope_delimiter = ','
     authorize_url = settings.get('AUTHORIZE_URL', provider_default_auth_url)
     access_token_url = GRAPH_API_URL + '/oauth/access_token'
     expires_in_key = 'expires_in'


### PR DESCRIPTION



ISSUE #2609
https://github.com/pennersr/django-allauth/issues/2609

There is currently an issue when authenticating with Facebook:
- The initial redirect URL that begins the login process incorrectly separates the scopes with a '+' character
- This causes Social Login Failures, as well as an Invalid Scopes Failure

The new Facebook  API v7.0 update requires scopes to be separated by the ',' character

As mentioned by Facebook support in the image below

- This PR sets the scope_delimter class attribute to a "," character in the FacebookOAuth2Adapter class to resolve the issue




![image](https://user-images.githubusercontent.com/24502060/88612526-09966100-d051-11ea-815e-8d6cdeafebef.png)

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
