### PR TITLE
feat(adapter): SocialAccount model str returns value from adapter

### DIFF
--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.core.exceptions import ValidationError
 from django.urls import reverse
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 from ..account import app_settings as account_settings
@@ -206,6 +207,9 @@ class DefaultSocialAccountAdapter(object):
         else:
             app = SocialApp.objects.get_current(provider, request)
         return app
+
+    def get_socialaccount_model_str(self, obj):
+        return force_str(obj.user)
 
 
 def get_adapter(request=None):

--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -6,7 +6,6 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import PermissionDenied
 from django.db import models
 from django.utils.crypto import get_random_string
-from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 import allauth.app_settings
@@ -117,7 +116,7 @@ class SocialAccount(models.Model):
         return authenticate(account=self)
 
     def __str__(self):
-        return force_str(self.user)
+        return get_adapter().get_socialaccount_model_str(self)
 
     def get_profile_url(self):
         return self.get_provider_account().get_profile_url()


### PR DESCRIPTION
Adding method get_socialaccount_model_str to DefaultSocialAccountAdapter so that SocialAccount's __str__ method can be customized. As it currently stands it returns self.user which by default only returns the username.

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
