### PR TITLE
fix(eventbrite): removed "primary" attribute from provider settings

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,7 @@
+- Fixed Eventbrite provider methods ``extract_common_fields()`` and
+  ``extract_email_addresses`` that tried to get a non-existent attribute `primary`
+
+
 0.44.0 (2020-11-25)
 *******************
 

--- a/allauth/socialaccount/providers/eventbrite/provider.py
+++ b/allauth/socialaccount/providers/eventbrite/provider.py
@@ -34,7 +34,7 @@ class EventbriteProvider(OAuth2Provider):
         email = None
         for curr_email in data.get("emails", []):
             email = email or curr_email.get("email")
-            if curr_email.get("verified", False) and curr_email.get("primary", False):
+            if curr_email.get("verified", False):
                 email = curr_email.get("email")
 
         return dict(
@@ -53,7 +53,6 @@ class EventbriteProvider(OAuth2Provider):
                 EmailAddress(
                     email=email.get("email"),
                     verified=email.get("verfified"),
-                    primary=email.get("primary"),
                 )
             )
 

--- a/allauth/socialaccount/providers/eventbrite/tests.py
+++ b/allauth/socialaccount/providers/eventbrite/tests.py
@@ -19,7 +19,6 @@ class EventbriteTests(OAuth2TestsMixin, TestCase):
             "emails": [{
                 "email": "test@example.com",
                 "verified": "True",
-                "primary": "True"
             }],
             "id": "999999999",
             "name": "Andrew Godwin",


### PR DESCRIPTION
This is the fix for the Eventbrite provider. Two methods tried to get a non-existent attribute `primary`. 
Eventbrite reference: https://www.eventbrite.com/platform/api#/reference/user/retrieve-information-about-a-user-account/retrieve-information-about-a-user-account

fixes #2844
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
