### PR TITLE
fix(weixin): remove WeixinOAuth2ClientMixin

### DIFF
--- a/allauth/socialaccount/providers/weixin/views.py
+++ b/allauth/socialaccount/providers/weixin/views.py
@@ -18,6 +18,7 @@ class WeixinOAuth2Adapter(OAuth2Adapter):
     provider_id = WeixinProvider.id
     access_token_url = "https://api.weixin.qq.com/sns/oauth2/access_token"
     profile_url = "https://api.weixin.qq.com/sns/userinfo"
+    client_class = WeixinOAuth2Client
 
     @property
     def authorize_url(self):
@@ -42,34 +43,5 @@ class WeixinOAuth2Adapter(OAuth2Adapter):
         return self.get_provider().sociallogin_from_response(request, extra_data)
 
 
-class WeixinOAuth2ClientMixin(object):
-    def get_client(self, request, app):
-        callback_url = reverse(self.adapter.provider_id + "_callback")
-        protocol = (
-            self.adapter.redirect_uri_protocol or app_settings.DEFAULT_HTTP_PROTOCOL
-        )
-        callback_url = build_absolute_uri(request, callback_url, protocol=protocol)
-        provider = self.adapter.get_provider()
-        scope = provider.get_scope(request)
-        client = WeixinOAuth2Client(
-            request,
-            app.client_id,
-            app.secret,
-            self.adapter.access_token_method,
-            self.adapter.access_token_url,
-            callback_url,
-            scope,
-        )
-        return client
-
-
-class WeixinOAuth2LoginView(WeixinOAuth2ClientMixin, OAuth2LoginView):
-    pass
-
-
-class WeixinOAuth2CallbackView(WeixinOAuth2ClientMixin, OAuth2CallbackView):
-    pass
-
-
-oauth2_login = WeixinOAuth2LoginView.adapter_view(WeixinOAuth2Adapter)
-oauth2_callback = WeixinOAuth2CallbackView.adapter_view(WeixinOAuth2Adapter)
+oauth2_login = OAuth2LoginView.adapter_view(WeixinOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(WeixinOAuth2Adapter)

--- a/allauth/socialaccount/providers/weixin/views.py
+++ b/allauth/socialaccount/providers/weixin/views.py
@@ -1,14 +1,10 @@
 import requests
 
-from django.urls import reverse
-
-from allauth.account import app_settings
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
     OAuth2LoginView,
 )
-from allauth.utils import build_absolute_uri
 
 from .client import WeixinOAuth2Client
 from .provider import WeixinProvider


### PR DESCRIPTION
client_class is configurable now.
WeixinOAuth2ClientMixin.get_client is outdated, use default OAuth2View.get_client.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
