### PR TITLE
fix(docs): steam provider requires key in client id and secret key fields

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1593,7 +1593,8 @@ access to more of the user's details such as username, full name, avatar, etc.
 You need to register an API key here:
     https://steamcommunity.com/dev/apikey
 
-Make sure to create a Steam SocialApp with that secret key.
+Copy the Key supplied by the website above into BOTH Client ID and Secret
+Key fields of the Social Application.
 
 
 Strava


### PR DESCRIPTION
When the user returns from steam having verified their login, if you do not supply the key in the Secret Key field you get 403 forbidden response errors from steam and oauth fails expecting a json response.

#2358

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
