### PR TITLE
fix(kakao): Prevent 'kakao_account' KeyError

### DIFF
--- a/allauth/socialaccount/providers/kakao/provider.py
+++ b/allauth/socialaccount/providers/kakao/provider.py
@@ -25,14 +25,14 @@ class KakaoProvider(OAuth2Provider):
         return str(data["id"])
 
     def extract_common_fields(self, data):
-        email = data["kakao_account"].get("email")
+        email = data.get("kakao_account", {}).get("email")
         nickname = data.get("properties", {}).get("nickname")
 
         return dict(email=email, username=nickname)
 
     def extract_email_addresses(self, data):
         ret = []
-        data = data["kakao_account"]
+        data = data.get("kakao_account", {})
         email = data.get("email")
 
         if email:


### PR DESCRIPTION
# Submitting Pull Requests

According to Kakao official document ([Response of Retrieve user information](https://developers.kakao.com/docs/latest/en/kakaologin/rest-api#req-user-info) section), `kakao_account` is not required. If you don't set any consent items in Kakao Login settings, `kakao_account` does not exist in the response. See the [Consent Items](https://developers.kakao.com/docs/latest/en/kakaologin/prerequisite#consent-item) for more information.

Because of this, KeyError occurred in my project, and I found this bug. I also confirmed that `kakao_account` was in the response when any consent items were set.

I followed this [commit](https://github.com/pennersr/django-allauth/commit/dc66e01dacd3881a46c12241bb8f5820726e04d8).

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
