### PR TITLE
docs: Fix a few typos

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -393,7 +393,7 @@ class SignupForm(BaseSignupForm):
 
         # `password` cannot be of type `SetPasswordField`, as we don't
         # have a `User` yet. So, let's populate a dummy user to be used
-        # for password validaton.
+        # for password validation.
         User = get_user_model()
         dummy_user = User()
         user_username(dummy_user, self.cleaned_data.get("username"))

--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -150,7 +150,7 @@ class DefaultSocialAccountAdapter(object):
                         # Oops, another user already has this address.
                         # We cannot simply connect this social account
                         # to the existing user. Reason is that the
-                        # email adress may not be verified, meaning,
+                        # email address may not be verified, meaning,
                         # the user may be a hacker that has added your
                         # email address to their account in the hope
                         # that you fall in their trap.  We cannot

--- a/allauth/socialaccount/providers/base/provider.py
+++ b/allauth/socialaccount/providers/base/provider.py
@@ -170,7 +170,7 @@ class ProviderAccount(object):
                     dflt = super(GoogleAccount, self).__str__()
                     return self.account.extra_data.get('name', dflt)
 
-        So we have this method `to_str` that can be overriden in a conventional
+        So we have this method `to_str` that can be overridden in a conventional
         fashion, without having to worry about it.
         """
         return self.get_brand()["name"]

--- a/allauth/socialaccount/providers/dataporten/views.py
+++ b/allauth/socialaccount/providers/dataporten/views.py
@@ -29,7 +29,7 @@ class DataportenAdapter(OAuth2Adapter):
             by the methods of the DataportenProvider view, i.e.
             extract_uid(), extract_extra_data(), and extract_common_fields()
         """
-        # The athentication header
+        # The authentication header
         headers = {"Authorization": "Bearer " + token.token}
 
         # Userinfo endpoint, for documentation see:

--- a/allauth/socialaccount/providers/trainingpeaks/views.py
+++ b/allauth/socialaccount/providers/trainingpeaks/views.py
@@ -19,7 +19,7 @@ class TrainingPeaksOAuth2Adapter(OAuth2Adapter):
         return app_settings.PROVIDERS.get(self.provider_id, {})
 
     def get_hostname(self):
-        """Return hostname depending on sandbox seting"""
+        """Return hostname depending on sandbox setting"""
         settings = self.get_settings()
         if settings.get("USE_PRODUCTION"):
             return "trainingpeaks.com"

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -275,7 +275,7 @@ SCOPE:
 REGION:
     Either ``apac``, ``cn``, ``eu``, ``kr``, ``sea``, ``tw`` or ``us``
 
-    Sets the default region to use, can be overriden using query parameters
+    Sets the default region to use, can be overridden using query parameters
     in the URL, for example: ``?region=eu``. Defaults to ``us``.
 
 Bitbucket
@@ -422,7 +422,7 @@ Authentication documentation
 Development callback URL
     https://localhost:8000/accounts/drip/login/callback/
 
-Make sure the registed application is active.
+Make sure the registered application is active.
 
 
 Dropbox


### PR DESCRIPTION
There are small typos in:
- allauth/account/forms.py
- allauth/socialaccount/adapter.py
- allauth/socialaccount/providers/base/provider.py
- allauth/socialaccount/providers/dataporten/views.py
- allauth/socialaccount/providers/trainingpeaks/views.py
- docs/providers.rst

Fixes:
- Should read `overridden` rather than `overriden`.
- Should read `validation` rather than `validaton`.
- Should read `setting` rather than `seting`.
- Should read `registered` rather than `registed`.
- Should read `authentication` rather than `athentication`.
- Should read `address` rather than `adress`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md