### PR TITLE
fix: Remove use of deprecated pyjwt parameter

### DIFF
--- a/allauth/socialaccount/providers/apple/views.py
+++ b/allauth/socialaccount/providers/apple/views.py
@@ -68,7 +68,6 @@ class AppleOAuth2Adapter(OAuth2Adapter):
                 id_token,
                 public_key,
                 algorithms=["RS256"],
-                verify=True,
                 audience=allowed_auds,
                 issuer="https://appleid.apple.com",
             )


### PR DESCRIPTION
allauth/socialaccount/providers/apple/views.py:
Remove the use of `verify=True` when calling `jwt.decode()`, as it is
deprecated with pyjwt == 1.7.0 (see
https://github.com/jpadilla/pyjwt/blob/3f735fdf68cc865a6241aae1fcf92a410c73fbdb/jwt/api_jws.py#L132-L134)
and removed in pywjt == 2.0.0.
The default is now to use an (optional) `options` dict, that always uses
`{"verify_signature": True}` as fallback if `options` is `None` or if
`verify_signature` is not set in it.

Closes #2977

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.