### PR TITLE
fix(docs): fixed reference in ACCOUNT_LOGOUT_REDIRECT_URL docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -154,7 +154,7 @@ ACCOUNT_LOGIN_ON_PASSWORD_RESET (=False)
 
 ACCOUNT_LOGOUT_REDIRECT_URL (="/")
   The URL (or URL name) to return to after the user logs out. This is
-  the counterpart to Django's ``LOGIN_REDIRECT_URL``.
+  the counterpart to Django's ``LOGOUT_REDIRECT_URL``.
 
 ACCOUNT_PASSWORD_INPUT_RENDER_VALUE (=False)
   ``render_value`` parameter as passed to ``PasswordInput`` fields.


### PR DESCRIPTION
Fixed the reference in `ACCOUNT_LOGOUT_REDIRECT_URL` docs in the `configuration.rst` file which as I believe should refer to default Django `LOGOUT_REDIRECT_URL` instead of `LOGIN_REDIRECT_URL` as its counterpart.