### PR TITLE
chore: specify default_auto_field for `account` and `socialaccount` apps

### DIFF
--- a/allauth/account/apps.py
+++ b/allauth/account/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class AccountConfig(AppConfig):
     name = 'allauth.account'
     verbose_name = _('Accounts')
+    default_auto_field = 'django.db.models.AutoField'

--- a/allauth/socialaccount/apps.py
+++ b/allauth/socialaccount/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class SocialAccountConfig(AppConfig):
     name = 'allauth.socialaccount'
     verbose_name = _('Social Accounts')
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Related to issue #2929 
https://github.com/pennersr/django-allauth/issues/2929#issue-966896868