### PR TITLE
feat(accounts): Added prefilling of forms with GET query strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ pep8.txt
 *.db
 *.tmp
 virtualenv
+.venv
+.vscode
 .DS_Store
 
 *.prefs

--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ Francis Brito
 Frantisek Malina
 Fred Palmer
 Fábio Santos
+Germán Mené Santa Olaya
 George Whewell
 Griffith Rees
 Guignard Javier

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -27,6 +27,10 @@ Note worthy changes
   installed. Therefore, enabling or disabling ``sites`` is not something you can
   do on the fly.
 
+- The ``login`` and ``signup`` pages support now the prefilling of form fields with the 
+  GET query strings. Examples: 
+  ``https://example.com/accounts/login/?login=myuser&remember=true``,
+  ``https://example.com/accounts/signup/?username=myuser&email=user@mail.com``
 
 
 Backwards incompatible changes

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1051,29 +1051,29 @@ class AccountTests(TestCase):
         actual_message = msgs._queued_messages[0].message
         assert user.username in actual_message, actual_message
 
-
     def test_get_login_view_with_query_strings_prefills_form(self):
         from .views import LoginView
+
         form_fields = LoginView.form_class().fields
         self.assertNotEqual(form_fields, {})
 
-        query_string_dict = {k: "query" for k,_ in form_fields.items()}
+        query_string_dict = {k: "query" for k, _ in form_fields.items()}
         response = self.client.get(reverse("account_login"), query_string_dict)
         initial_data_form_in_response = {
-            k: v[0] for k,v in dict(response.context_data["form"].initial).items()
+            k: v[0] for k, v in dict(response.context_data["form"].initial).items()
         }
         self.assertEqual(initial_data_form_in_response, query_string_dict)
 
-
     def test_get_signup_view_with_query_strings_prefills_form(self):
         from .views import SignupView
+
         form_fields = SignupView.form_class().fields
         self.assertNotEqual(form_fields, {})
 
-        query_string_dict = {k: "query" for k,_ in form_fields.items()}
+        query_string_dict = {k: "query" for k, _ in form_fields.items()}
         response = self.client.get(reverse("account_signup"), query_string_dict)
         initial_data_form_in_response = {
-            k: v[0] for k,v in dict(response.context_data["form"].initial).items()
+            k: v[0] for k, v in dict(response.context_data["form"].initial).items()
         }
         self.assertEqual(initial_data_form_in_response, query_string_dict)
 

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1065,6 +1065,19 @@ class AccountTests(TestCase):
         self.assertEqual(initial_data_form_in_response, query_string_dict)
 
 
+    def test_get_signup_view_with_query_strings_prefills_form(self):
+        from .views import SignupView
+        form_fields = SignupView.form_class().fields
+        self.assertNotEqual(form_fields, {})
+
+        query_string_dict = {k: "query" for k,_ in form_fields.items()}
+        response = self.client.get(reverse("account_signup"), query_string_dict)
+        initial_data_form_in_response = {
+            k: v[0] for k,v in dict(response.context_data["form"].initial).items()
+        }
+        self.assertEqual(initial_data_form_in_response, query_string_dict)
+
+
 class EmailFormTests(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1052,6 +1052,16 @@ class AccountTests(TestCase):
         assert user.username in actual_message, actual_message
 
 
+    def test_get_login_view_with_query_strings_prefills_form(self):
+        from .views import LoginView
+        form_fields = LoginView.form_class().fields
+        self.assertNotEqual(form_fields, {})
+        
+        query_string_dict = {k: "query" for k,_ in form_fields.items()}
+        response = self.client.get(reverse("account_login"), query_string_dict)
+        self.assertNotEqual(response.context_data["form"].initial, {})
+
+
 class EmailFormTests(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1056,10 +1056,13 @@ class AccountTests(TestCase):
         from .views import LoginView
         form_fields = LoginView.form_class().fields
         self.assertNotEqual(form_fields, {})
-        
+
         query_string_dict = {k: "query" for k,_ in form_fields.items()}
         response = self.client.get(reverse("account_login"), query_string_dict)
-        self.assertNotEqual(response.context_data["form"].initial, {})
+        initial_data_form_in_response = {
+            k: v[0] for k,v in dict(response.context_data["form"].initial).items()
+        }
+        self.assertEqual(initial_data_form_in_response, query_string_dict)
 
 
 class EmailFormTests(TestCase):

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -135,9 +135,15 @@ class LogoutFunctionalityMixin(object):
         )
         adapter.logout(self.request)
 
+class PrefillFormWithQueryString(object):
+    def get_initial(self):
+        if self.request.GET:
+            self.initial = self.request.GET.copy()
+        return super().get_initial()
+
 
 class LoginView(
-    RedirectAuthenticatedUserMixin, AjaxCapableProcessFormViewMixin, FormView
+    RedirectAuthenticatedUserMixin, AjaxCapableProcessFormViewMixin, PrefillFormWithQueryString, FormView
 ):
     form_class = LoginForm
     template_name = "account/login." + app_settings.TEMPLATE_EXTENSION
@@ -189,11 +195,6 @@ class LoginView(
         )
         return ret
 
-    def get_initial(self):
-        if self.request.GET:
-            self.initial = self.request.GET.copy()
-        return super().get_initial()
-
 
 login = LoginView.as_view()
 
@@ -227,6 +228,7 @@ class SignupView(
     RedirectAuthenticatedUserMixin,
     CloseableSignupMixin,
     AjaxCapableProcessFormViewMixin,
+    PrefillFormWithQueryString,
     FormView,
 ):
     template_name = "account/signup." + app_settings.TEMPLATE_EXTENSION
@@ -288,11 +290,6 @@ class SignupView(
             }
         )
         return ret
