### PR TITLE
Improve the performance of ORM calls

### DIFF
--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -131,15 +131,8 @@ class DefaultSocialAccountAdapter(object):
                 raise ValidationError(_("Your account has no password set" " up."))
             # No email address, no password reset
             if app_settings.EMAIL_VERIFICATION == EmailVerificationMethod.MANDATORY:
-                if (
-                    EmailAddress.objects.filter(
-                        user=account.user, verified=True
-                    ).count()
-                    == 0
-                ):
-                    raise ValidationError(
-                        _("Your account has no verified" " e-mail address.")
-                    )
+                if not EmailAddress.objects.filter(user=account.user, verified=True).exists():
+                    raise ValidationError(_("Your account has no verified e-mail address."))
 
     def is_auto_signup_allowed(self, request, sociallogin):
         # If email is specified, check for duplicate and if so, no auto signup.

--- a/allauth/socialaccount/providers/openid/utils.py
+++ b/allauth/socialaccount/providers/openid/utils.py
@@ -94,7 +94,7 @@ class DBOpenIDStore(OIDStore):
 
         stored_assocs.order_by("-issued")
 
-        if stored_assocs.count() == 0:
+        if not stored_assocs.exists():
             return None
 
         return_val = None


### PR DESCRIPTION
using `if not queryset.exists()` is more efficient than checking `if queryset.count() == 0` [read more](https://django.doctor/advice/C9002)

I found this problem during auditing your codebase. [Read the full report](https://django.doctor/pennersr/django-allauth)