### PR TITLE
fix(django): default_app_config is deprecated in django 3.2

### DIFF
--- a/allauth/account/__init__.py
+++ b/allauth/account/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = "allauth.account.apps.AccountConfig"
+import django
+
+if django.VERSION < (3, 2):  # pragma: no cover
+    default_app_config = "allauth.account.apps.AccountConfig"

--- a/allauth/socialaccount/__init__.py
+++ b/allauth/socialaccount/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = "allauth.socialaccount.apps.SocialAccountConfig"
+import django
+
+if django.VERSION < (3, 2):  # pragma: no cover
+    default_app_config = "allauth.socialaccount.apps.SocialAccountConfig"

--- a/example/example/demo/__init__.py
+++ b/example/example/demo/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'example.demo.apps.DemoConfig'
+import django
+
+if django.VERSION < (3, 2):  # pragma: no cover
+    default_app_config = 'example.demo.apps.DemoConfig'


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery
Fix RemovedInDjango41Warning

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.
