### PR TITLE
fix(socialaccount): Fix STORE_TOKEN with settings-based credentials

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -142,6 +142,7 @@ Serafeim Papastefanos
 Sergey Silaev
 Shane Rice
 Stuart Ross
+Sungbin Jo
 Terry Jones
 Tiago Loureiro
 Tim Gates

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,13 @@
+0.46.0 (unreleased)
+*******************
+
+Note worthy changes
+-------------------
+
+- Fixed a bug where tokens weren't saved when credentials were provided with the
+  ``SOCIALACCOUNT_PROVIDERS`` configuration.
+
+
 0.45.0 (2021-07-11)
 *******************
 


### PR DESCRIPTION
The app instance must be stored in the database for the tokens to be saved.

If `STORE_TOKENS` is `True`, we can implicitly assume that the user wants the app instance to be stored. In that case, we save it the first time and return the saved app instance.

Specifying specific sites with settings-based credentials without storing the app instance is infeasible due to Django requiring models to be saved before setting many-to-many relationships. Once a method to specify sites is introduced, the method to get the app instance must be switched to get_current method that also considers sites as well. In the meantime, just searching with the provider preserves the status quo.

Fixes #2423, fixes #2467

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

