### PR TITLE
feat(accounts): add key to password reset template

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -563,9 +563,10 @@ class ResetPasswordForm(forms.Form):
             # password_reset.save()
 
             # send the password reset email
+            uid = user_pk_to_url_str(user)
             path = reverse(
                 "account_reset_password_from_key",
-                kwargs=dict(uidb36=user_pk_to_url_str(user), key=temp_key),
+                kwargs=dict(uidb36=uid, key=temp_key),
             )
             url = build_absolute_uri(request, path)
 
@@ -573,6 +574,8 @@ class ResetPasswordForm(forms.Form):
                 "current_site": get_current_site(request),
                 "user": user,
                 "password_reset_url": url,
+                "uid": uid,
+                "key": temp_key,
                 "request": request,
             }
 


### PR DESCRIPTION
Currently, the password reset email template gets passed the full URL to
the password reset endpoint. However, in some scenarios, this endpoint
isn't the location where the user will actually perform the password
reset data entry, for example if Django only hosts an API backend and
the user-facing part instead is implemented via a SPA.

To make it easier to integrate such setups with allauth, this change
additionally passes the uid and key to the password reset email
template. This provides full control to the template author to generate
their own password reset links and support a split frontend/backend.