### PR TITLE
fix(accounts) 404 /accounts/email/ setting

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -316,6 +316,10 @@ class AppSettings(object):
         return self._setting("PRESERVE_USERNAME_CASING", True)
 
     @property
+    def EMAIL_PAGE_404(self):
+        return self._setting("EMAIL_PAGE_404", False)
+    
+    @property
     def USERNAME_VALIDATORS(self):
         from django.core.exceptions import ImproperlyConfigured
 

--- a/allauth/account/urls.py
+++ b/allauth/account/urls.py
@@ -2,6 +2,8 @@ from django.urls import path, re_path
 
 from . import views
 
+from django.conf import settings
+from django.views.defaults import page_not_found
 
 urlpatterns = [
     path("signup/", views.signup, name="account_signup"),
@@ -15,7 +17,6 @@ urlpatterns = [
     path("password/set/", views.password_set, name="account_set_password"),
     path("inactive/", views.account_inactive, name="account_inactive"),
     # E-mail
-    path("email/", views.email, name="account_email"),
     path(
         "confirm-email/",
         views.email_verification_sent,
@@ -44,3 +45,12 @@ urlpatterns = [
         name="account_reset_password_from_key_done",
     ),
 ]
+
+if settings.ACCOUNT_MAX_EMAIL_ADDRESSES == 1:
+    urlpatterns += [
+        path('email/', page_not_found, {'exception': Exception()}, name="account_email",),
+    ]
+else:
+    urlpatterns += [
+        path("email/", views.email, name="account_email"),
+    ]

--- a/allauth/account/urls.py
+++ b/allauth/account/urls.py
@@ -46,7 +46,7 @@ urlpatterns = [
     ),
 ]
 
-if settings.ACCOUNT_MAX_EMAIL_ADDRESSES == 1:
+if settings.ACCOUNT_EMAIL_PAGE_404 is True:
     urlpatterns += [
         path('email/', page_not_found, {'exception': Exception()}, name="account_email",),
     ]

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -394,7 +394,8 @@ class ConfirmEmailView(TemplateResponseMixin, LogoutFunctionalityMixin, View):
         ctx = kwargs
         ctx["confirmation"] = self.object
         site = get_current_site(self.request)
-        ctx.update({"site": site})
+        max_email_addresses = app_settings.MAX_EMAIL_ADDRESSES
+        ctx.update({"site": site, "max_email_addresses":max_email_addresses})
         return ctx
 
     def get_redirect_url(self):

--- a/allauth/templates/account/email_confirm.html
+++ b/allauth/templates/account/email_confirm.html
@@ -24,7 +24,11 @@
 
 {% url 'account_email' as email_url %}
 
+{% if max_email_addresses == 1 %}
+<p>{% blocktrans %}This e-mail confirmation link expired or is invalid.{% endblocktrans %}</p>
+{% else %}
 <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+{% endif %}
 
 {% endif %}
 


### PR DESCRIPTION
There is no reason to have /accounts/email/ accessible when ACCOUNT_MAX_EMAIL_ADDRESSES == 1. If ACCOUNT_MAX_EMAIL_ADDRESSES > 1, then provide access to /accounts/email/.

Update: Changed this to add a new setting that allows the user to either enable or disable this without worrying about ACCOUNT_MAX_EMAIL_ADDRESSES.