### PR TITLE
feat(account): Add unique constraint for a user's primary email

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -16,6 +16,7 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMessage, EmailMultiAlternatives
+from django.db.models import CharField, EmailField
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.template import TemplateDoesNotExist
@@ -483,15 +484,11 @@ class DefaultAccountAdapter(object):
 
     def get_user_search_fields(self):
         user = get_user_model()()
-        return filter(
-            lambda a: a and hasattr(user, a),
-            [
-                app_settings.USER_MODEL_USERNAME_FIELD,
-                "first_name",
-                "last_name",
-                "email",
-            ],
-        )
+        return [
+            f.name
+            for f in user._meta.fields
+            if type(f) in [CharField, EmailField] and f.name != "password"
+        ]
 
     def is_safe_url(self, url):
         try:


### PR DESCRIPTION
Since Django 2.2 the UniqueConstraint supports conditions. This allows enforcing only one primary email per user on the database level.

The docs mention that [Oracle databases don't support partial indexes](https://docs.djangoproject.com/en/2.2/ref/models/indexes/#django.db.models.Index.condition). I'm not sure if that means that the index will silently be ignored (just as MariaDB and MySQL do).

Closes #225.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.
