### PR TITLE
Remove unused condition to show success message on successful password reset

### DIFF
--- a/allauth/templates/account/password_reset_from_key.html
+++ b/allauth/templates/account/password_reset_from_key.html
@@ -10,14 +10,10 @@
         {% url 'account_reset_password' as passwd_reset_url %}
         <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
     {% else %}
-        {% if form %}
-            <form method="POST" action="{{ action_url }}">
-                {% csrf_token %}
-                {{ form.as_p }}
-                <input type="submit" name="action" value="{% trans 'change password' %}"/>
-            </form>
-        {% else %}
-            <p>{% trans 'Your password is now changed.' %}</p>
-        {% endif %}
+        <form method="POST" action="{{ action_url }}">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <input type="submit" name="action" value="{% trans 'change password' %}"/>
+        </form>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
The reason why this is not needed is because on successful password reset, this template is not shown, 'password_reset_from_key_done.html' is used instead

# Submitting Pull Requests

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
