### PR TITLE
feat(socialaccount): Add CILogon as a provider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,6 +115,7 @@ Nathan Strobbe
 Niklas A Emanuelsson
 Oleg Sergeev
 Patrick Paul
+Paul Juergen Fischer
 Paulo Eduardo Neves
 Pavel Savchenko
 Peter Bittner

--- a/allauth/socialaccount/providers/cilogon/provider.py
+++ b/allauth/socialaccount/providers/cilogon/provider.py
@@ -23,7 +23,7 @@ class CILogonProvider(OAuth2Provider):
     account_class = CILogonAccount
 
     def get_default_scope(self):
-        scope = [Scope.PROFILE]
+        scope = [Scope.PROFILE, Scope.USERINFO, Scope.OPENID]
         if QUERY_EMAIL:
             scope.append(Scope.EMAIL)
         return scope
@@ -41,7 +41,8 @@ class CILogonProvider(OAuth2Provider):
         return dict(
             email=data.get("email"),
             last_name=data.get("family_name"),
-            first_name=data.get("given_name")
+            first_name=data.get("given_name"),
+            eppn=data.get("eppn")
         )
 
     def extract_email_addresses(self, data):

--- a/allauth/socialaccount/providers/cilogon/provider.py
+++ b/allauth/socialaccount/providers/cilogon/provider.py
@@ -1,0 +1,55 @@
+from allauth.account.models import EmailAddress
+from allauth.socialaccount.app_settings import QUERY_EMAIL
+from allauth.socialaccount.providers.base import AuthAction, ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class Scope(object):
+    OPENID = "openid"
+    EMAIL = "email"
+    PROFILE = "profile"
+    USERINFO = "org.cilogon.userinfo"
+
+
+class CILogonAccount(ProviderAccount):
+    def to_str(self):
+        dflt = super(CILogonAccount, self).to_str()
+        return self.account.extra_data.get("name", dflt)
+
+
+class CILogonProvider(OAuth2Provider):
+    id = "cilogon"
+    name = "CILogon"
+    account_class = CILogonAccount
+
+    def get_default_scope(self):
+        scope = [Scope.PROFILE]
+        if QUERY_EMAIL:
+            scope.append(Scope.EMAIL)
+        return scope
+
+    def get_auth_params(self, request, action):
+        ret = super(CILogonProvider, self).get_auth_params(request, action)
+        if action == AuthAction.REAUTHENTICATE:
+            ret["prompt"] = "select_account consent"
+        return ret
+
+    def extract_uid(self, data):
+        return str(data.get("sub"))
+
+    def extract_common_fields(self, data):
+        return dict(
+            email=data.get("email"),
+            last_name=data.get("family_name"),
+            first_name=data.get("given_name")
+        )
+
+    def extract_email_addresses(self, data):
+        ret = []
+        email = data.get("email")
+        if email and data.get("verified_email"):
+            ret.append(EmailAddress(email=email, verified=True, primary=True))
+        return ret
+
+
+provider_classes = [CILogonProvider]

--- a/allauth/socialaccount/providers/cilogon/tests.py
+++ b/allauth/socialaccount/providers/cilogon/tests.py
@@ -19,6 +19,7 @@ class CILogonTests(OAuth2TestsMixin, TestCase):
             "eppn": "u1234567@example.edu",
             "firstname": "John",
             "lastname": "Doe",
-            "idp_name": "Example University"
+            "idp_name": "Example University",
+            "sub": "http://cilogon.org/serverA/users/1234567"
         }""",
         )

--- a/allauth/socialaccount/providers/cilogon/tests.py
+++ b/allauth/socialaccount/providers/cilogon/tests.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
+
+from .provider import CILogonProvider
+
+
+class CILogonTests(OAuth2TestsMixin, TestCase):
+    provider_id = CILogonProvider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(
+            200,
+            """
+        {
+            "email": "johndoe@example.edu",
+            "eppn": "u1234567@example.edu",
+            "firstname": "John",
+            "lastname": "Doe",
+            "idp_name": "Example University"
+        }""",
+        )

--- a/allauth/socialaccount/providers/cilogon/urls.py
+++ b/allauth/socialaccount/providers/cilogon/urls.py
@@ -1,0 +1,6 @@
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+
+from .provider import CILogonProvider
+
+
+urlpatterns = default_urlpatterns(CILogonProvider)

--- a/allauth/socialaccount/providers/cilogon/views.py
+++ b/allauth/socialaccount/providers/cilogon/views.py
@@ -1,0 +1,29 @@
+import requests
+
+from allauth.socialaccount.providers.oauth2.views import (
+    OAuth2Adapter,
+    OAuth2CallbackView,
+    OAuth2LoginView,
+)
+
+from .provider import CILogonProvider
+
+class CILogonOAuth2Adapter(OAuth2Adapter):
+    provider_id = CILogonProvider.id
+    access_token_url = "https://cilogon.org/oauth2/token"
+    authorize_url = "https://cilogon.org/authorize"
+    profile_url = "https://cilogon.org/oauth2/userinfo"
+
+    def complete_login(self, request, app, token, **kwargs):
+        resp = requests.get(
+            self.profile_url,
+            params={"access_token": token.token, "alt": "json"},
+        )
+        resp.raise_for_status()
+        extra_data = resp.json()
+        login = self.get_provider().sociallogin_from_response(request, extra_data)
+        return login
+
+
+oauth2_login = OAuth2LoginView.adapter_view(CILogonOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(CILogonOAuth2Adapter)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -65,6 +65,7 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
         'allauth.socialaccount.providers.bitly',
         'allauth.socialaccount.providers.box',
         'allauth.socialaccount.providers.cern',
+        'allauth.socialaccount.providers.cilogon',
         'allauth.socialaccount.providers.coinbase',
         'allauth.socialaccount.providers.dataporten',
         'allauth.socialaccount.providers.daum',

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -69,6 +69,8 @@ Supported Providers
 
 - CERN (OAuth2)
 
+- CILogon (OAuth2)
+
 - Coinbase (OAuth2)
 
 - Dataporten (OAuth2)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -312,6 +312,17 @@ CERN OAuth2 Documentation
     https://espace.cern.ch/authentication/CERN%20Authentication/OAuth.aspx
 
 
+CILogon
+----
+CILogon is a federated identity provider for hundreds of universities and research institutions around the world.
+
+App registration (get your key and secret here)
+    https://cilogon.org/oauth2/register
+
+CILogon OIDC/OAuth2 Documentation
+    https://www.cilogon.org/oidc
+
+
 Dataporten
 ----------
 App registration (get your key and secret here)

--- a/test_settings.py
+++ b/test_settings.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = (
     "allauth.socialaccount.providers.bitly",
     "allauth.socialaccount.providers.box",
     "allauth.socialaccount.providers.cern",
+    "allauth.socialaccount.providers.cilogon",
     "allauth.socialaccount.providers.coinbase",
     "allauth.socialaccount.providers.dataporten",
     "allauth.socialaccount.providers.daum",


### PR DESCRIPTION
# CILogon provider addition

## Overview

CILogon is a OAuth2-based federated identity provider for hundreds of universities and research institutions around the world, reaching millions of international researchers, students, and administrative staff.

Note: I used the Google provider as a template.

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers.rst`.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.
