### PR TITLE
save only updated fields

### DIFF
--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -48,7 +48,8 @@ class EmailAddress(models.Model):
         self.primary = True
         self.save()
         user_email(self.user, self.email)
-        self.user.save()
+        if app_settings.USER_MODEL_EMAIL_FIELD:
+            self.user.save(update_fields=[app_settings.USER_MODEL_EMAIL_FIELD])
         return True
 
     def send_confirmation(self, request=None, signup=False):
@@ -65,7 +66,8 @@ class EmailAddress(models.Model):
         """
         with transaction.atomic():
             user_email(self.user, new_email)
-            self.user.save()
+            if app_settings.USER_MODEL_EMAIL_FIELD:
+                self.user.save(update_fields=[app_settings.USER_MODEL_EMAIL_FIELD])
             self.email = new_email
             self.verified = False
             self.save()

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -93,6 +93,58 @@ class AccountTests(TestCase):
             resp, settings.LOGIN_REDIRECT_URL, fetch_redirect_response=False
         )
 
+    def test_set_email_as_primary_doesnt_override_existed_changes_on_the_user(self):
+        user = get_user_model().objects.create(
+            username="@raymond.penners", first_name="Before Update"
+        )
+        email = EmailAddress.objects.create(
+            user=user,
+            email="raymond.penners@example.com",
+            primary=True,
+            verified=True,
+        )
+        updated_first_name = "Updated"
+        get_user_model().objects.filter(id=user.id).update(
+            first_name=updated_first_name
+        )
+
+        email.set_as_primary()
+
+        user.refresh_from_db()
+        self.assertEqual(user.first_name, updated_first_name)
+
+    def test_set_new_email_doesnt_override_existed_changes_on_the_user(self):
+        user = get_user_model().objects.create(
+            username="@raymond.penners", first_name="Before Update"
+        )
+        email = EmailAddress.objects.create(
+            user=user,
+            email="raymond.penners@example.com",
+            primary=False,
+            verified=True,
+        )
+        updated_first_name = "Updated"
+        get_user_model().objects.filter(id=user.id).update(
+            first_name=updated_first_name
+        )
+
+        email.change(None, 'new.raymond.penners@example.com"', confirm=False)
+
+        user.refresh_from_db()
+        self.assertEqual(user.first_name, updated_first_name)
+
+    @override_settings(ACCOUNT_USER_MODEL_EMAIL_FIELD=None)
+    def test_set_email_as_primary_doesnt_override_existed_changes_on_the_user_for_user_model_without_email_field(
+        self,
+    ):
+        self.test_set_email_as_primary_doesnt_override_existed_changes_on_the_user()
+
+    @override_settings(ACCOUNT_USER_MODEL_EMAIL_FIELD=None)
+    def test_set_new_email_doesnt_override_existed_changes_on_the_user_when_user_model_without_email_field(
+        self,
+    ):
+        self.test_set_new_email_doesnt_override_existed_changes_on_the_user()
+
     def test_signup_same_email_verified_externally(self):
         user = self._test_signup_email_verified_externally(
             "john@example.com", "john@example.com"


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics
There is possible to get raise conditions. I.e.

1. allauth update email field of the user in the memory
2. another process update some other user fields
3. allauth save user into DB and this will override all changes on step 2

My point that is better to specify fields to update, in order to keep changes(https://docs.djangoproject.com/en/4.0/ref/models/instances/#specifying-which-fields-to-save).
But cons of that solution that could be some fields that should be updated on the user save, ie `updated_at` and because it's not specified they wont updated during save.

