### PR TITLE
fix (apple): id_token missing by overriding access_token_data handling

### DIFF
--- a/allauth/socialaccount/providers/apple/views.py
+++ b/allauth/socialaccount/providers/apple/views.py
@@ -125,10 +125,15 @@ class AppleOAuth2Adapter(OAuth2Adapter):
         code = get_request_param(request, "code")
         access_token_data = client.get_access_token(code)
 
+        id_token = access_token_data.get("id_token", None)
+        # In case of missing id_token in access_token_data
+        if id_token is None:
+            id_token = request.apple_login_session.get("id_token")
+
         return {
             **access_token_data,
             **self.get_user_scope_data(request),
-            "id_token": request.apple_login_session.get("id_token"),
+            "id_token": id_token,
         }
 
 


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers.rst`.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.

##

This code handles [this problem](https://github.com/pennersr/django-allauth/pull/2424#discussion_r465940292) in issue #2424 .

In case of first sign in in app, there are no `apple_login_session["id_token"]`. Existing code is overriding `"id_token"` value with `None`. It makes `OAuth2Error("Invalid id_token")`.

However, in `access_token_data`, there is `id_token` value that almost always comes from apple api server. So this code make up `id_token` value by one valid value of two variable dict.

Base of this code is @bcarradini.