### PR TITLE
feat: make it possible to provide extra data for access token requests

### DIFF
--- a/allauth/socialaccount/providers/apple/client.py
+++ b/allauth/socialaccount/providers/apple/client.py
@@ -58,7 +58,7 @@ class AppleOAuth2Client(OAuth2Client):
         """We support multiple client_ids, but use the first one for api calls"""
         return self.consumer_key.split(",")[0]
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, **extra_data):
         url = self.access_token_url
         client_secret = self.generate_client_secret()
         data = {
@@ -67,6 +67,7 @@ class AppleOAuth2Client(OAuth2Client):
             "grant_type": "authorization_code",
             "redirect_uri": self.callback_url,
             "client_secret": client_secret,
+            **extra_data
         }
         self._strip_empty_keys(data)
         resp = requests.request(

--- a/allauth/socialaccount/providers/apple/client.py
+++ b/allauth/socialaccount/providers/apple/client.py
@@ -67,7 +67,9 @@ class AppleOAuth2Client(OAuth2Client):
             "grant_type": "authorization_code",
             "redirect_uri": self.callback_url,
             "client_secret": client_secret,
-            **extra_data
+            # Trailing comma added by Black is not compatible with Python 3.5.
+            # https://github.com/psf/black/issues/1356
+            **extra_data  # fmt: skip
         }
         self._strip_empty_keys(data)
         resp = requests.request(

--- a/allauth/socialaccount/providers/feishu/client.py
+++ b/allauth/socialaccount/providers/feishu/client.py
@@ -55,7 +55,9 @@ class FeishuOAuth2Client(OAuth2Client):
             "grant_type": "authorization_code",
             "code": code,
             "app_access_token": self.app_access_token(),
-            **extra_data
+            # Trailing comma added by Black is not compatible with Python 3.5.
+            # https://github.com/psf/black/issues/1356
+            **extra_data  # fmt: skip
         }
         params = None
         self._strip_empty_keys(data)

--- a/allauth/socialaccount/providers/feishu/client.py
+++ b/allauth/socialaccount/providers/feishu/client.py
@@ -50,11 +50,12 @@ class FeishuOAuth2Client(OAuth2Client):
             raise OAuth2Error("Error retrieving app access token: %s" % resp.content)
         return access_token["app_access_token"]
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, **extra_data):
         data = {
             "grant_type": "authorization_code",
             "code": code,
             "app_access_token": self.app_access_token(),
+            **extra_data
         }
         params = None
         self._strip_empty_keys(data)

--- a/allauth/socialaccount/providers/oauth2/client.py
+++ b/allauth/socialaccount/providers/oauth2/client.py
@@ -45,11 +45,12 @@ class OAuth2Client(object):
         params.update(extra_params)
         return "%s?%s" % (authorization_url, urlencode(params))
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, **extra_data):
         data = {
             "redirect_uri": self.callback_url,
             "grant_type": "authorization_code",
             "code": code,
+            **extra_data
         }
         if self.basic_auth:
             auth = requests.auth.HTTPBasicAuth(self.consumer_key, self.consumer_secret)

--- a/allauth/socialaccount/providers/oauth2/client.py
+++ b/allauth/socialaccount/providers/oauth2/client.py
@@ -50,7 +50,9 @@ class OAuth2Client(object):
             "redirect_uri": self.callback_url,
             "grant_type": "authorization_code",
             "code": code,
-            **extra_data
+            # Trailing comma added by Black is not compatible with Python 3.5.
+            # https://github.com/psf/black/issues/1356
+            **extra_data  # fmt: skip
         }
         if self.basic_auth:
             auth = requests.auth.HTTPBasicAuth(self.consumer_key, self.consumer_secret)

--- a/allauth/socialaccount/providers/untappd/client.py
+++ b/allauth/socialaccount/providers/untappd/client.py
@@ -16,7 +16,7 @@ class UntappdOAuth2Client(OAuth2Client):
         * nests access_token inside an extra 'response' object
     """
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, **extra_data):
         data = {
             "client_id": self.consumer_key,
             "redirect_url": self.callback_url,
@@ -24,6 +24,7 @@ class UntappdOAuth2Client(OAuth2Client):
             "response_type": "code",
             "client_secret": self.consumer_secret,
             "code": code,
+            **extra_data
         }
         params = None
         self._strip_empty_keys(data)

--- a/allauth/socialaccount/providers/untappd/client.py
+++ b/allauth/socialaccount/providers/untappd/client.py
@@ -24,7 +24,9 @@ class UntappdOAuth2Client(OAuth2Client):
             "response_type": "code",
             "client_secret": self.consumer_secret,
             "code": code,
-            **extra_data
+            # Trailing comma added by Black is not compatible with Python 3.5.
+            # https://github.com/psf/black/issues/1356
+            **extra_data  # fmt: skip
         }
         params = None
         self._strip_empty_keys(data)

--- a/allauth/socialaccount/providers/weixin/client.py
+++ b/allauth/socialaccount/providers/weixin/client.py
@@ -25,7 +25,7 @@ class WeixinOAuth2Client(OAuth2Client):
             sorted_params[param] = params[param]
         return "%s?%s" % (authorization_url, urlencode(sorted_params))
 
-    def get_access_token(self, code):
+    def get_access_token(self, code, **extra_data):
         data = {
             "appid": self.consumer_key,
             "redirect_uri": self.callback_url,
@@ -33,6 +33,7 @@ class WeixinOAuth2Client(OAuth2Client):
             "secret": self.consumer_secret,
             "scope": self.scope,
             "code": code,
+            **extra_data
         }
         params = None
         self._strip_empty_keys(data)

--- a/allauth/socialaccount/providers/weixin/client.py
+++ b/allauth/socialaccount/providers/weixin/client.py
@@ -33,7 +33,9 @@ class WeixinOAuth2Client(OAuth2Client):
             "secret": self.consumer_secret,
             "scope": self.scope,
             "code": code,
-            **extra_data
+            # Trailing comma added by Black is not compatible with Python 3.5.
+            # https://github.com/psf/black/issues/1356
+            **extra_data  # fmt: skip
         }
         params = None
         self._strip_empty_keys(data)


### PR DESCRIPTION
[dj-rest-auth](https://github.com/iMerica/dj-rest-auth/blob/a2638b438e4ef13c4f12329541b6a5cfb19af83a/dj_rest_auth/registration/serializers.py#L133) and possibly some other libraries and projects based on django-allauth use `OAuth2Client.get_access_token` to exchange authorization codes for access tokens.

It works fine, but it is impossible to support [PKCE](https://oauth.net/2/pkce/) with the current implementation: `code_verifier` cannot be included in requests.

This change makes it possible to provide some extra data to be included in requests (e.g., by calling `get_access_token(code, code_verifier=code_verifier)`).
I did not add a specific `code_verifier` argument to the method because some providers does not support it.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
