### PR TITLE
feat(accounts) - Primary Email Change Enable/Disable Setting

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -316,6 +316,10 @@ class AppSettings(object):
         return self._setting("PRESERVE_USERNAME_CASING", True)
 
     @property
+    def PRIMARY_EMAIL_CHANGE(self):
+        return self._setting("PRIMARY_EMAIL_CHANGE", True)
+
+    @property
     def USERNAME_VALIDATORS(self):
         from django.core.exceptions import ImproperlyConfigured
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -509,6 +509,11 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 
     def _action_primary(self, request, *args, **kwargs):
         email = request.POST["email"]
+        primary_email_address = EmailAddress.objects.get(user=request.user,primary=True)
+        if app_settings.PRIMARY_EMAIL_CHANGE is False:
+            if email not in primary_email_address:
+                messages.error(self.request, "You cannot make this email a primary email address")
+                return HttpResponseRedirect(self.request.path_info)
         try:
             email_address = EmailAddress.objects.get_for_user(
                 user=request.user, email=email


### PR DESCRIPTION
Partially attempts to solve #2620. This PR will allow django developers to use a setting to allow/deny users to change their primary email address. If True, allow users to change their primary email address to another email address. If False, prevent users from changing their primary email address at all. 

This PR does not include what #2620 suggests as a solution. That feature could always come later on in a future PR. 