### PR TITLE
feat(login): deny unverified EmailAddress from login

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -7,6 +7,9 @@ Note worthy changes
 - If ``ACCOUNT_LOGIN_ATTEMPTS_LIMIT`` is set and the user successfully
   resets their password, the timeout is cleared to allow immediate login.
 
+- New setting ``ACCOUNT_LOGIN_VERIFIED_ONLY(=False)`` allows
+  blocking unverified EmailAddress logins
+
 0.42.0 (2020-05-24)
 *******************
 

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -315,6 +315,10 @@ class AppSettings(object):
                 ret = []
         return ret
 
+    @property
+    def LOGIN_VERIFIED_ONLY(self):
+        return self._setting('LOGIN_VERIFIED_ONLY', False)
+
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/auth_backends.py
+++ b/allauth/account/auth_backends.py
@@ -8,7 +8,7 @@ from .app_settings import AuthenticationMethod
 from .utils import (
     filter_users_by_email,
     filter_users_by_username,
-    verify_login_user_email_verified_flag
+    verify_login_user_email_verified_flag,
 )
 
 

--- a/allauth/account/auth_backends.py
+++ b/allauth/account/auth_backends.py
@@ -5,7 +5,11 @@ from django.contrib.auth.backends import ModelBackend
 from ..utils import get_user_model
 from . import app_settings
 from .app_settings import AuthenticationMethod
-from .utils import filter_users_by_email, filter_users_by_username
+from .utils import (
+    filter_users_by_email,
+    filter_users_by_username,
+    verify_login_user_email_verified_flag
+)
 
 
 _stash = local()
@@ -53,6 +57,13 @@ class AuthenticationBackend(ModelBackend):
         if email:
             for user in filter_users_by_email(email):
                 if self._check_password(user, credentials["password"]):
+
+                    if app_settings.LOGIN_VERIFIED_ONLY:
+
+                        # function raises PermissionDenied exception in the
+                        # case the user is not allowed to login.
+                        verify_login_user_email_verified_flag(user, email)
+
                     return user
         return None
 

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1209,25 +1209,26 @@ class AuthenticationBackendTests(TestCase):
     @override_settings(
         ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod.EMAIL,
         ACCOUNT_LOGIN_VERIFIED_ONLY=True)  # noqa
-    def test_auth_by_email_verified_only_fails_two_unverified(self):
+    def test_auth_by_email_verified_only_success_two_unverified(self):
         user = self.user
+        backend = AuthenticationBackend()
 
         email1 = user.emailaddress_set.create(email='email1@domain.com')
         email2 = user.emailaddress_set.create(email='email2@domain.com')
 
-        backend = AuthenticationBackend()
-
-        with self.assertRaises(PermissionDenied):
+        self.assertEqual(
             backend.authenticate(
                 request=None,
                 username=email1.email,
-                password=user.username)
+                password=user.username).pk,
+            user.pk)
 
