### PR TITLE
feat(accounts) - Delete account

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -318,6 +318,10 @@ class AppSettings(object):
     @property
     def DELETE_REDIRECT_URL(self):
         return  self._setting('DELETE_REDIRECT_URL', '/accounts/login/')
+    
+    @property
+    def DELETE(self):
+        return  self._setting('DELETE', False)
 
     @property
     def USERNAME_VALIDATORS(self):

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -316,6 +316,10 @@ class AppSettings(object):
         return self._setting("PRESERVE_USERNAME_CASING", True)
 
     @property
+    def DELETE_REDIRECT_URL(self):
+        return  self._setting('DELETE_REDIRECT_URL', '/accounts/login/')
+
+    @property
     def USERNAME_VALIDATORS(self):
         from django.core.exceptions import ImproperlyConfigured
 

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -32,6 +32,11 @@ from .utils import (
 )
 
 
+class DeleteAccount(forms.Form):
+    delete_checkbox = forms.BooleanField(label='Are you sure you want to delete your account?', required=True)
+    def __init__(self, *args, **kwargs):
+        super(DeleteAccount, self).__init__(*args, **kwargs)
+
 class EmailAwarePasswordResetTokenGenerator(PasswordResetTokenGenerator):
     def _make_hash_value(self, user, timestamp):
         ret = super(EmailAwarePasswordResetTokenGenerator, self)._make_hash_value(

--- a/allauth/account/urls.py
+++ b/allauth/account/urls.py
@@ -43,4 +43,9 @@ urlpatterns = [
         views.password_reset_from_key_done,
         name="account_reset_password_from_key_done",
     ),
+    path(
+        "delete/",
+        views.delete_account,
+        name="account_delete",
+    ),
 ]

--- a/allauth/account/urls.py
+++ b/allauth/account/urls.py
@@ -2,6 +2,9 @@ from django.urls import path, re_path
 
 from . import views
 
+from django.conf import settings
+from django.views.defaults import page_not_found
+
 
 urlpatterns = [
     path("signup/", views.signup, name="account_signup"),
@@ -43,9 +46,13 @@ urlpatterns = [
         views.password_reset_from_key_done,
         name="account_reset_password_from_key_done",
     ),
-    path(
-        "delete/",
-        views.delete_account,
-        name="account_delete",
-    ),
 ]
+
+if settings.ACCOUNT_DELETE is False:
+    urlpatterns += [
+        path('delete/', page_not_found, {'exception': Exception()}, name="account_delete",),
+    ]
+else:
+    urlpatterns += [
+        path("delete/", views.delete_account, name="account_delete"),
+    ]

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -55,26 +55,27 @@ from django.shortcuts import render
 from django.contrib.auth.models import User
 
 def delete_account(request):
-    if request.user.is_anonymous:
-        return HttpResponseRedirect(app_settings.DELETE_REDIRECT_URL)
-    if request.user.is_authenticated:
-        if request.method == 'POST':
-            form = DeleteAccount(request.POST)
+    if app_settings.DELETE is True:
+        if request.user.is_anonymous:
+            return HttpResponseRedirect(app_settings.DELETE_REDIRECT_URL)
+        if request.user.is_authenticated:
+            if request.method == 'POST':
+                form = DeleteAccount(request.POST)
 
-            if form.is_valid():
-                if request.POST["delete_checkbox"]:
-                    account = User.objects.get(username=request.user)
-                    if account is not None:
-                        account.delete()
-                        logout(request)
-                        messages.info(request, "Your account has been deleted.")
-                        return HttpResponseRedirect(app_settings.DELETE_REDIRECT_URL)
-                    else:
-                        messages.error(request, "There was an error.")
-        else:
-            form = DeleteAccount()
-        context = {'form': form}
-        return render(request, 'account/delete.html', context)
+                if form.is_valid():
+                    if request.POST["delete_checkbox"]:
+                        account = User.objects.get(username=request.user)
+                        if account is not None:
+                            account.delete()
+                            logout(request)
+                            messages.info(request, "Your account has been deleted.")
+                            return HttpResponseRedirect(app_settings.DELETE_REDIRECT_URL)
+                        else:
+                            messages.error(request, "There was an error.")
+            else:
+                form = DeleteAccount()
+            context = {'form': form}
+            return render(request, 'account/delete.html', context)
 
 def _ajax_response(request, response, form=None, data=None):
     adapter = get_adapter(request)

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -52,7 +52,8 @@ sensitive_post_parameters_m = method_decorator(
 
 from django.contrib.auth import logout
 from django.shortcuts import render
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 def delete_account(request):
     if app_settings.DELETE is True:

--- a/allauth/templates/account/delete.html
+++ b/allauth/templates/account/delete.html
@@ -1,0 +1,16 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Delete Account" %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "Delete Account" %}</h1>
+
+<form method="post" action="{% url 'account_delete' %}">
+  {% csrf_token %}
+{{ form.delete_checkbox.label }} {{ form.delete_checkbox }}
+  <button type="submit">{% trans 'Delete Account' %}</button>
+</form>
+
+{% endblock %}


### PR DESCRIPTION
Attempts to solve #2726, #344

Not sure how to do the adapter part where the django developer could override the forms and views for this. But otherwise, this is a minimal viable product & built in allauth way to allow users to delete their account. This code does delete the user and the developer could specify where to redirect after the account deletion with ACCOUNT_DELETE_REDIRECT_URL and whether they want to enable/disable account deletion with ACCOUNT_DELETE. 

The django developer should specify in their models with on_delete whether they want to delete things like media files from each account. The django developer should be able to customize the form and views from this new code so that they could do things like surveys or store feedback in the database to satisfy project specific needs. Otherwise something default like a checkbox for consent should be fine. 