### PR TITLE
fix(accounts): Use Reddit name as username

### DIFF
--- a/allauth/socialaccount/providers/reddit/provider.py
+++ b/allauth/socialaccount/providers/reddit/provider.py
@@ -18,7 +18,7 @@ class RedditProvider(OAuth2Provider):
         return data["name"]
 
     def extract_common_fields(self, data):
-        return dict(name=data.get("name"))
+        return dict(username=data.get("name"))
 
     def get_default_scope(self):
         scope = ["identity"]


### PR DESCRIPTION
Using Reddit's screen name as username instead of first name will allow the sign to skip one more field.

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.