-        with self.assertRaises(PermissionDenied):
+        self.assertEqual(
             backend.authenticate(
                 request=None,
                 username=email2.email,
-                password=user.username)
+                password=user.username).pk,
+            user.pk)
 
     @override_settings(
         ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod.EMAIL,
@@ -1376,10 +1377,10 @@ class UtilsTests(TestCase):
         email1 = self._create_user_email_address(user, 'email1@domain.com')
         email2 = self._create_user_email_address(user, 'email2@domain.com')
 
-        with self.assertRaises(PermissionDenied):
-            verify_login_user_email_verified_flag(user, email1.email)
-        with self.assertRaises(PermissionDenied):
-            verify_login_user_email_verified_flag(user, email2.email)
+        val = verify_login_user_email_verified_flag(user, email1.email)
+        self.assertTrue(val)
+        val = verify_login_user_email_verified_flag(user, email2.email)
+        self.assertTrue(val)
 
     def test_vlue_verified_flag_with_multiple_emailaddress_one_verified(self):
         user = get_user_model().objects.create(

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1190,7 +1190,9 @@ class AuthenticationBackendTests(TestCase):
         user = self.user
         backend = AuthenticationBackend()
 
-        email1 = user.emailaddress_set.create(email='email1@domain.com', verified=True)
+        email1 = user.emailaddress_set.create(
+            email='email1@domain.com', verified=True
+        )
         self.assertEqual(
             backend.authenticate(
                 request=None,
@@ -1199,12 +1201,10 @@ class AuthenticationBackendTests(TestCase):
             user.pk)
 
         email2 = user.emailaddress_set.create(email='email2@domain.com')
-        self.assertEqual(
+        with self.assertRaises(PermissionDenied):
             backend.authenticate(
-                request=None,
-                username=email1.email,
-                password=user.username).pk,
-            user.pk)
+                request=None, username=email2.email, password=user.username
+            )
 
     @override_settings(
         ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod.EMAIL,
@@ -1233,10 +1233,10 @@ class AuthenticationBackendTests(TestCase):
     @override_settings(
         ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod.EMAIL,
         ACCOUNT_LOGIN_VERIFIED_ONLY=True)  # noqa
-    def test_auth_by_email_verified_only_fails_one_unverified_using_unverified(self):
+    def test_auth_by_email_verified_only_fails_one_uv_using_unverified(self):
         user = self.user
 
-        email1 = user.emailaddress_set.create(email='email1@domain.com', verified=True)
+        user.emailaddress_set.create(email='email1@domain.com', verified=True)
         email2 = user.emailaddress_set.create(email='email2@domain.com')
 
         backend = AuthenticationBackend()
@@ -1250,11 +1250,13 @@ class AuthenticationBackendTests(TestCase):
     @override_settings(
         ACCOUNT_AUTHENTICATION_METHOD=app_settings.AuthenticationMethod.EMAIL,
         ACCOUNT_LOGIN_VERIFIED_ONLY=True)  # noqa
-    def test_auth_by_email_verified_only_success_one_unverified_using_verified(self):
+    def test_auth_by_email_verified_only_success_one_uv_using_verified(self):
         user = self.user
 
-        email1 = user.emailaddress_set.create(email='email1@domain.com', verified=True)
-        email2 = user.emailaddress_set.create(email='email2@domain.com')
+        email1 = user.emailaddress_set.create(
+            email='email1@domain.com', verified=True
+        )
+        user.emailaddress_set.create(email='email2@domain.com')
 
         backend = AuthenticationBackend()
 
@@ -1271,8 +1273,12 @@ class AuthenticationBackendTests(TestCase):
     def test_auth_by_email_verified_only_success_both_verified(self):
         user = self.user
 
-        email1 = user.emailaddress_set.create(email='email1@domain.com', verified=True)
-        email2 = user.emailaddress_set.create(email='email2@domain.com', verified=True)
+        email1 = user.emailaddress_set.create(
+            email='email1@domain.com', verified=True
+        )
+        email2 = user.emailaddress_set.create(
+            email='email2@domain.com', verified=True
+        )
 
         backend = AuthenticationBackend()
 
@@ -1357,7 +1363,7 @@ class UtilsTests(TestCase):
     def _create_user_email_address(self, user, email, **kwargs):
         return user.emailaddress_set.create(email=email, **kwargs)
 
-    def test_vlue_verified_flag_with_one_emailaddress(self):
+    def test_vluevf_with_one_emailaddress(self):
         user = get_user_model().objects.create(
             is_active=True,
             email='john@example.com',
@@ -1368,7 +1374,7 @@ class UtilsTests(TestCase):
 
         self.assertTrue(val)
 
-    def test_vlue_verified_flag_with_multiple_emailaddress_all_unverified(self):
+    def test_vluevf_with_multiple_emailaddress_all_unverified(self):
         user = get_user_model().objects.create(
             is_active=True,
             email='john@example.com',
@@ -1382,26 +1388,32 @@ class UtilsTests(TestCase):
         val = verify_login_user_email_verified_flag(user, email2.email)
         self.assertTrue(val)
 
-    def test_vlue_verified_flag_with_multiple_emailaddress_one_verified(self):
+    def test_vluevf_with_multiple_emailaddress_one_verified(self):
         user = get_user_model().objects.create(
             is_active=True,
             email='john@example.com',
             username='john')
 
-        email1 = self._create_user_email_address(user, 'email1@domain.com', verified=True)
-        email2 = self._create_user_email_address(user, 'email2@domain.com')
+        email1 = self._create_user_email_address(
+            user, 'email1@domain.com', verified=True
+        )
+        self._create_user_email_address(user, 'email2@domain.com')
 
         val = verify_login_user_email_verified_flag(user, email1.email)
         self.assertTrue(val)
 
-    def test_vlue_verified_flag_with_multiple_emailaddress_one_verified_using_unverified(self):
+    def test_vluevf_with_multiple_emailaddress_one_v_using_unverified(self):
         user = get_user_model().objects.create(
             is_active=True,
             email='john@example.com',
             username='john')
 
-        email1 = self._create_user_email_address(user, 'email1@domain.com', verified=True)
-        email2 = self._create_user_email_address(user, 'email2@domain.com')
+        self._create_user_email_address(
+            user, 'email1@domain.com', verified=True
+        )
+        email2 = self._create_user_email_address(
+            user, 'email2@domain.com'
+        )
 
         with self.assertRaises(PermissionDenied):
             verify_login_user_email_verified_flag(user, email2.email)
@@ -1412,8 +1424,12 @@ class UtilsTests(TestCase):
             email='john@example.com',
             username='john')
 
-        email1 = self._create_user_email_address(user, 'email1@domain.com', verified=True)
-        email2 = self._create_user_email_address(user, 'email2@domain.com', verified=True)
+        email1 = self._create_user_email_address(
+            user, 'email1@domain.com', verified=True
+        )
+        email2 = self._create_user_email_address(
+            user, 'email2@domain.com', verified=True
+        )
 
         val = verify_login_user_email_verified_flag(user, email1.email)
         self.assertTrue(val)

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -5,7 +5,11 @@ from datetime import timedelta
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import update_session_auth_hash
-from django.core.exceptions import FieldDoesNotExist, PermissionDenied, ValidationError
+from django.core.exceptions import (
+    FieldDoesNotExist,
+    PermissionDenied,
+    ValidationError,
+)
 from django.db import models
 from django.db.models import Q
 from django.http import HttpResponseRedirect
@@ -480,7 +484,7 @@ def verify_login_user_email_verified_flag(user, email):
     # or if user only has unverified emails, do not block as the
     # verification system blocks login and sends confirmation emails.
     if not users_unverified_emails.exists() or \
-        users_emails.count() == users_unverified_emails.count():
+            users_emails.count() == users_unverified_emails.count():
         return True
 
     # If the email supplied is unverified, block.

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -12,6 +12,7 @@ from django.http import HttpResponseRedirect
 from django.utils.encoding import force_str
 from django.utils.http import base36_to_int, int_to_base36, urlencode
 from django.utils.timezone import now
+from django.utils.translation import gettext_lazy as _
 
 from ..exceptions import ImmediateHttpResponse
 from ..utils import (
@@ -476,11 +477,14 @@ def verify_login_user_email_verified_flag(user, email):
     users_unverified_emails = users_emails.filter(verified=False)
 
     # If the user has no unverified emails, no need to block
-    if not users_unverified_emails.exists():
+    # or if user only has unverified emails, do not block as the
+    # verification system blocks login and sends confirmation emails.
+    if not users_unverified_emails.exists() or \
+        users_emails.count() == users_unverified_emails.count():
         return True
 
     # If the email supplied is unverified, block.
     if users_unverified_emails.filter(email=email).exists():
-        raise PermissionDenied('test')
+        raise PermissionDenied(_('email address is unverified'))
 
     return True

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -52,9 +52,9 @@ ACCOUNT_EMAIL_REQUIRED (=False)
 ACCOUNT_EMAIL_VERIFICATION (="optional")
   Determines the e-mail verification method during signup -- choose
   one of ``"mandatory"``, ``"optional"``, or ``"none"``.
-  
+
   Setting this to `"mandatory"` requires `ACCOUNT_EMAIL_REQUIRED` to be `True`
-  
+
   When set to "mandatory" the user is blocked from logging in until the email
   address is verified. Choose "optional" or "none" to allow logins
   with an unverified e-mail address. In case of "optional", the e-mail
@@ -125,6 +125,23 @@ ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION (=False)
   they confirm their email address. Note however that this only works when
   confirming the email address **immediately after signing up**, assuming users
   didn't close their browser or used some sort of private browsing mode.
+
+ACCOUNT_LOGIN_VERIFIED_ONLY (=False)
+  Set to true to only allow verified email addresses to login. Does NOT
+  affect accounts with one EmailAddress entry.
+
+  This setting requires ``ACCOUNT_AUTHENTICATION_METHOD='email'`` to work.
+
+  It is recommended to set ``ACCOUNT_EMAIL_VERIFICATION='mandatory'`` as well.
+
+  Setting this to ``True`` means the follow scenarios occur on the assumption
+  that we're looking at one User account with multiple EmailAddress entries.
+
+  * Zero EmailAddress: login allowed as login was via User.email entry.
+  * One EmailAddress: login allowed
+  * Two or more EmailAddress: all unverified: login disallowed for both emails.
+  * Two or more EmailAddress: one or more verified: login allowed for verified, denied for unverified.
+
 
 ACCOUNT_LOGOUT_ON_GET (=False)
   Determines whether or not the user is automatically logged out by a
@@ -215,17 +232,17 @@ ACCOUNT_USERNAME_VALIDATORS (=None)
   (``'some.module.validators.custom_username_validators'``) to a list of
   custom username validators. If left unset, the validators setup
   within the user model username field are used.
-  
+
   Example::
-  
+
       # In validators.py
-      
+
       from django.contrib.auth.validators import ASCIIUsernameValidator
 
       custom_username_validators = [ASCIIUsernameValidator()]
-      
+
       # In settings.py
-      
+
       ACCOUNT_USERNAME_VALIDATORS = 'some.module.validators.custom_username_validators'
 
 SOCIALACCOUNT_ADAPTER (="allauth.socialaccount.adapter.DefaultSocialAccountAdapter")


### PR DESCRIPTION
Allow admin to set a config option that disables a users ability to login via an unverified email address.

Only applies when there are multiple EmailAddress entries, single entries are handled by login system checking for verified emails when ``ACCOUNT_EMAIL_VERIFICATION = 'mandatory'``.

In relation to #650

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.