### PR TITLE
docs: update Microsoft Graph tenant configuration

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1310,16 +1310,17 @@ Apps can be registered (for consumer key and secret) here
     https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade
 
 By default, `common` (`organizations` and `consumers`) tenancy is configured
-for the login. To restrict it, change the `tenant` setting as shown below.
+for the login. To restrict it, change the `TENANT` setting as shown below.
 
 .. code-block:: python
 
     SOCIALACCOUNT_PROVIDERS = {
         'microsoft': {
-            'tenant': 'organizations',
+            'TENANT': 'organizations',
         }
     }
 
+Note: before version 0.49.0, use lowercase `tenant` instead of `TENANT`.
 
 Naver
 -----


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.

## Description

Previously, the Microsoft Graph tenant configuration was read from a lowercase `tenant` key:

https://github.com/pennersr/django-allauth/blob/cfc0e9d2b774c94e5bc57008da369f5c3eda4499/allauth/socialaccount/providers/microsoft/views.py#L40

After https://github.com/pennersr/django-allauth/commit/d5c410bfe211348ba18c0e3200949dd9ca051dee, it was changed to uppercase `TENANT`:

https://github.com/pennersr/django-allauth/blob/46f4a8a72e0940b470c7345574b4eac95365a1ac/allauth/socialaccount/providers/microsoft/views.py#L39

This breaks code which configures the Microsoft Graph provider using `SOCIALACCOUNT_PROVIDERS` in settings.py using lowercase `tenant` instead of `TENANT` after version 0.49.0.