### PR TITLE
fix(apple): get user data with token

### DIFF
--- a/allauth/socialaccount/providers/oauth2/views.py
+++ b/allauth/socialaccount/providers/oauth2/views.py
@@ -130,7 +130,7 @@ class OAuth2CallbackView(OAuth2View):
         client = self.get_client(self.request, app)
 
         try:
-            access_token = client.get_access_token(request.GET["code"])
+            access_token = self.adapter.get_access_token_data(request, app, client)
             token = self.adapter.parse_token(access_token)
             token.app = app
             login = self.adapter.complete_login(

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -163,6 +163,13 @@ Add the following configuration to your settings:
         }
     }
 
+Note: Sign In With Apple uses a slight variation of OAuth2, which uses a POST
+instead of a GET. Unlike a GET with SameSite=Lax, the session cookie will not
+get sent along with a POST. If you encounter 'PermissionDenied' errors during
+Apple log in, check that you don't have any 3rd party middleweare that is
+generating a new session on this cross-origin POST, as this will prevent the
+login process from being able to access the original session after the POST
+completes.
 
 Auth0
 -----


### PR DESCRIPTION
Sign in with apple added support for pulling user data from apple's temporary session via get_access_token_data method in both OAuth2 and Apple providers, but then neglected to actually use it in OAuth2 dispatch. 

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
