### PR TITLE
test(test_settings): decrease password iterations to increase test speed

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -161,7 +161,9 @@ from django.contrib.auth.hashers import PBKDF2PasswordHasher
 
 class MyPBKDF2PasswordHasher(PBKDF2PasswordHasher):
     """
-    A subclass of PBKDF2PasswordHasher that uses 100 iterations.
+    A subclass of PBKDF2PasswordHasher that uses 1 iteration.
+
+    This is for test purposes only. Never use anywhere else.
     """
     iterations = 1
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -155,3 +155,21 @@ AUTHENTICATION_BACKENDS = (
 
 STATIC_ROOT = '/tmp/'  # Dummy
 STATIC_URL = '/static/'
+
+from django.contrib.auth.hashers import PBKDF2PasswordHasher
+
+
+class MyPBKDF2PasswordHasher(PBKDF2PasswordHasher):
+    """
+    A subclass of PBKDF2PasswordHasher that uses 100 iterations.
+    """
+    iterations = 1
+
+
+PASSWORD_HASHERS = [
+    'test_settings.MyPBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+]


### PR DESCRIPTION
I'm finding tests currently take roughly 200s to complete. That can be reduced greatly by decreasing the PBKDF2 iterations using a custom hasher. This is only applied to test_settings.py and should never be used in production.

Standard Iterations: Ran 525 tests in 227.867s
Decrease Iterations: Ran 525 tests in 17.950s

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
