### PR TITLE
feat(accounts): add flag to allow login only with primary email

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -132,6 +132,13 @@ class AppSettings(object):
         return self._setting("EMAIL_MAX_LENGTH", 254)
 
     @property
+    def EMAIL_ONLY_PRIMARY_LOGIN(self):
+        """
+        Only allow login/password reset for primary email
+        """
+        return self._setting("EMAIL_ONLY_PRIMARY_LOGIN", False)
+
+    @property
     def UNIQUE_EMAIL(self):
         """
         Enforce uniqueness of e-mail addresses

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -418,6 +418,8 @@ def filter_users_by_email(email, is_active=None):
     mails = EmailAddress.objects.filter(email__iexact=email)
     if is_active is not None:
         mails = mails.filter(user__is_active=is_active)
+    if app_settings.EMAIL_ONLY_PRIMARY_LOGIN:
+        mails = mails.filter(primary=True)
     users = []
     for e in mails.prefetch_related("user"):
         if _unicode_ci_compare(e.email, email):


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

## Description

Adds a Flag `EMAIL_ONLY_PRIMARY_LOGIN` to allow login with email addresses only for the primary address. Background for this is that I had a problem with user accounts beeing reset by outdated secondary email addresses the users did not remove.