### PR TITLE
fix: Use ALLOWED_HOSTS from django settings in is_safe_url

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -6,6 +6,7 @@ import time
 import warnings
 
 from django import forms
+from django.conf import global_settings
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import (
@@ -28,6 +29,7 @@ from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
+from . import app_settings
 from ..utils import (
     build_absolute_uri,
     email_address_exists,
@@ -35,7 +37,6 @@ from ..utils import (
     get_user_model,
     import_attribute,
 )
-from . import app_settings
 
 
 class DefaultAccountAdapter(object):
@@ -435,7 +436,7 @@ class DefaultAccountAdapter(object):
                 is_safe_url as url_has_allowed_host_and_scheme,
             )
 
-        return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
+        return url_has_allowed_host_and_scheme(url, allowed_hosts=global_settings.ALLOWED_HOSTS)
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         """Constructs the email confirmation (activation) url.


### PR DESCRIPTION
## Description

Currently it does not seem possible for `account.adapter.DefaultAccountAdapter.is_safe_url` to ever return `True`. 

As such I cannot pass a `next=` redirect URL parameter when beginning an OAuth flow, e.g.:

```
https://cloud.coreweave.test/accounts/github/login/?process=login&next=https%3A%2F%2Fcloud.coreweave.test%2Flogin
```
The param is removed [here](https://github.com/mecampbellsoup/django-allauth/blob/06560b5d3544da925759c56f85d0fce845520be1/allauth/account/utils.py#L44-L46) when `is_safe_url` runs. Every check done is OK except for `url_info.netloc in allowed_hosts` which is always `False` as `allowed_hosts` is always set to `set()` (from `None`). Here is the flow through the code:

1. https://github.com/mecampbellsoup/django-allauth/blob/2fa7038a53e77dad504624584d2a533d08a3e7d1/allauth/account/adapter.py#L438
1. https://github.com/django/django/blob/main/django/utils/http.py#L256-L257
1. https://github.com/django/django/blob/main/django/utils/http.py#L263
1. https://github.com/django/django/blob/main/django/utils/http.py#L342-L343

## Implementation

I refer to the Django app's `global_settings.ALLOWED_HOSTS` to define `allowed_hosts` argument passed to `is_safe_url` instead of just defaulting to `None`.
