### PR TITLE
feat(accounts) Login with verified emails only

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -316,6 +316,10 @@ class AppSettings(object):
         return self._setting("PRESERVE_USERNAME_CASING", True)
 
     @property
+    def LOGIN_VERIFIED_EMAIL_ONLY(self):
+        return self._setting("LOGIN_VERIFIED_EMAIL_ONLY", False)
+    
+    @property
     def USERNAME_VALIDATORS(self):
         from django.core.exceptions import ImproperlyConfigured
 

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -175,6 +175,9 @@ class LoginForm(forms.Form):
             return
         credentials = self.user_credentials()
         user = get_adapter(self.request).authenticate(self.request, **credentials)
+        email = user.email
+        if EmailAddress.objects.filter(email=email, verified=False).exists() is True and app_settings.LOGIN_VERIFIED_EMAIL_ONLY is True:
+            raise forms.ValidationError('Please check ' + email + ' to verify your email address.')
         if user:
             self.user = user
         else:

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -175,17 +175,20 @@ class LoginForm(forms.Form):
             return
         credentials = self.user_credentials()
         user = get_adapter(self.request).authenticate(self.request, **credentials)
-        email = user.email
-        if EmailAddress.objects.filter(email=email, verified=False).exists() is True and app_settings.LOGIN_VERIFIED_EMAIL_ONLY is True:
-            raise forms.ValidationError('Please check ' + email + ' to verify your email address.')
         if user:
             self.user = user
         else:
             auth_method = app_settings.AUTHENTICATION_METHOD
             if auth_method == app_settings.AuthenticationMethod.USERNAME_EMAIL:
                 login = self.cleaned_data["login"]
+                email = user.email
+                if EmailAddress.objects.filter(email=email, verified=False).exists() is True and app_settings.LOGIN_VERIFIED_EMAIL_ONLY is True:
+                    raise forms.ValidationError('Please check ' + email + ' to verify your email address.')
                 if self._is_login_email(login):
                     auth_method = app_settings.AuthenticationMethod.EMAIL
+                    email = user.email
+                    if EmailAddress.objects.filter(email=email, verified=False).exists() is True and app_settings.LOGIN_VERIFIED_EMAIL_ONLY is True:
+                        raise forms.ValidationError('Please check ' + email + ' to verify your email address.')
                 else:
                     auth_method = app_settings.AuthenticationMethod.USERNAME
             raise forms.ValidationError(

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -181,9 +181,6 @@ class LoginForm(forms.Form):
             auth_method = app_settings.AUTHENTICATION_METHOD
             if auth_method == app_settings.AuthenticationMethod.USERNAME_EMAIL:
                 login = self.cleaned_data["login"]
-                email = user.email
-                if EmailAddress.objects.filter(email=email, verified=False).exists() is True and app_settings.LOGIN_VERIFIED_EMAIL_ONLY is True:
-                    raise forms.ValidationError('Please check ' + email + ' to verify your email address.')
                 if self._is_login_email(login):
                     auth_method = app_settings.AuthenticationMethod.EMAIL
                     email = user.email

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -184,7 +184,7 @@ class LoginForm(forms.Form):
                 if self._is_login_email(login):
                     auth_method = app_settings.AuthenticationMethod.EMAIL
                     email = user.email
-                    if EmailAddress.objects.filter(email=email, verified=False).exists() is True and app_settings.LOGIN_VERIFIED_EMAIL_ONLY is True:
+                    if app_settings.LOGIN_VERIFIED_EMAIL_ONLY is True and EmailAddress.objects.filter(email=email, verified=False).exists() is True:
                         raise forms.ValidationError('Please check ' + email + ' to verify your email address.')
                 else:
                     auth_method = app_settings.AuthenticationMethod.USERNAME


### PR DESCRIPTION
Adds a setting to only allow verified emails to login. Unverified emails will get a form validation error.

This is useful because it prevents unverified emails trying to login from sending spam confirmation emails over and over. And it ensures only legitimate people are able to login to your website. 

If this setting is true, the django developer could always run a cronjob to delete unverified emails if the newly signed up user loses their original confirmation email or it expires. Then the user could signup again with the same email address. 