### PR TITLE
fix(keycloak): Add configuration to override provider name displayed in UI

### DIFF
--- a/allauth/socialaccount/providers/keycloak/provider.py
+++ b/allauth/socialaccount/providers/keycloak/provider.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
+OVERRIDE_NAME = (
+    getattr(settings, "SOCIALACCOUNT_PROVIDERS", {})
+    .get("keycloak", {})
+    .get("OVERRIDE_NAME", "Keycloak")
+)
 
 class KeycloakAccount(ProviderAccount):
     def get_avatar_url(self):
@@ -14,7 +20,7 @@ class KeycloakAccount(ProviderAccount):
 
 class KeycloakProvider(OAuth2Provider):
     id = "keycloak"
-    name = "Keycloak"
+    name = OVERRIDE_NAME
     account_class = KeycloakAccount
 
     def get_default_scope(self):

--- a/allauth/socialaccount/providers/keycloak/provider.py
+++ b/allauth/socialaccount/providers/keycloak/provider.py
@@ -9,6 +9,7 @@ OVERRIDE_NAME = (
     .get("OVERRIDE_NAME", "Keycloak")
 )
 
+
 class KeycloakAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")

--- a/allauth/socialaccount/providers/keycloak/provider.py
+++ b/allauth/socialaccount/providers/keycloak/provider.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
+
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
-from django.conf import settings
+
 
 OVERRIDE_NAME = (
     getattr(settings, "SOCIALACCOUNT_PROVIDERS", {})

--- a/allauth/socialaccount/providers/keycloak/provider.py
+++ b/allauth/socialaccount/providers/keycloak/provider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from django.conf import settings
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from django.conf import settings
 
 OVERRIDE_NAME = (
     getattr(settings, "SOCIALACCOUNT_PROVIDERS", {})


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [X] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [X] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.

This implements a solution to #2963. For this pull request, I've only made the change to the Keycloak provider but I've tackled it in a way that can be generalised across all providers, which is why I picked `OVERRIDE_NAME` as the variable rather than something like `KEYCLOAK_NAME`. I'm happy to change it, though, if you'd prefer it to specify the provider's name in the variable name.

Simply adding a value for `OVERRIDE_NAME` in the provider's block in `SOCIALACCOUNT_PROVIDERS` causes that value to be used wherever the provider's name is used in the UI.
