### PR TITLE
Fetch keycloak userinfo with GET

### DIFF
--- a/allauth/socialaccount/providers/keycloak/views.py
+++ b/allauth/socialaccount/providers/keycloak/views.py
@@ -30,7 +30,7 @@ class KeycloakOAuth2Adapter(OAuth2Adapter):
     profile_url = "{0}/protocol/openid-connect/userinfo".format(server_base_url)
 
     def complete_login(self, request, app, token, response):
-        response = requests.post(
+        response = requests.get(
             self.profile_url, headers={"Authorization": "Bearer " + str(token)}
         )
         response.raise_for_status()


### PR DESCRIPTION
Keycloak v20.0.0 does not support fetching userinfo with POST.

# Submitting Pull Requests

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
