### PR TITLE
fix(provider): Yahoo deprecation of scope and profile url.

### DIFF
--- a/allauth/socialaccount/providers/yahoo/tests.py
+++ b/allauth/socialaccount/providers/yahoo/tests.py
@@ -10,76 +10,14 @@ class YahooTests(OAuth2TestsMixin, TestCase):
     def get_mocked_response(self):
         response_data = """
         {
-            "profile": {
-                "guid": "HZP2G4VBSQBVATWWTNO3CRKVP8",
-                "addresses": [
-                    {
-                        "city": "Timbuktu",
-                        "country": "US",
-                        "current": true,
-                        "id": 1,
-                        "postalCode": "100013",
-                        "state": "New York",
-                        "street": "",
-                        "type": "HOME"
-                    },
-                    {
-                        "city": "",
-                        "country": "US",
-                        "current": true,
-                        "id": 2,
-                        "postalCode": "",
-                        "state": "",
-                        "street": "",
-                        "type": "WORK"
-                    }
-                ],
-                "ageCategory": "A",
-                "birthYear": 1982,
-                "birthdate": "2/15",
-                "created": "2017-09-09T13:45:29Z",
-                "displayAge": 28,
-                "emails": [
-                    {
-                        "handle": "john.doe@yahoo.com",
-                        "id": 2,
-                        "primary": false,
-                        "type": "HOME"
-                    }
-                ],
-                "familyName": "Doe",
-                "gender": "M",
-                "givenName": "John",
-                "image": {
-                    "height": 192,
-                    "imageUrl": "https://s.yimg.com/wm/modern/images/default_user_profile_pic_192.png",
-                    "size": "192x192",
-                    "width": 192
-                },
-                "ims": [
-                    {
-                        "handle": "john.doe",
-                        "id": 1,
-                        "type": "YAHOO"
-                    }
-                ],
-                "intl": "us",
-                "jurisdiction": "us",
-                "lang": "en-US",
-                "memberSince": "2000-08-18T12:28:31Z",
-                "migrationSource": 1,
-                "nickname": "john.doe",
-                "notStored": true,
-                "nux": "0",
-                "profileMode": "PUBLIC",
-                "profileStatus": "ACTIVE",
-                "profileUrl": "http://profile.yahoo.com/HZP2G4VBSQBVATWWTNO3CRKVP8",
-                "timeZone": "Asia/Calcutta",
-                "isConnected": true,
-                "profileHidden": false,
-                "profilePermission": "PRIVATE",
-                "uri": "https://social.yahooapis.com/v1/user/HZP2G4VBSQBVATWWTNO3CRKVP8/profile"
-            }
+         "sub": "FSVIDUW3D7FSVIDUW3D72F2F",
+         "name": "Jane Doe",
+         "given_name": "Jane",
+         "family_name": "Doe",
+         "preferred_username": "j.doe",
+         "email": "janedoe@example.com",
+         "email_verified": true,
+         "picture": "http://example.com/janedoe/me.jpg"
         }
         """ # noqa
         return MockedResponse(200, response_data)

--- a/allauth/socialaccount/providers/yahoo/views.py
+++ b/allauth/socialaccount/providers/yahoo/views.py
@@ -15,11 +15,12 @@ class YahooOAuth2Adapter(OAuth2Adapter):
     provider_id = YahooProvider.id
     access_token_url = 'https://api.login.yahoo.com/oauth2/get_token'
     authorize_url = 'https://api.login.yahoo.com/oauth2/request_auth'
-    profile_url = 'https://social.yahooapis.com/v1/user/me/profile?format=json'
+    profile_url = 'https://api.login.yahoo.com/openid/v1/userinfo'
 
     def complete_login(self, request, app, token, **kwargs):
         headers = {'Authorization': 'Bearer {0}'.format(token.token)}
         resp = requests.get(self.profile_url, headers=headers)
+        resp.raise_for_status()
 
         extra_data = resp.json()
         return self.get_provider().sociallogin_from_response(request,


### PR DESCRIPTION
- Scope `sdps-r` is no longer in use. Now using `profile`, `email`.
- api for profile data also moved

Deprecation information: https://developer.yahoo.com/oauth/social-directory-eol/

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
 - [x] All Python code must be 100% pep8 and isort clean.
