### PR TITLE
feat(accounts) Password Reset Verified and/or Active Emails Only

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -343,6 +343,10 @@ class AppSettings(object):
     def PASSWORD_RESET_VERIFIED_ONLY(self):
         return  self._setting('PASSWORD_RESET_VERIFIED_ONLY', True)
 
+    @property
+    def PASSWORD_RESET_ACTIVE_ONLY(self):
+        return  self._setting('PASSWORD_RESET_ACTIVE_ONLY', True)
+
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html
 import sys  # noqa

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -339,6 +339,9 @@ class AppSettings(object):
                 ret = []
         return ret
 
+    @property
+    def PASSWORD_RESET_VERIFIED_ONLY(self):
+        return  self._setting('PASSWORD_RESET_VERIFIED_ONLY', True)
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -19,7 +19,8 @@ from . import app_settings
 from .adapter import get_adapter
 from .app_settings import AuthenticationMethod
 from .models import EmailAddress
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 from .utils import (
     filter_users_by_email,
     get_user_model,

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -19,6 +19,7 @@ from . import app_settings
 from .adapter import get_adapter
 from .app_settings import AuthenticationMethod
 from .models import EmailAddress
+from django.contrib.auth.models import User
 from .utils import (
     filter_users_by_email,
     get_user_model,
@@ -526,6 +527,11 @@ class ResetPasswordForm(forms.Form):
         unverified_email_exists = tuple(EmailAddress.objects.filter(email=email, verified=False).values_list('email', flat=True))
         if email in unverified_email_exists and app_settings.PASSWORD_RESET_VERIFIED_ONLY is True:
             raise forms.ValidationError("Only verified e-mails can reset passwords")
+        inactive_users = User.objects.filter(is_active="False")
+        for x in inactive_users:
+            emails = EmailAddress.objects.filter(user=x).values_list('user', flat=True)
+            for y in emails:
+                raise forms.ValidationError("Only active users can reset passwords")
         if not self.users:
             raise forms.ValidationError(
                 _("The e-mail address is not assigned" " to any user account")

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -523,6 +523,9 @@ class ResetPasswordForm(forms.Form):
         email = self.cleaned_data["email"]
         email = get_adapter().clean_email(email)
         self.users = filter_users_by_email(email, is_active=True)
+        unverified_email_exists = tuple(EmailAddress.objects.filter(email=email, verified=False).values_list('email', flat=True))
+        if email in unverified_email_exists and app_settings.PASSWORD_RESET_VERIFIED_ONLY is True:
+            raise forms.ValidationError("Only verified e-mails can reset passwords")
         if not self.users:
             raise forms.ValidationError(
                 _("The e-mail address is not assigned" " to any user account")

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -526,12 +526,13 @@ class ResetPasswordForm(forms.Form):
         self.users = filter_users_by_email(email, is_active=True)
         unverified_email_exists = tuple(EmailAddress.objects.filter(email=email, verified=False).values_list('email', flat=True))
         if email in unverified_email_exists and app_settings.PASSWORD_RESET_VERIFIED_ONLY is True:
-            raise forms.ValidationError("Only verified e-mails can reset passwords")
+            raise forms.ValidationError("If that email address is in our database, we will send you an email to reset your password.")
         inactive_users = User.objects.filter(is_active="False")
         for x in inactive_users:
             emails = EmailAddress.objects.filter(user=x).values_list('user', flat=True)
             for y in emails:
-                raise forms.ValidationError("Only active users can reset passwords")
+                if app_settings.PASSWORD_RESET_VERIFIED_ONLY is True:
+                    raise forms.ValidationError("If that email address is in our database, we will send you an email to reset your password.")
         if not self.users:
             raise forms.ValidationError(
                 _("The e-mail address is not assigned" " to any user account")


### PR DESCRIPTION
Attempts to solve #2360

Related: #2103 and #2627 and #1267

After extensive digging I found #1317 which was hard to find since it was closed. You can use the same methodology for preventing inactive accounts from receiving password reset emails. 

These raised form validation errors should also follow OWASP guidelines for password resets:

https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html