### PR TITLE
chore(example settings): fix import of local_settings from incorrect path

### DIFF
--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -174,15 +174,9 @@ AUTH_PASSWORD_VALIDATORS = [
     }
 ]
 
+ALLOWED_HOSTS = ['127.0.0.1']
 
 try:
-    from local_settings import *  # noqa
+    from .local_settings import *  # noqa
 except ImportError:
     pass
-ALLOWED_HOSTS = ['5d825be1.ngrok.io','127.0.0.1']
-
-SOCIALACCOUNT_PROVIDERS = {
-    'edx': {
-        'EDX_URL': "https://draft.navoica.pl",
-    }
-}

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -174,7 +174,7 @@ AUTH_PASSWORD_VALIDATORS = [
     }
 ]
 
-ALLOWED_HOSTS = ['127.0.0.1']
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 
 try:
     from .local_settings import *  # noqa


### PR DESCRIPTION
example site attempts to import local_settings from the wrong path. local_settings.example states to copy it to local_settings.py and if someone does that in the same directory as the example file then the import needs to be `.local_settings` with the dot.

Also reset and moved ALLOWED_HOSTS above import so import can override it properly.