### PR TITLE
feat(Facebook): set the default Graph API version to v13.0

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,12 @@
+0.50.0 (unreleased)
+*******************
+
+Note worthy changes
+-------------------
+
+- The Facebook API version now defaults to v13.0.
+
+
 0.49.0 (2022-02-22)
 *******************
 

--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -25,7 +25,7 @@ from .locale import get_default_locale_callable
 GRAPH_API_VERSION = (
     getattr(settings, "SOCIALACCOUNT_PROVIDERS", {})
     .get("facebook", {})
-    .get("VERSION", "v7.0")
+    .get("VERSION", "v13.0")
 )
 GRAPH_API_URL = "https://graph.facebook.com/" + GRAPH_API_VERSION
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -609,7 +609,7 @@ The following Facebook settings are available:
             'EXCHANGE_TOKEN': True,
             'LOCALE_FUNC': 'path.to.callable',
             'VERIFIED_EMAIL': False,
-            'VERSION': 'v7.0',
+            'VERSION': 'v13.0',
         }
     }
 
@@ -677,7 +677,7 @@ VERIFIED_EMAIL:
     risk.
 
 VERSION:
-    The Facebook Graph API version to use. The default is ``v7.0``.
+    The Facebook Graph API version to use. The default is ``v13.0``.
 
 App registration (get your key and secret here)
     A key and secret key can be obtained by


### PR DESCRIPTION
Let's upgrade the default Facebook Graph API version to v13.0 because v7.0 will become unusable on August 4, 2022 according to https://developers.facebook.com/docs/graph-api/changelog/.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
