### PR TITLE
Fix naming from 'internal_reset_url_token' to 'reset_url_token' in PasswordResetFromKey view

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -725,7 +725,7 @@ class PasswordResetFromKeyView(
     template_name = "account/password_reset_from_key." + app_settings.TEMPLATE_EXTENSION
     form_class = ResetPasswordKeyForm
     success_url = reverse_lazy("account_reset_password_from_key_done")
-    internal_reset_url_key = "set-password"
+    reset_url_key = "set-password"
 
     def get_form_class(self):
         return get_form_class(
@@ -736,7 +736,7 @@ class PasswordResetFromKeyView(
         self.request = request
         self.key = key
 
-        if self.key == self.internal_reset_url_key:
+        if self.key == self.reset_url_key:
             self.key = self.request.session.get(INTERNAL_RESET_SESSION_KEY, "")
             # (Ab)using forms here to be able to handle errors in XHR #890
             token_form = UserTokenForm(data={"uidb36": uidb36, "key": self.key})
@@ -765,7 +765,7 @@ class PasswordResetFromKeyView(
                 # HTTP Referer header.
                 self.request.session[INTERNAL_RESET_SESSION_KEY] = self.key
                 redirect_url = self.request.path.replace(
-                    self.key, self.internal_reset_url_key
+                    self.key, self.reset_url_key
                 )
                 return redirect(redirect_url)
 


### PR DESCRIPTION
# Submitting Pull Requests

The issue was introduced with [that PR](https://github.com/pennersr/django-allauth/pull/2995) which is released under the version 0.48 and it does not correspond to the docs, where we mentioned about [reset_token_url](https://github.com/pennersr/django-allauth/pull/2995/files#diff-0d16353e7f1a8593229f982c23d4c0b092c7840b7a2d9bfd15c4088f70741ec1R20) and not `internal_reset_token_url`.
That was introduced by myself so we should follow the [initial issue](https://github.com/pennersr/django-allauth/issues/2892) where we should follow the [initial Django's PR](https://github.com/django/django/commit/58df8aa40fe88f753ba79e091a52f236246260b3) related to it

## General

 - [X] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [X] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [X] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [X] If your changes are significant, please update `ChangeLog.rst`.
 - [X] If your change is substantial, feel free to add yourself to `AUTHORS`.
