### PR TITLE
hotfix issues/2027: avoid failure with missing .to attribute

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -467,7 +467,9 @@ def url_str_to_user_pk(s):
     User = get_user_model()
     # TODO: Ugh, isn't there a cleaner way to determine whether or not
     # the PK is a str-like field?
-    if getattr(User._meta.pk, "remote_field", None):
+    if getattr(User._meta.pk, "remote_field", None) and getattr(User._meta.pk.remote_field, "to", None):
+        # TODO: "and getattr.." is just hotfix for missing .to, need review, see
+        #   https://github.com/pennersr/django-allauth/issues/2027
         pk_field = User._meta.pk.remote_field.to._meta.pk
     else:
         pk_field = User._meta.pk


### PR DESCRIPTION
The old code fails with missing .to attribute.
This can be fixed with just testing if .to is present (this PR),
however I am not sure for the values leading to the failure if the code from 'else:' branch (ie. pk_field = User._meta.pk) is ok.

Please see at least the issue
https://github.com/pennersr/django-allauth/issues/2027
where example of values leading to the crash can be found.