### PR TITLE
fix(forms): signup.custom_signup should use self instead of super due to MRO

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -347,16 +347,15 @@ class BaseSignupForm(_base_signup_form_class()):
         return cleaned_data
 
     def custom_signup(self, request, user):
-        custom_form = super(BaseSignupForm, self)
-        if hasattr(custom_form, 'signup') and callable(custom_form.signup):
-            custom_form.signup(request, user)
+        if hasattr(self, 'signup') and callable(self.signup):
+            self.signup(request, user)
         else:
             warnings.warn("The custom signup form must offer"
                           " a `def signup(self, request, user)` method",
                           DeprecationWarning)
             # Historically, it was called .save, but this is confusing
             # in case of ModelForm
-            custom_form.save(user)
+            self.save(user)
 
 
 class SignupForm(BaseSignupForm):

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -355,7 +355,7 @@ class BaseSignupForm(_base_signup_form_class()):
                           DeprecationWarning)
             # Historically, it was called .save, but this is confusing
             # in case of ModelForm
-            self.save(user)
+            super(BaseSignupForm, self).save(user)
 
 
 class SignupForm(BaseSignupForm):


### PR DESCRIPTION
Due to python MRO, a custom form inheriting from ``account.forms.SignupForm`` and using ``ACCOUNT_FORMS['signup']`` currently does not allow calling ``def signup`` due to the use of super which is calling the very base class which is ``_DummyCustomSignupForm`` by default instead of the custom form.

The check and use of signup should be based on self.

Related to #2039 because overriding the base class using ``ACCOUNT_SIGNUP_FORM_CLASS`` does call ``signup`` properly whereas ``ACCOUNT_FORMS['signup']`` does not due to MRO.

Fixes #2435 

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 