### PR TITLE
fix(documentation): Fix grammar in Signals documentation

### DIFF
--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -57,7 +57,7 @@ allauth.socialaccount
     provided.
 
 - ``allauth.socialaccount.signals.social_account_added(request, sociallogin)``
-    Sent after a user connects a social account to a their local account.
+    Sent after a user connects a social account to their local account.
 
 - ``allauth.socialaccount.signals.social_account_updated(request, sociallogin)``
     Sent after a social account has been updated. This happens when a user


### PR DESCRIPTION
The sentence `Sent after a user connects a social account to a their local account` should not contain the second `a` in there. Removed that.