### PR TITLE
fix(template tags): Update templates.rst

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -43,6 +43,10 @@ Or, if you need to use in a ``{% blocktrans %}``::
 Then, override the ``ACCOUNT_USER_DISPLAY`` setting with your project
 specific user display callable.
 
+If you set ``ACCOUNT_USERNAME_REQUIRED = False`` and ``ACCOUNT_USER_MODEL_USERNAME_FIELD = None``,
+then you can simply display the user.email with {{ user }}::
+    
+    In case you forgot, your username is {{ user }}.
 
 Social Account Tags
 *******************


### PR DESCRIPTION
Since I disabled the username field for my project, I struggled to understand how to display user email in template tags.
Until I simply used {{ user }} tag, after trying to override the view and the form to custom the get_context_data to retrieve the email.
I thought it could be useful to add it clearly in your documentation.
Your lib and documentation is great by the way, thanks for your work!