### PR TITLE
fix(account/forms): Use user instance for password validation

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -27,6 +27,8 @@ Note worthy changes
   installed. Therefore, enabling or disabling ``sites`` is not something you can
   do on the fly.
 
+- Fixed ``SignupForm`` setting username and email attributes on the ``User`` class
+  instead of a dummy user instance.
 
 
 Backwards incompatible changes

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -394,7 +394,8 @@ class SignupForm(BaseSignupForm):
         # `password` cannot be of type `SetPasswordField`, as we don't
         # have a `User` yet. So, let's populate a dummy user to be used
         # for password validaton.
-        dummy_user = get_user_model()
+        User = get_user_model()
+        dummy_user = User()
         user_username(dummy_user, self.cleaned_data.get("username"))
         user_email(dummy_user, self.cleaned_data.get("email"))
         password = self.cleaned_data.get("password1")

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1299,6 +1299,29 @@ class CustomSignupFormTests(TestCase):
         form = CustomSignupForm()
         self.assertEqual(list(form.fields.keys()), expected_field_order)
 
+    def test_user_class_attribute(self):
+        from django.contrib.auth import get_user_model
+        from django.db.models.query_utils import DeferredAttribute
+
+        class CustomSignupForm(SignupForm):
+            # ACCOUNT_SIGNUP_FORM_CLASS is only abided by when the
+            # BaseSignupForm definition is loaded the first time on Django
+            # startup. @override_settings() has therefore no effect.
+            pass
+
+        User = get_user_model()
+        data = {
+            "username": "username",
+            "email": "user@example.com",
+            "password1": "very-secret",
+            "password2": "very-secret",
+        }
+        form = CustomSignupForm(data, email_required=True)
+
+        assert isinstance(User.username, DeferredAttribute)
+        form.is_valid()
+        assert isinstance(User.username, DeferredAttribute)
+
 
 class AuthenticationBackendTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
The `SignupForm` is supposed to use a temporary dummy user, that the form data is written to, to enable password validation.
As it is right now, `dummy_user` is not actually a blank `User` instance but the model itself. That means that the `User` model always contains the data of the user that signed up most recently.

```python
def clean(self):
    super(SignupForm, self).clean()

    # `password` cannot be of type `SetPasswordField`, as we don't
    # have a `User` yet. So, let's populate a dummy user to be used
    # for password validaton.
    dummy_user = get_user_model()
    user_username(dummy_user, self.cleaned_data.get("username"))
    user_email(dummy_user, self.cleaned_data.get("email"))
    password = self.cleaned_data.get("password1")
```

I suppose the fix is simply to use 

```python
dummy_user = get_user_model()()
# Or better yet:
User = get_user_model()
dummy_user = User()
```

What makes this bug so nasty is that it can lead to leaked private data: For example, deferred user instances will infer data from the `User` class. Accessing `user.email` on a deferred instance will display the email address of the user that most-recently signed up.

---

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.