### PR TITLE
feat: Pass password reset path to template for email generation

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -572,6 +572,7 @@ class ResetPasswordForm(forms.Form):
             context = {
                 "current_site": get_current_site(request),
                 "user": user,
+                "password_reset_path": path,
                 "password_reset_url": url,
                 "request": request,
             }


### PR DESCRIPTION
Currently, the password reset url is constructed using
build_absolute_uri() and passed into the email template. This builds the
url based on the server variables available in the request object,
including the base url.

Some platform-as-a-service vendors allow users to deploy their services
behind custom domains, but thje "location" of these servers is still the
generated domain from the PaaS vendor, which leads to the password reset
url looking sketchy. By passing the path to the email template,
consumers of this library can construct their url using their custom
domain without having to override the ResetPasswordForm
