### PR TITLE
docs: formatting problem

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -174,7 +174,7 @@ ACCOUNT_PREVENT_ENUMERATION (=True)
   is always sent, regardless of whether or not the account exists. Note that
   there is a slight usability tax to pay because there is no immediate feedback.
   **Warning**: this is a work in progress, password reset is covered, yet,
-   signing up is not.
+  signing up is not.
 
 ACCOUNT_RATE_LIMITS
   In order to be secure out of the box various rate limits are in place. The


### PR DESCRIPTION
The old behavior is a blockquote instead of a line continuation, as seen in https://django-allauth.readthedocs.io/en/latest/configuration.html

# Submitting Pull Requests

## General

 - [X] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).