### PR TITLE
fix(apple): Sign in error when use PyJWT >= 2.0.0a1

### DIFF
--- a/allauth/socialaccount/providers/apple/client.py
+++ b/allauth/socialaccount/providers/apple/client.py
@@ -43,7 +43,11 @@ class AppleOAuth2Client(OAuth2Client):
         headers = {"kid": self.consumer_secret, "alg": "ES256"}
         client_secret = jwt.encode(
             payload=claims, key=app.certificate_key, algorithm="ES256", headers=headers
-        ).decode("utf-8")
+        )
+        if isinstance(client_secret, bytes):
+            # For PyJWT <= 1.7.1
+            return client_secret.decode('utf-8')
+        # For PyJWT >= 2.0.0a1
         return client_secret
 
     def get_client_id(self):


### PR DESCRIPTION
Fix Apple sign in error, when use PyJWT >= 2.0.0a1

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.
