### PR TITLE
feat(accounts) - Deactivate account

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -339,6 +339,13 @@ class AppSettings(object):
                 ret = []
         return ret
 
+    @property
+    def DEACTIVATE_REDIRECT_URL(self):
+        return  self._setting('DEACTIVATE_REDIRECT_URL', '/accounts/login/')
+
+    @property
+    def DEACTIVATE(self):
+        return  self._setting('DEACTIVATE', False)
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -48,6 +48,10 @@ class EmailAwarePasswordResetTokenGenerator(PasswordResetTokenGenerator):
 
 default_token_generator = EmailAwarePasswordResetTokenGenerator()
 
+class DeactivateAccount(forms.Form):
+    deactivate_checkbox = forms.BooleanField(label='Are you sure you want to deactivate your account?', required=True)
+    def __init__(self, *args, **kwargs):
+        super(DeactivateAccount, self).__init__(*args, **kwargs)
 
 class PasswordVerificationMixin(object):
     def clean(self):

--- a/allauth/account/urls.py
+++ b/allauth/account/urls.py
@@ -2,6 +2,8 @@ from django.urls import path, re_path
 
 from . import views
 
+from django.conf import settings
+from django.views.defaults import page_not_found
 
 urlpatterns = [
     path("signup/", views.signup, name="account_signup"),
@@ -44,3 +46,12 @@ urlpatterns = [
         name="account_reset_password_from_key_done",
     ),
 ]
+
+if settings.ACCOUNT_DEACTIVATE is False:
+    urlpatterns += [
+        path('deactivate/', page_not_found, {'exception': Exception()}, name="account_deactivate",),
+    ]
+else:
+    urlpatterns += [
+        path("deactivate/", views.deactivate_account, name="account_deactivate"),
+    ]

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -26,6 +26,7 @@ from .forms import (
     SetPasswordForm,
     SignupForm,
     UserTokenForm,
+    DeactivateAccount,
 )
 from .models import EmailAddress, EmailConfirmation, EmailConfirmationHMAC
 from .utils import (
@@ -47,6 +48,34 @@ INTERNAL_RESET_SESSION_KEY = "_password_reset_key"
 sensitive_post_parameters_m = method_decorator(
     sensitive_post_parameters("oldpassword", "password", "password1", "password2")
 )
+
+from django.contrib.auth import logout
+from django.contrib.auth.models import User
+from django.shortcuts import render
+
+def deactivate_account(request):
+    if app_settings.DEACTIVATE is True:
+        if request.user.is_anonymous:
+            return HttpResponseRedirect(app_settings.DEACTIVATE_REDIRECT_URL)
+        if request.user.is_authenticated:
+            if request.method == 'POST':
+                form = DeactivateAccount(request.POST)
+
+                if form.is_valid():
+                    if request.POST["deactivate_checkbox"]:
+                        account = User.objects.get(username=request.user)
+                        if account is not None:
+                            account.is_active = False
+                            account.save()
+                            logout(request)
+                            messages.info(request, "Your account has been deactivated.")
+                            return HttpResponseRedirect(app_settings.DEACTIVATE_REDIRECT_URL)
+                        else:
+                            messages.error(request, "There was an error.")
+            else:
+                form = DeactivateAccount()
+            context = {'form': form}
+            return render(request, 'account/deactivate.html', context)
 
 
 def _ajax_response(request, response, form=None, data=None):

--- a/allauth/templates/account/deactivate.html
+++ b/allauth/templates/account/deactivate.html
@@ -1,0 +1,17 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Deactivate Account" %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "Deactivate Account" %}</h1>
+
+<form method="post" action="{% url 'account_deactivate' %}">
+  {% csrf_token %}
+{{ form.deactivate_checkbox.label }} {{ form.deactivate_checkbox }}
+  <button type="submit">{% trans 'Deactivate Account' %}</button>
+</form>
+
+
+{% endblock %}


### PR DESCRIPTION
There does not seem to be an already created issue for this. But lots of apps nowadays allow users to deactivate their accounts themselves and then possibly come back later on. This will allow users to deactivate their accounts but currently this code does not offer a way to allow users to come back / reactivate afterwards unless they contact the website to request it. There should probably be a way to differentiate users who choose to deactivate themselves versus bad acting deactivated users who deserve to be deactivated permanently. 

Not sure how to do the adapter part where the django developer could override the forms and views for this. But otherwise, this is a minimal viable product & built in allauth way to allow users to deactivate their account.