-
-    def get_initial(self):
-        if self.request.GET:
-            self.initial = self.request.GET.copy()
-        return super().get_initial()
 
 
 signup = SignupView.as_view()

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -136,7 +136,7 @@ class LogoutFunctionalityMixin(object):
         adapter.logout(self.request)
 
 
-class PrefillFormWithQueryString(object):
+class PrefillFormWithQueryStringMixin(object):
     def get_initial(self):
         if self.request.GET:
             self.initial = self.request.GET.copy()
@@ -146,7 +146,7 @@ class PrefillFormWithQueryString(object):
 class LoginView(
     RedirectAuthenticatedUserMixin,
     AjaxCapableProcessFormViewMixin,
-    PrefillFormWithQueryString,
+    PrefillFormWithQueryStringMixin,
     FormView,
 ):
     form_class = LoginForm
@@ -232,7 +232,7 @@ class SignupView(
     RedirectAuthenticatedUserMixin,
     CloseableSignupMixin,
     AjaxCapableProcessFormViewMixin,
-    PrefillFormWithQueryString,
+    PrefillFormWithQueryStringMixin,
     FormView,
 ):
     template_name = "account/signup." + app_settings.TEMPLATE_EXTENSION

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -135,6 +135,7 @@ class LogoutFunctionalityMixin(object):
         )
         adapter.logout(self.request)
 
+
 class PrefillFormWithQueryString(object):
     def get_initial(self):
         if self.request.GET:
@@ -143,7 +144,10 @@ class PrefillFormWithQueryString(object):
 
 
 class LoginView(
-    RedirectAuthenticatedUserMixin, AjaxCapableProcessFormViewMixin, PrefillFormWithQueryString, FormView
+    RedirectAuthenticatedUserMixin,
+    AjaxCapableProcessFormViewMixin,
+    PrefillFormWithQueryString,
+    FormView,
 ):
     form_class = LoginForm
     template_name = "account/login." + app_settings.TEMPLATE_EXTENSION

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -189,6 +189,11 @@ class LoginView(
         )
         return ret
 
+    def get_initial(self):
+        if self.request.GET:
+            self.initial = self.request.GET.copy()
+        return super().get_initial()
+
 
 login = LoginView.as_view()
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -289,6 +289,11 @@ class SignupView(
         )
         return ret
 
+    def get_initial(self):
+        if self.request.GET:
+            self.initial = self.request.GET.copy()
+        return super().get_initial()
+
 
 signup = SignupView.as_view()
 


### PR DESCRIPTION
Closes #2861 

## Summary
Added support for prefilling form fields with the query strings submitted on GET requests. This functionality has been added to the `login` and `signup` views. Examples:
 - https://example.com/accounts/login/?login=myuser&remember=true
 - https://example.com/accounts/signup/?username=myuser&email=user@mail.com

This feature was requested on issue #2861

# Submitting Pull Requests

## General

 - [X] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [X] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [X] If your changes are significant, please update `ChangeLog.rst`.
 - [X] If your change is substantial, feel free to add yourself to `AUTHORS`.