### PR TITLE
Add admin action to mark email addresses as verified

### DIFF
--- a/allauth/account/admin.py
+++ b/allauth/account/admin.py
@@ -10,10 +10,16 @@ class EmailAddressAdmin(admin.ModelAdmin):
     list_filter = ("primary", "verified")
     search_fields = []
     raw_id_fields = ("user",)
+    actions = ["make_verified"]
 
     def get_search_fields(self, request):
         base_fields = get_adapter(request).get_user_search_fields()
         return ["email"] + list(map(lambda a: "user__" + a, base_fields))
+
+    def make_verified(self, request, queryset):
+        queryset.update(verified=True)
+
+    make_verified.short_description = "Mark selected email addresses as verified"
 
 
 class EmailConfirmationAdmin(admin.ModelAdmin):


### PR DESCRIPTION
this enables admins to use the Django admin panel to select some email addresses from the table and override their `verified` field to True