### PR TITLE
feat(providers): add LemonLDAP::NG 

### DIFF
--- a/allauth/socialaccount/providers/lemonldap/provider.py
+++ b/allauth/socialaccount/providers/lemonldap/provider.py
@@ -3,19 +3,19 @@ from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
-class LemonldapAccount(ProviderAccount):
+class LemonLDAPAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 
     def to_str(self):
-        dflt = super(LemonldapAccount, self).to_str()
+        dflt = super(LemonLDAPAccount, self).to_str()
         return self.account.extra_data.get("name", dflt)
 
 
-class LemonldapProvider(OAuth2Provider):
+class LemonLDAPProvider(OAuth2Provider):
     id = "lemonldap"
     name = "LemonLDAP::NG"
-    account_class = LemonldapAccount
+    account_class = LemonLDAPAccount
 
     def get_default_scope(self):
         return ["openid", "profile", "email"]
@@ -32,4 +32,4 @@ class LemonldapProvider(OAuth2Provider):
         )
 
 
-provider_classes = [LemonldapProvider]
+provider_classes = [LemonLDAPProvider]

--- a/allauth/socialaccount/providers/lemonldap/provider.py
+++ b/allauth/socialaccount/providers/lemonldap/provider.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from allauth.socialaccount.providers.base import ProviderAccount
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+
+
+class LemonldapAccount(ProviderAccount):
+    def get_avatar_url(self):
+        return self.account.extra_data.get("picture")
+
+    def to_str(self):
+        dflt = super(LemonldapAccount, self).to_str()
+        return self.account.extra_data.get("name", dflt)
+
+
+class LemonldapProvider(OAuth2Provider):
+    id = "lemonldap"
+    name = "LemonLDAP::NG"
+    account_class = LemonldapAccount
+
+    def get_default_scope(self):
+        return ["openid", "profile", "email"]
+
+    def extract_uid(self, data):
+        return str(data["id"])
+
+    def extract_common_fields(self, data):
+        return dict(
+            email=data.get("email"),
+            username=data.get("preferred_username"),
+            name=data.get("name"),
+            picture=data.get("picture"),
+        )
+
+
+provider_classes = [LemonldapProvider]

