### PR TITLE
fix(telegram): fixed KeyError being raised during signin or signup

### DIFF
--- a/allauth/socialaccount/providers/telegram/provider.py
+++ b/allauth/socialaccount/providers/telegram/provider.py
@@ -20,8 +20,8 @@ class TelegramProvider(Provider):
     def extract_common_fields(self, data):
         return {
             "first_name": data["first_name"],
-            "last_name": data["last_name"],
-            "username": data["username"],
+            "last_name": data.get("last_name"),
+            "username": data.get("username"),
         }
 
 


### PR DESCRIPTION
telegram signin and signup was raising KeyError if user does not have a last_name or username set with telegram account

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

