### PR TITLE
autocomplete password2, Update forms.py

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -380,7 +380,7 @@ class SignupForm(BaseSignupForm):
             label=_("Password"), autocomplete="new-password"
         )
         if app_settings.SIGNUP_PASSWORD_ENTER_TWICE:
-            self.fields["password2"] = PasswordField(label=_("Password (again)"))
+            self.fields["password2"] = PasswordField(label=_("Password (again)"), autocomplete="new-password")
 
         if hasattr(self, "field_order"):
             set_form_field_order(self, self.field_order)


### PR DESCRIPTION
chrome is complaining about lack of autocomplete on password2. As per https://stackoverflow.com/questions/50186223/autocomplete-new-password-and-making-them-confirm-it-via-entering-the-password-a, seems we need.

# Submitting Pull Requests

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
