### PR TITLE
fix(apple): documentation error on certificate key id

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -153,7 +153,7 @@ Add the following configuration to your settings:
                 "key": "MEMAPPIDPREFIX",
 
                 # The certificate you downloaded when generating the key.
-                "certificate_key": """-----BEGIN PRIVATE KEY-----
+                "certificate": """-----BEGIN PRIVATE KEY-----
     s3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr
     3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3
     c3ts3cr3t

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -163,7 +163,7 @@ Add the following configuration to your settings:
         }
     }
 
-Sign in with Apple ID will get a user's email address (or a proxy email address by Apple if the user decline to share the real email address), and according to Apple's API no additional information besides email is shared.
+Sign in with Apple ID will get a user's email address (or a proxy email address by Apple if the user decline to share the real email address), and according to Apple's API no additional information besides email is shared. https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple
 
 Note: Sign In With Apple uses a slight variation of OAuth2, which uses a POST
 instead of a GET. Unlike a GET with SameSite=Lax, the session cookie will not

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -163,6 +163,8 @@ Add the following configuration to your settings:
         }
     }
 
+Sign in with Apple ID will get a user's email address (or a proxy email address by Apple if the user decline to share the real email address), and according to Apple's API no additional information besides email is shared.
+
 Note: Sign In With Apple uses a slight variation of OAuth2, which uses a POST
 instead of a GET. Unlike a GET with SameSite=Lax, the session cookie will not
 get sent along with a POST. If you encounter 'PermissionDenied' errors during


### PR DESCRIPTION
if use the ```certificate_key``` as the key, sign in with Apple ID would fail with error message ImproperlyConfigured Apple 'certificate' missing". From the code it seems to be ```certificate```, located at line 34 of socialaccount/apple/client.py.
