### PR TITLE
LOGIN_ON_PASSWORD_RESET redirect bug

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -806,7 +806,7 @@ class PasswordResetFromKeyView(
         )
 
         if app_settings.LOGIN_ON_PASSWORD_RESET:
-            return perform_login(
+            perform_login(
                 self.request,
                 self.reset_user,
                 email_verification=app_settings.EMAIL_VERIFICATION,


### PR DESCRIPTION
Hi, I have an error.

When LOGIN_ON_PASSWORD_RESET is set to true, the view method returns perform_login which ignores success_url redirect.