### PR TITLE
fix(vk): Correct work of vk provider

### DIFF
--- a/allauth/socialaccount/providers/vk/views.py
+++ b/allauth/socialaccount/providers/vk/views.py
@@ -40,21 +40,15 @@ class VKOAuth2Adapter(OAuth2Adapter):
     profile_url = 'https://api.vk.com/method/users.get'
 
     def complete_login(self, request, app, token, **kwargs):
-        uid = kwargs['response'].get('user_id')
         params = {
             'v': '5.95',
             'access_token': token.token,
             'fields': ','.join(USER_FIELDS),
         }
-        if uid:
-            params['user_ids'] = uid
         resp = requests.get(self.profile_url,
                             params=params)
         resp.raise_for_status()
         extra_data = resp.json()['response'][0]
-        email = kwargs['response'].get('email')
-        if email:
-            extra_data['email'] = email
         return self.get_provider().sociallogin_from_response(request,
                                                              extra_data)
 


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.


Hi! 
this fixes #2530 and is the updated version of #1627

currently vk oauth is not working because of 
```
'str' object has no attribute 'get'
```
at
```
uid = kwargs['response'].get('user_id')
```
because response is actually
```
{
response: 'some_token_here'
}
```

i've removed the params parsing to fix this issue