### PR TITLE
fix(keycloak): Use preferred_username claim for username

### DIFF
--- a/allauth/socialaccount/providers/keycloak/provider.py
+++ b/allauth/socialaccount/providers/keycloak/provider.py
@@ -27,7 +27,7 @@ class KeycloakProvider(OAuth2Provider):
     def extract_common_fields(self, data):
         return dict(
             email=data.get('email'),
-            username=data.get('username'),
+            username=data.get('preferred_username'),
             name=data.get('name'),
             user_id=data.get('user_id'),
             picture=data.get('picture'),


### PR DESCRIPTION
As per the OpenID Connect spec the standard username claim is `preferred_username`.

By default Keycloak confirms to OpenID Connect spec and provides a `preferred_username` claim, but no `username` claim in the profile scope.

ref: https://openid.net/specs/openid-connect-basic-1_0-28.html#StandardClaims