### PR TITLE
Set default_auto_field to 'AutoField'

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -16,6 +16,11 @@ Backwards incompatible changes
   been renamed to ``certificate_key``. This is done to prevent the key from being displayed
   without being masked in Django debug pages.
 
+0.44.0
+******
+
+- Better compatibility with Django 3.2
+
 
 0.43.0 (2020-10-15)
 *******************

--- a/allauth/account/apps.py
+++ b/allauth/account/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class AccountConfig(AppConfig):
     name = "allauth.account"
     verbose_name = _("Accounts")
+    default_auto_field = 'django.db.models.AutoField'

--- a/allauth/socialaccount/apps.py
+++ b/allauth/socialaccount/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class SocialAccountConfig(AppConfig):
     name = "allauth.socialaccount"
     verbose_name = _("Social Accounts")
+    default_auto_field = 'django.db.models.AutoField'

--- a/example/example/demo/apps.py
+++ b/example/example/demo/apps.py
@@ -37,6 +37,7 @@ def setup_dummy_social_apps(sender, **kwargs):
 class DemoConfig(AppConfig):
     name = 'example.demo'
     verbose_name = _('Demo')
+    default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
         post_migrate.connect(setup_dummy_social_apps, sender=self)


### PR DESCRIPTION
Django 3.2 introduces DEFAULT_AUTO_FIELD . If you set this to something other than `'django.db.models.AutoField'`, migrations will need to be generated for allauth's models. This pull request sets `default_auto_field` just for these apps so that no migrations need to be generated.

It also hides warnings on Django 3.2.

Fixes: https://github.com/pennersr/django-allauth/issues/2826
