### PR TITLE
feat(account) Prevent Privacy Leaking

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -458,7 +458,7 @@ class AddEmailForm(UserForm):
                 "This e-mail address is already associated" " with this account."
             ),
             "different_account": _(
-                "This e-mail address is already associated" " with another account."
+                "A link to activate your account has been emailed to the address provided."
             ),
             "max_email_addresses": _("You cannot add more than %d e-mail addresses."),
         }

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -19,7 +19,8 @@ from . import app_settings
 from .adapter import get_adapter
 from .app_settings import AuthenticationMethod
 from .models import EmailAddress
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 from .utils import (
     filter_users_by_email,
     get_user_model,

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -455,7 +455,7 @@ class AddEmailForm(UserForm):
         value = get_adapter().clean_email(value)
         errors = {
             "this_account": _(
-                "This e-mail address is already associated" " with this account."
+                "A link to activate your account has been emailed to the address provided."
             ),
             "different_account": _(
                 "A link to activate your account has been emailed to the address provided."

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -536,7 +536,7 @@ class ResetPasswordForm(forms.Form):
         self.users = filter_users_by_email(email, is_active=True)
         if not self.users:
             raise forms.ValidationError(
-                _("The e-mail address is not assigned" " to any user account")
+                _("If that email address is in our database, we will send you an email to reset your password")
             )
         return self.cleaned_data["email"]
 

--- a/allauth/templates/account/password_reset_done.html
+++ b/allauth/templates/account/password_reset_done.html
@@ -12,5 +12,5 @@
     {% include "account/snippets/already_logged_in.html" %}
     {% endif %}
     
-    <p>{% blocktrans %}We have sent you an e-mail. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+    <p>{% blocktrans %}If that email address is in our database, we will send you an email to reset your password{% endblocktrans %}</p>
 {% endblock %}


### PR DESCRIPTION
Attempts to solve #1307

Changed multiple error messages for password reset, signup, and adding email pages to make it harder for a user to see proof that another user's credentials exist. 

Follows OWASP recommendations:

https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html