### PR TITLE
Microsoft provider: add companyName to user_properties

### DIFF
--- a/allauth/socialaccount/providers/microsoft/views.py
+++ b/allauth/socialaccount/providers/microsoft/views.py
@@ -57,6 +57,7 @@ class MicrosoftGraphOAuth2Adapter(OAuth2Adapter):
         "surname",
         "userPrincipalName",
         "mailNickname",
+        "companyName",
     )
     profile_url_params = {"$select": ",".join(user_properties)}
 


### PR DESCRIPTION
# Submitting Pull Requests

 ## Provider Specifics
Extended the Microsoft Graph provider to give the companyName of the user while calling the graph API. 