### PR TITLE
feat(account): change adapter allowing easy email customization with …

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -124,12 +124,14 @@ class DefaultAccountAdapter(object):
                 if ext == "txt" and not bodies:
                     # We need at least one body
                     raise
-        if "txt" in bodies:
+        if "html" in bodies and "txt" in bodies:
             msg = EmailMultiAlternatives(
-                subject, bodies["txt"], from_email, to, headers=headers
+                subject, bodies["html"], from_email, to, headers=headers
             )
-            if "html" in bodies:
-                msg.attach_alternative(bodies["html"], "text/html")
+            msg.attach_alternative(bodies["txt"], "text/html")
+        elif "txt" in bodies:
+            msg = EmailMessage(subject, bodies["txt"], from_email, to, headers=headers)
+            msg.content_subtype = "txt"  # Main content is now text/html
         else:
             msg = EmailMessage(subject, bodies["html"], from_email, to, headers=headers)
             msg.content_subtype = "html"  # Main content is now text/html


### PR DESCRIPTION
Hello! 
I'm making this pull request with little changes just to allow more easier email styling and customization. 

What it does is add a few if statments modification on adapter.py / render_mail method 

So, if someone wants to add html templates to the allauth mails. It just need's to add the template in the correct folder structure.

if html template exists and txt template exists. It sends the email with html content as main and txt as alternative.

if only txt template exist it send email with txt template

else
send the email with html template

Thank you!