### PR TITLE
Slack provider: Works with Bearer token inside HTTP headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Fred Palmer
 Fábio Santos
 George Whewell
 Griffith Rees
+Guignard Javier
 Guilhem Saurel
 Guillaume Vincent
 Guoyu Hao

--- a/allauth/socialaccount/providers/slack/views.py
+++ b/allauth/socialaccount/providers/slack/views.py
@@ -23,7 +23,8 @@ class SlackOAuth2Adapter(OAuth2Adapter):
 
     def get_data(self, token):
         # Verify the user first
-        resp = requests.get(self.identity_url, params={"token": token})
+        hed = {'Authorization': 'Bearer ' + token}
+        resp = requests.get(self.identity_url, headers=hed)
         resp = resp.json()
 
         if not resp.get("ok"):


### PR DESCRIPTION
# Slack provider: Works with Bearer token inside HTTP headers instead of params

Deprecating usage of token as a query string parameter in Web API requests: Apps created after February 24, 2021 may no longer send tokens as query parameters and must instead use an HTTP authorization header or send the token in an HTTP POST body.
See slack post [here](https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps)

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
