### PR TITLE
fix(accounts) Control Removal Of Emails

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -340,8 +340,20 @@ class AppSettings(object):
         return ret
 
     @property
-    def DELETE_PRIMARY_VERIFIED_EMAIL(self):
-        return  self._setting('DELETE_PRIMARY_VERIFIED_EMAIL', True)
+    def DELETE_UNVERIFIED_PRIMARY_EMAIL(self):
+        return  self._setting('DELETE_UNVERIFIED_PRIMARY_EMAIL', True)
+
+    @property
+    def DELETE_UNVERIFIED_UNPRIMARY_EMAIL(self):
+        return  self._setting('DELETE_UNVERIFIED_UNPRIMARY_EMAIL', True)
+
+    @property
+    def DELETE_VERIFIED_PRIMARY_EMAIL(self):
+        return  self._setting('DELETE_VERIFIED_PRIMARY_EMAIL', True)
+
+    @property
+    def DELETE_VERIFIED_UNPRIMARY_EMAIL(self):
+        return  self._setting('DELETE_VERIFIED_UNPRIMARY_EMAIL', True)
 
 
 # Ugly? Guido recommends this himself ...

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -339,6 +339,10 @@ class AppSettings(object):
                 ret = []
         return ret
 
+    @property
+    def DELETE_PRIMARY_VERIFIED_EMAIL(self):
+        return  self._setting('DELETE_PRIMARY_VERIFIED_EMAIL', True)
+
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -521,7 +521,7 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 
     def _action_primary(self, request, *args, **kwargs):
         email = request.POST["email"]
-        if email in EmailAddress.objects.filter(user=request.user,email=email, verified=False).values_list('email', flat=True):
+        if email in EmailAddress.objects.filter(user=request.user,email=email, primary=False, verified=False).values_list('email', flat=True):
             messages.error(self.request, "E-mail needs to be verified before making it primary")
             return HttpResponseRedirect(self.request.path_info)
         try:

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -521,6 +521,9 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 
     def _action_primary(self, request, *args, **kwargs):
         email = request.POST["email"]
+        if email in EmailAddress.objects.filter(user=request.user,email=email, verified=False).values_list('email', flat=True):
+            messages.error(self.request, "E-mail needs to be verified before making it primary")
+            return HttpResponseRedirect(self.request.path_info)
         try:
             email_address = EmailAddress.objects.get_for_user(
                 user=request.user, email=email

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -493,6 +493,8 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
             elif email in unverified_primary_email:
                 email_address.delete()
             else:
+                if EmailAddress.objects.filter(user=request.user).count() == 1 and app_settings.EMAIL_REQUIRED is False:
+                    User.objects.filter(username=request.user).update(email="")
                 email_address.delete()
                 signals.email_removed.send(
                     sender=request.user.__class__,

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -482,6 +482,9 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
         email = request.POST["email"]
         try:
             email_address = EmailAddress.objects.get(user=request.user, email=email)
+            if EmailAddress.objects.filter(user=request.user, email=email, primary=True, verified=True) and app_settings.DELETE_PRIMARY_VERIFIED_EMAIL is True:
+                User.objects.filter(username=request.user).update(email="")
+                email_address.delete()
             unverified_primary_email = EmailAddress.objects.filter(user=request.user,email=email, primary=True, verified=False).values_list('email', flat=True)
             if email_address.primary and email not in unverified_primary_email:
                 get_adapter(request).add_message(

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -39,6 +39,9 @@ from .utils import (
     url_str_to_user_pk,
 )
 
+from django.contrib.auth import get_user_model
+User = get_user_model()
+
 
 INTERNAL_RESET_URL_KEY = "set-password"
 INTERNAL_RESET_SESSION_KEY = "_password_reset_key"


### PR DESCRIPTION
Attempts to solve #290 and #1958

I made it so that users could control whether they want to delete emails based on if they are verified, primary, or any combination of those. 