### PR TITLE
 feat(oauth callback): add callback_view to extra_context on render_authentication_error

### DIFF
--- a/allauth/socialaccount/providers/oauth/views.py
+++ b/allauth/socialaccount/providers/oauth/views.py
@@ -87,12 +87,15 @@ class OAuthCallbackView(OAuthView):
                 error = AuthError.CANCELLED
             else:
                 error = AuthError.UNKNOWN
-            extra_context = dict(oauth_client=client)
             return render_authentication_error(
                 request,
                 self.adapter.provider_id,
                 error=error,
-                extra_context=extra_context)
+                extra_context={
+                    'oauth_client': client,
+                    'callback_view': self,
+                },
+            )
         app = self.adapter.get_provider().get_app(request)
         try:
             access_token = client.get_access_token()

--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -121,7 +121,11 @@ class OAuth2CallbackView(OAuth2View):
             return render_authentication_error(
                 request,
                 self.adapter.provider_id,
-                error=error)
+                error=error,
+                extra_context={
+                    'callback_view': self,
+                },
+            )
         app = self.adapter.get_provider().get_app(self.request)
         client = self.get_client(request, app)
         try:


### PR DESCRIPTION
Allows access to more objects that may be necessary to carry out advanced redirect options.

Use case scenario: redirecting the user back to the oauth provider requires access to the adapter, view, client, and socialapp. Without the view itself you cannot access the necessary client.