--- a/allauth/socialaccount/providers/lemonldap/tests.py
+++ b/allauth/socialaccount/providers/lemonldap/tests.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-from allauth.socialaccount.providers.lemonldap.provider import LemonldapProvider
+from allauth.socialaccount.providers.lemonldap.provider import LemonLDAPProvider
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
 
 
-class LemonldapTests(OAuth2TestsMixin, TestCase):
-    provider_id = LemonldapProvider.id
+class LemonLDAPTests(OAuth2TestsMixin, TestCase):
+    provider_id = LemonLDAPProvider.id
 
     def get_mocked_response(self):
         return MockedResponse(

--- a/allauth/socialaccount/providers/lemonldap/tests.py
+++ b/allauth/socialaccount/providers/lemonldap/tests.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from allauth.socialaccount.providers.lemonldap.provider import LemonldapProvider
+from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.tests import MockedResponse, TestCase
+
+
+class LemonldapTests(OAuth2TestsMixin, TestCase):
+    provider_id = LemonldapProvider.id
+
+    def get_mocked_response(self):
+        return MockedResponse(
+            200,
+            """
+            {
+                "email": "dwho@example.com",
+                "sub": "dwho",
+                "preferred_username": "dwho",
+                "name": "Doctor Who"
+            }
+        """,
+        )

--- a/allauth/socialaccount/providers/lemonldap/tests.py
+++ b/allauth/socialaccount/providers/lemonldap/tests.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from allauth.socialaccount.providers.lemonldap.provider import LemonLDAPProvider
+from allauth.socialaccount.providers.lemonldap.provider import (
+    LemonLDAPProvider,
+)
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
 

--- a/allauth/socialaccount/providers/lemonldap/urls.py
+++ b/allauth/socialaccount/providers/lemonldap/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from allauth.socialaccount.providers.lemonldap.provider import LemonldapProvider
+from allauth.socialaccount.providers.lemonldap.provider import LemonLDAPProvider
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
 
 
-urlpatterns = default_urlpatterns(LemonldapProvider)
+urlpatterns = default_urlpatterns(LemonLDAPProvider)

--- a/allauth/socialaccount/providers/lemonldap/urls.py
+++ b/allauth/socialaccount/providers/lemonldap/urls.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-from allauth.socialaccount.providers.lemonldap.provider import LemonLDAPProvider
+from allauth.socialaccount.providers.lemonldap.provider import (
+    LemonLDAPProvider,
+)
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
 
 

--- a/allauth/socialaccount/providers/lemonldap/urls.py
+++ b/allauth/socialaccount/providers/lemonldap/urls.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from allauth.socialaccount.providers.lemonldap.provider import LemonldapProvider
+from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+
+
+urlpatterns = default_urlpatterns(LemonldapProvider)

--- a/allauth/socialaccount/providers/lemonldap/views.py
+++ b/allauth/socialaccount/providers/lemonldap/views.py
@@ -2,7 +2,7 @@
 import requests
 
 from allauth.socialaccount import app_settings
-from allauth.socialaccount.providers.lemonldap.provider import LemonldapProvider
+from allauth.socialaccount.providers.lemonldap.provider import LemonLDAPProvider
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,
@@ -10,8 +10,8 @@ from allauth.socialaccount.providers.oauth2.views import (
 )
 
 
-class LemonldapOAuth2Adapter(OAuth2Adapter):
-    provider_id = LemonldapProvider.id
+class LemonLDAPOAuth2Adapter(OAuth2Adapter):
+    provider_id = LemonLDAPProvider.id
     supports_state = True
 
     settings = app_settings.PROVIDERS.get(provider_id, {})
@@ -33,5 +33,5 @@ class LemonldapOAuth2Adapter(OAuth2Adapter):
         return self.get_provider().sociallogin_from_response(request, extra_data)
 
 
-oauth2_login = OAuth2LoginView.adapter_view(LemonldapOAuth2Adapter)
-oauth2_callback = OAuth2CallbackView.adapter_view(LemonldapOAuth2Adapter)
+oauth2_login = OAuth2LoginView.adapter_view(LemonLDAPOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(LemonLDAPOAuth2Adapter)

--- a/allauth/socialaccount/providers/lemonldap/views.py
+++ b/allauth/socialaccount/providers/lemonldap/views.py
@@ -2,7 +2,9 @@
 import requests
 
 from allauth.socialaccount import app_settings
-from allauth.socialaccount.providers.lemonldap.provider import LemonLDAPProvider
+from allauth.socialaccount.providers.lemonldap.provider import (
+    LemonLDAPProvider,
+)
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
     OAuth2CallbackView,

--- a/allauth/socialaccount/providers/lemonldap/views.py
+++ b/allauth/socialaccount/providers/lemonldap/views.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import requests
+
+from allauth.socialaccount import app_settings
+from allauth.socialaccount.providers.lemonldap.provider import LemonldapProvider
+from allauth.socialaccount.providers.oauth2.views import (
+    OAuth2Adapter,
+    OAuth2CallbackView,
+    OAuth2LoginView,
+)
+
+
+class LemonldapOAuth2Adapter(OAuth2Adapter):
+    provider_id = LemonldapProvider.id
+    supports_state = True
+
+    settings = app_settings.PROVIDERS.get(provider_id, {})
+    provider_base_url = settings.get("LEMONLDAP_URL")
+
+    access_token_url = "{0}/oauth2/token".format(provider_base_url)
+    authorize_url = "{0}/oauth2/authorize".format(provider_base_url)
+    profile_url = "{0}/oauth2/userinfo".format(provider_base_url)
+
+    def complete_login(self, request, app, token, response):
+        response = requests.post(
+            self.profile_url, headers={"Authorization": "Bearer " + str(token)}
+        )
+        response.raise_for_status()
+        extra_data = response.json()
+        extra_data["id"] = extra_data["sub"]
+        del extra_data["sub"]
+
+        return self.get_provider().sociallogin_from_response(request, extra_data)
+
+
+oauth2_login = OAuth2LoginView.adapter_view(LemonldapOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(LemonldapOAuth2Adapter)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -102,6 +102,7 @@ settings.py (Important - Please note 'django.contrib.sites' is required as INSTA
         'allauth.socialaccount.providers.jupyterhub',
         'allauth.socialaccount.providers.kakao',
         'allauth.socialaccount.providers.keycloak',
+        'allauth.socialaccount.providers.lemonldap',
         'allauth.socialaccount.providers.line',
         'allauth.socialaccount.providers.linkedin',
         'allauth.socialaccount.providers.linkedin_oauth2',

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -141,6 +141,8 @@ Supported Providers
 
 - Keycloak (OAuth2)
 
+- LemonLDAP::NG (OAuth2)
+
 - Line (OAuth2)
 
 - LinkedIn (OAuth, OAuth2)

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1083,6 +1083,36 @@ Example:
       }
   }
 
+LemonLDAP::NG
+-------------
+
+Create a new OpenID Connect Relying Party with the following settings:
+
+* Exported attributes:
+
+    * ``email``
+    * ``name``
+    * ``preferred_username``
+
+* Basic options:
+
+    * Development Redirect URI: http://localhost:8000/accounts/lemonldap/login/callback/
+
+The following LemonLDAP::NG settings are available.
+
+LEMONLDAP_URL:
+    The base URL of your LemonLDAP::NG portal. For example: ``https://auth.example.com``
+
+Example:
+
+.. code-block:: python
+
+  SOCIALACCOUNT_PROVIDERS = {
+      'lemonldap': {
+          'LEMONLDAP_URL': 'https://auth.example.com'
+      }
+  }
+
 Line
 ----
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -105,6 +105,7 @@ INSTALLED_APPS = (
     "allauth.socialaccount.providers.jupyterhub",
     "allauth.socialaccount.providers.kakao",
     "allauth.socialaccount.providers.keycloak",
+    "allauth.socialaccount.providers.lemonldap",
     "allauth.socialaccount.providers.line",
     "allauth.socialaccount.providers.linkedin",
     "allauth.socialaccount.providers.linkedin_oauth2",


### PR DESCRIPTION
LemonLDAP::NG (https://lemonldap-ng.org/welcome/) is a web SSO server that supports the OpenID Connect protocol. This implementation is based on existing OAuth2 code

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers.rst`.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.
