### PR TITLE
fix(apple): return HttpResponseNotAllowed instead of trying to raise it

### DIFF
--- a/allauth/socialaccount/providers/apple/views.py
+++ b/allauth/socialaccount/providers/apple/views.py
@@ -151,7 +151,7 @@ def apple_post_callback(request, finish_endpoint_name="apple_finish_callback"):
             callback endpoint.
     """
     if request.method != "POST":
-        raise HttpResponseNotAllowed(["POST"])
+        return HttpResponseNotAllowed(["POST"])
     add_apple_session(request)
 
     # Add regular OAuth2 params to the URL - reduces the overrides required


### PR DESCRIPTION
Fixes https://github.com/pennersr/django-allauth/issues/2821. `HttpResponseNotAllowed` is not an exception, so it cannot be raised and must be returned instead.