### PR TITLE
feat(accounts) Encrypt Email Address

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -339,6 +339,9 @@ class AppSettings(object):
                 ret = []
         return ret
 
+    @property
+    def EMAIL_ENCRYPTED(self):
+        return  self._setting('EMAIL_ENCRYPTED', True)
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -14,18 +14,22 @@ from .adapter import get_adapter
 from .managers import EmailAddressManager, EmailConfirmationManager
 from .utils import user_email
 
+from django.conf import settings
+if settings.PGCRYPTO_KEY:
+   from pgcrypto import fields
+
 
 class EmailAddress(models.Model):
+
+    if app_settings.EMAIL_ENCRYPTED is True:
+        email = fields.EmailPGPSymmetricKeyField(unique=app_settings.UNIQUE_EMAIL,max_length=app_settings.EMAIL_MAX_LENGTH,verbose_name=_('e-mail address'))
+    else:
+        email = models.EmailField(unique=app_settings.UNIQUE_EMAIL,max_length=app_settings.EMAIL_MAX_LENGTH,verbose_name=_('e-mail address'))
 
     user = models.ForeignKey(
         allauth_app_settings.USER_MODEL,
         verbose_name=_("user"),
         on_delete=models.CASCADE,
-    )
-    email = models.EmailField(
-        unique=app_settings.UNIQUE_EMAIL,
-        max_length=app_settings.EMAIL_MAX_LENGTH,
-        verbose_name=_("e-mail address"),
     )
     verified = models.BooleanField(verbose_name=_("verified"), default=False)
     primary = models.BooleanField(verbose_name=_("primary"), default=False)


### PR DESCRIPTION
https://gdpr.eu/email-encryption/

This depends on the pgcrypto extension to be installed in Postgres and it only works if Postgres is the database.

```
psql -d database_name -c 'CREATE EXTENSION pgcrypto'
CREATE EXTENSION pgcrypto;
```

It uses a third party library to do the encryption/decryption with a symmetric key users set in settings.py:

https://github.com/incuna/django-pgcrypto-fields

Settings.py:

```
PGCRYPTO_KEY = 'KEY_VALUE'
INSTALLED_APPS = [ 'pgcrypto',]
```

If users wanted to encrypt the username, Allauth has a user = models.ForeignKey in models.py so you would probably need to encrypt usernames using the custom user model. What this PR does is it encrypts the account_emailaddress email column so that whenever Allauth updates in the future, the django developer does not need to override Allauth each time just to add encryption to the email address inside the account_emailaddress table. 

Warning - a user would need to do a data migration if they decide to switch from decrypted email to encrypted email or vice versa. It is better in the beginning of a new project to choose whether you want the email to be encrypted/decrypted and never change it later on.

https://docs.djangoproject.com/en/3.2/howto/writing-migrations/