### PR TITLE
fix: synchronize Gettext plural forms with Django

### DIFF
--- a/allauth/locale/cs/LC_MESSAGES/django.po
+++ b/allauth/locale/cs/LC_MESSAGES/django.po
@@ -16,7 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 "X-Generator: Gtranslator 2.91.7\n"
 
 #: account/adapter.py:45

--- a/allauth/locale/en/LC_MESSAGES/django.po
+++ b/allauth/locale/en/LC_MESSAGES/django.po
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."

--- a/allauth/locale/fa/LC_MESSAGES/django.po
+++ b/allauth/locale/fa/LC_MESSAGES/django.po
@@ -15,6 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.7.4\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."

--- a/allauth/locale/hu/LC_MESSAGES/django.po
+++ b/allauth/locale/hu/LC_MESSAGES/django.po
@@ -16,6 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.7.6\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."

--- a/allauth/locale/ky/LC_MESSAGES/django.po
+++ b/allauth/locale/ky/LC_MESSAGES/django.po
@@ -16,6 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."

--- a/allauth/locale/lt/LC_MESSAGES/django.po
+++ b/allauth/locale/lt/LC_MESSAGES/django.po
@@ -16,8 +16,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
-"%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
+"11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
+"1 : n % 1 != 0 ? 2: 3);\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."

--- a/allauth/locale/nb/LC_MESSAGES/django.po
+++ b/allauth/locale/nb/LC_MESSAGES/django.po
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."

--- a/allauth/locale/pl/LC_MESSAGES/django.po
+++ b/allauth/locale/pl/LC_MESSAGES/django.po
@@ -15,6 +15,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
+"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
+"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."

--- a/allauth/locale/ru/LC_MESSAGES/django.po
+++ b/allauth/locale/ru/LC_MESSAGES/django.po
@@ -15,6 +15,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
 #: account/adapter.py:45

--- a/allauth/locale/sk/LC_MESSAGES/django.po
+++ b/allauth/locale/sk/LC_MESSAGES/django.po
@@ -16,6 +16,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.1\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n == 1 ? 0 : n % 1 == 0 && n "
+">= 2 && n <= 4 ? 1 : n % 1 != 0 ? 2: 3);\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."

--- a/allauth/locale/uk/LC_MESSAGES/django.po
+++ b/allauth/locale/uk/LC_MESSAGES/django.po
@@ -15,8 +15,10 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != "
+"11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % "
+"100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
+"(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 
 #: account/adapter.py:45
 msgid "Username can not be used. Please use other username."


### PR DESCRIPTION
[Django bugfix #30439](https://code.djangoproject.com/ticket/30439) has cause translations with different plural forms definitions are loaded in a separated catalogue. This means that app translations cannot be overwritten on the project level (in project LOCALE).

This pull request synchronize plural forms with the current Django version https://github.com/django/django/tree/main/django/conf/locale