### PR TITLE
fix(provider docs): yahoo requires manually selecting permissions and https callback

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1872,6 +1872,16 @@ Yahoo
 Register your OAuth2 app below and enter the resultant client id and secret into admin
     https://developer.yahoo.com/apps/create/
 
+The Redirect URL requires secure URLs, please see the section on HTTPS about how this is handled.
+
+When you register the app within yahoo, ensure you select the following API Permissions
+
+- OpenID Connect Permissions
+ - Email
+ - Profile
+
+When copying the supplied Client ID and Client Secret, do not include the 4 starting spaces.
+
 
 Yandex
 ------


### PR DESCRIPTION
Current documentation makes no mention of having to select app permissions or the fact that the redirect url requires https.

Also when you click on the client id and secret on yahoos website, it auto highlights the line and when you copy/paste from there it adds 4 spaces to the start of the copied string which needs removing.