### PR TITLE
fix(provider): stocktwits scope delimiter is comma not space

### DIFF
--- a/allauth/socialaccount/providers/stocktwits/views.py
+++ b/allauth/socialaccount/providers/stocktwits/views.py
@@ -14,6 +14,7 @@ class StocktwitsOAuth2Adapter(OAuth2Adapter):
     access_token_url = 'https://api.stocktwits.com/api/2/oauth/token'
     authorize_url = 'https://api.stocktwits.com/api/2/oauth/authorize'
     profile_url = 'https://api.stocktwits.com/api/2/streams/user/{user}.json'
+    scope_delimiter = ','
 
     def complete_login(self, request, app, token, **kwargs):
         user_id = kwargs.get('response').get('user_id')


### PR DESCRIPTION
Correcting the scope delimiter used on stocktwits

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.

