### PR TITLE
Allow simple e-mail replacement when MAX_EMAIL_ADDRESSES=1

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -634,3 +634,40 @@ class UserTokenForm(forms.Form):
             raise forms.ValidationError(self.error_messages["token_invalid"])
 
         return cleaned_data
+
+
+class EmailChangeForm(forms.Form):
+    email = forms.EmailField(label=_("New e-mail"), max_length=100, required=True)
+
+    email_rewritten = forms.EmailField(
+        label=_("Rewrite new e-mail"), max_length=100, required=True
+    )
+
+    def __init__(self, *args, user=None, **kwargs):
+        self.user = user
+        super(EmailChangeForm, self).__init__(*args, **kwargs)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data["email"] != cleaned_data["email_rewritten"]:
+            raise forms.ValidationError(_("E-mail addresses do not match."))
+
+    def clean_email(self):
+        email = self.cleaned_data["email"]
+        errors = {
+            "this_account": _(
+                "This e-mail address is already associated with this account."
+            ),
+            "different_account": _(
+                "This e-mail address is already associated with another account."
+            ),
+        }
+        users = filter_users_by_email(email)
+        on_this_account = [u for u in users if u.pk == self.user.pk]
+        on_diff_account = [u for u in users if u.pk != self.user.pk]
+
+        if on_this_account:
+            raise forms.ValidationError(errors["this_account"])
+        if on_diff_account:
+            raise forms.ValidationError(errors["different_account"])
+        return email

--- a/allauth/templates/account/email.html
+++ b/allauth/templates/account/email.html
@@ -52,6 +52,14 @@
         {{ form.as_p }}
         <button name="action_add" type="submit">{% trans "Add E-mail" %}</button>
     </form>
+  {% elif can_replace_email %}
+    <h2>{% trans "Change E-mail Address" %}</h2>
+
+    <form method="post" action="{% url 'account_email' %}" class="change_email">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button name="action_replace_one" type="submit">{% trans "Change E-mail" %}</button>
+    </form>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Closes: https://github.com/pennersr/django-allauth/issues/3062

This is just a draft to show general idea.   
But I am not whether is there any chance of getting a review and merging it, because there are a lot of PR-s without any review or comment from maintainers. Is this repo actively maintained? (If yes, I will finish this code and change from draft to proper PR)

I think this code would be very useful in cases when we expect from users having one email.  
In general this case complicates process of changing email, because you can't add a new one and remove old one, nor remove old one to add a new one (when users have to have emails linked with accounts).

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.
 
 ## Other things to do

- [ ] Fix tests
- [ ] Add migration
- [ ] Test it manually with my app