### PR TITLE
fix(openid): Mark tests as expected failures

### DIFF
--- a/allauth/socialaccount/providers/openid/tests.py
+++ b/allauth/socialaccount/providers/openid/tests.py
@@ -1,3 +1,5 @@
+from unittest import expectedFailure
+
 from django.test import override_settings
 from django.urls import reverse
 
@@ -23,7 +25,9 @@ class OpenIDTests(TestCase):
                                 dict(openid='http://www.google.com'))
         self.assertTrue('openid' in resp.context['form'].errors)
 
+    @expectedFailure
     def test_login(self):
+        # Location: https://s.yimg.com/wm/mbr/html/openid-eol-0.0.1.html
         resp = self.client.post(reverse(views.login),
                                 dict(openid='http://me.yahoo.com'))
         assert 'login.yahooapis' in resp['location']
@@ -55,6 +59,7 @@ class OpenIDTests(TestCase):
                     )
                     get_user_model().objects.get(first_name='raymond')
 
+    @expectedFailure
     @override_settings(SOCIALACCOUNT_PROVIDERS={'openid': {'SERVERS': [
         dict(id='yahoo',
              name='Yahoo',


### PR DESCRIPTION
Long term solution: phase out OpenID 2.0 support. Current test relies on
Yahoo (dead now) and Hyves (should be long dead, if it isn't, it's
undead).

This fix silences the tests, until someone wants to find a new provider
or mock the discovery, but OpenID itself has moved on to the next shiny
version: OpenID Connect, so it is best to sunset this support.

# Submitting Pull Requests

## General

 - [V] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [V] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 