### PR TITLE
feat: make the password reset token generator configurable

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,13 @@
+0.51.0 (unreleased)
+*******************
+
+Note worthy changes
+-------------------
+
+- Introduced a new setting ``ACCOUNT_PASSWORD_RESET_TOKEN_GENERATOR`` that allows
+  you to specify the token generator for password resets.
+
+
 0.50.0 (2022-03-25)
 *******************
 

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -364,6 +364,18 @@ class AppSettings(object):
                 ret = []
         return ret
 
+    @property
+    def PASSWORD_RESET_TOKEN_GENERATOR(self):
+        from allauth.account.forms import EmailAwarePasswordResetTokenGenerator
+        from allauth.utils import import_attribute
+
+        token_generator_path = self._setting("PASSWORD_RESET_TOKEN_GENERATOR", None)
+        if token_generator_path is not None:
+            token_generator = import_attribute(token_generator_path)
+        else:
+            token_generator = EmailAwarePasswordResetTokenGenerator
+        return token_generator
+
 
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -4,6 +4,7 @@ import warnings
 from importlib import import_module
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import exceptions, validators
@@ -13,6 +14,7 @@ from django.utils.translation import gettext, gettext_lazy as _, pgettext
 from ..utils import (
     build_absolute_uri,
     get_username_max_length,
+    import_attribute,
     set_form_field_order,
 )
 from . import app_settings
@@ -47,7 +49,12 @@ class EmailAwarePasswordResetTokenGenerator(PasswordResetTokenGenerator):
         return ret
 
 
-default_token_generator = EmailAwarePasswordResetTokenGenerator()
+if hasattr(settings, "ACCOUNT_PASSWORD_RESET_TOKEN_GENERATOR"):
+    token_generator = import_attribute(settings.ACCOUNT_PASSWORD_RESET_TOKEN_GENERATOR)
+else:
+    token_generator = EmailAwarePasswordResetTokenGenerator
+
+default_token_generator = token_generator()
 
 
 class PasswordVerificationMixin(object):

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -4,7 +4,6 @@ import warnings
 from importlib import import_module
 
 from django import forms
-from django.conf import settings
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import exceptions, validators
@@ -14,7 +13,6 @@ from django.utils.translation import gettext, gettext_lazy as _, pgettext
 from ..utils import (
     build_absolute_uri,
     get_username_max_length,
-    import_attribute,
     set_form_field_order,
 )
 from . import app_settings
@@ -49,12 +47,7 @@ class EmailAwarePasswordResetTokenGenerator(PasswordResetTokenGenerator):
         return ret
 
 
-if hasattr(settings, "ACCOUNT_PASSWORD_RESET_TOKEN_GENERATOR"):
-    token_generator = import_attribute(settings.ACCOUNT_PASSWORD_RESET_TOKEN_GENERATOR)
-else:
-    token_generator = EmailAwarePasswordResetTokenGenerator
-
-default_token_generator = token_generator()
+default_token_generator = app_settings.PASSWORD_RESET_TOKEN_GENERATOR()
 
 
 class PasswordVerificationMixin(object):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -159,6 +159,10 @@ ACCOUNT_LOGOUT_REDIRECT_URL (=`settings.LOGOUT_REDIRECT_URL or "/"`)
 ACCOUNT_PASSWORD_INPUT_RENDER_VALUE (=False)
   ``render_value`` parameter as passed to ``PasswordInput`` fields.
 
+ACCOUNT_PASSWORD_RESET_TOKEN_GENERATOR (=allauth.account.forms.EmailAwarePasswordResetTokenGenerator)
+  A string pointing to a custom token generator (e.g. 'myapp.auth.CustomTokenGenerator') for password resets. This class should implement the
+  same methods as ``django.contrib.auth.tokens.PasswordResetTokenGenerator`` or subclass it.
+
 ACCOUNT_PRESERVE_USERNAME_CASING (=True)
   This setting determines whether the username is stored in lowercase
   (``False``) or whether its casing is to be preserved (``True``). Note that when


### PR DESCRIPTION
This adds facilities to override the default EmailAwarePasswordResetTokenGenrator for users who wish to have custom
behaviour in this flow. Prior to this, the TokenForm class hardcoded only one option, and even subclassing the view was not sufficient to change the behaviour.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
