### PR TITLE
fix(signals): Remove Django 4.0 deprecation warning

### DIFF
--- a/allauth/account/signals.py
+++ b/allauth/account/signals.py
@@ -20,7 +20,8 @@ email_confirmed = Signal()
 # Provides the arguments "request", "confirmation", "signup"
 email_confirmation_sent = Signal()
 
-# Provides the arguments "request", "user", "from_email_address", "to_email_address"
+# Provides the arguments "request", "user", "from_email_address",
+# "to_email_address"
 email_changed = Signal()
 # Provides the arguments "request", "user", "email_address"
 email_added = Signal()

--- a/allauth/account/signals.py
+++ b/allauth/account/signals.py
@@ -1,23 +1,28 @@
 from django.contrib.auth.signals import user_logged_out  # noqa
 from django.dispatch import Signal
 
-
-user_logged_in = Signal(providing_args=["request", "user"])
+# Provides the arguments "request", "user"
+user_logged_in = Signal()
 
 # Typically followed by `user_logged_in` (unless, e-mail verification kicks in)
-user_signed_up = Signal(providing_args=["request", "user"])
+# Provides the arguments "request", "user"
+user_signed_up = Signal()
 
-password_set = Signal(providing_args=["request", "user"])
-password_changed = Signal(providing_args=["request", "user"])
-password_reset = Signal(providing_args=["request", "user"])
+# Provides the arguments "request", "user"
+password_set = Signal()
+# Provides the arguments "request", "user"
+password_changed = Signal()
+# Provides the arguments "request", "user"
+password_reset = Signal()
 
-email_confirmed = Signal(providing_args=["request", "email_address"])
-email_confirmation_sent = Signal(
-    providing_args=["request", "confirmation", "signup"])
+# Provides the arguments "request", "email_address"
+email_confirmed = Signal()
+# Provides the arguments "request", "confirmation", "signup"
+email_confirmation_sent = Signal()
 
-email_changed = Signal(
-    providing_args=[
-        "request", "user",
-        "from_email_address", "to_email_address"])
-email_added = Signal(providing_args=["request", "user", "email_address"])
-email_removed = Signal(providing_args=["request", "user", "email_address"])
+# Provides the arguments "request", "user", "from_email_address", "to_email_address"
+email_changed = Signal()
+# Provides the arguments "request", "user", "email_address"
+email_added = Signal()
+# Provides the arguments "request", "user", "email_address"
+email_removed = Signal()

--- a/allauth/socialaccount/signals.py
+++ b/allauth/socialaccount/signals.py
@@ -5,16 +5,20 @@ from django.dispatch import Signal
 # but before the login is actually processed. This signal is emitted
 # for social logins, signups and when connecting additional social
 # accounts to an account.
-pre_social_login = Signal(providing_args=["request", "sociallogin"])
+# Provides the arguments "request", "sociallogin"
+pre_social_login = Signal()
 
 # Sent after a user connects a social account to a their local account.
-social_account_added = Signal(providing_args=["request", "sociallogin"])
+# Provides the arguments "request", "sociallogin"
+social_account_added = Signal()
 
 # Sent after a user connects an already existing social account to a
 # their local account. The social account will have an updated token and
 # refreshed extra_data.
-social_account_updated = Signal(providing_args=["request", "sociallogin"])
+# Provides the arguments "request", "sociallogin"
+social_account_updated = Signal()
 
 # Sent after a user disconnects a social account from their local
 # account.
-social_account_removed = Signal(providing_args=["request", "socialaccount"])
+# Provides the arguments "request", "socialaccount"
+social_account_removed = Signal()


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.

With this PR the Django 4.0 deprecation warnings regarding the providing_args= argument of the signals are removed.