### PR TITLE
Google Provider: Check for 'sub' if 'id' is not present in 'data'

### DIFF
--- a/allauth/socialaccount/providers/google/provider.py
+++ b/allauth/socialaccount/providers/google/provider.py
@@ -39,7 +39,10 @@ class GoogleProvider(OAuth2Provider):
         return ret
 
     def extract_uid(self, data):
-        return str(data["id"])
+        try:
+            return str(data["id"])
+        except:
+            return str(data["sub"])
 
     def extract_common_fields(self, data):
         return dict(


### PR DESCRIPTION
When ID Token is used, in place of an access token, (as in the case of an android app), a 'sub' key is present instead of 'id' in 'data'. This change considers both keys.