### PR TITLE
Gitea provider does not work by default with gitea.com

### DIFF
--- a/allauth/socialaccount/providers/gitea/views.py
+++ b/allauth/socialaccount/providers/gitea/views.py
@@ -15,10 +15,9 @@ class GiteaOAuth2Adapter(OAuth2Adapter):
 
     if "GITEA_URL" in settings:
         web_url = settings.get("GITEA_URL").rstrip("/")
-        api_url = "{0}/api/v1".format(web_url)
     else:
         web_url = "https://gitea.com"
-        api_url = "https://gitea.com"
+    api_url = "{0}/api/v1".format(web_url)
 
     access_token_url = "{0}/login/oauth/access_token".format(web_url)
     authorize_url = "{0}/login/oauth/authorize".format(web_url)


### PR DESCRIPTION
Fix #3106

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
