### PR TITLE
Deprecated method request.is_ajax and crypto.get_random_string requires limit

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -519,7 +519,11 @@ class DefaultAccountAdapter(object):
             cache.set(cache_key, data, app_settings.LOGIN_ATTEMPTS_TIMEOUT)
 
     def is_ajax(self, request):
-        return request.is_ajax()
+        return any([
+            request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest',
+            request.content_type == 'application/json',
+            request.META.get('HTTP_ACCEPT') == 'application/json',
+        ])
 
 
 def get_adapter(request=None):

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1351,3 +1351,39 @@ class TestCVE2019_19844(TestCase):
         data = {'email': 'mike@ıxample.org'}
         form = ResetPasswordForm(data)
         self.assertFalse(form.is_valid())
+
+
+class RequestAjaxTests(TestCase):
+
+    def _send_post_request(self, **kwargs):
+        return self.client.post(
+            reverse('account_signup'), {
+                'username': 'johndoe',
+                'email': 'john@example.org',
+                'email2': 'john@example.org',
+                'password1': 'johndoe',
+                'password2': 'johndoe'
+            },
+            **kwargs
+        )
+
+    def test_no_ajax_header(self):
+        resp = self._send_post_request()
+        self.assertEqual(302, resp.status_code)
+        self.assertRedirects(
+            resp, settings.LOGIN_REDIRECT_URL, fetch_redirect_response=False
+        )
+
+    def test_ajax_header_x_requested_with(self):
+        resp = self._send_post_request(
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(settings.LOGIN_REDIRECT_URL, resp.json()['location'])
+
+    def test_ajax_header_http_accept(self):
+        resp = self._send_post_request(
+            HTTP_ACCEPT='application/json'
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(settings.LOGIN_REDIRECT_URL, resp.json()['location'])

--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -297,7 +297,7 @@ class SocialLogin(object):
     @classmethod
     def stash_state(cls, request):
         state = cls.state_from_request(request)
-        verifier = get_random_string()
+        verifier = get_random_string(12)
         request.session['socialaccount_state'] = (state, verifier)
         return verifier
 


### PR DESCRIPTION
`request.is_ajax()` is being depreciated in 4.0. I've updated adapter.is_ajax() i check 3 different sources for possible flags as to being an ajax based request. Namely checking `HTTP_X_REQUESTED_WITH`, `HTTP_ACCEPT` and the requests content_type.

django's `crypto.get_random_string` function has had a limit parameter which has always defaulted to 12 characters in length. As of 4.0 the limit parameter will be required. As such I've updated the only occurrence that was missing a given limit to use the default as set by django.

I was not entirely sure if I should separate these 2 into separate PR's or not. I figured the get_random_string was small enough and in the same type of vein I'm dealing with in this PR.

Resolves #2538 