### PR TITLE
chore(oauth): show an informative log when OAuthError is raised

### DIFF
--- a/allauth/socialaccount/providers/oauth/client.py
+++ b/allauth/socialaccount/providers/oauth/client.py
@@ -82,8 +82,9 @@ class OAuthClient(object):
             response = requests.post(url=rt_url, auth=oauth)
             if response.status_code not in [200, 201]:
                 raise OAuthError(
-                    _("Invalid response while obtaining request token" ' from "%s".')
-                    % get_token_prefix(self.request_token_url)
+                    _("Invalid response while obtaining request token from " +
+                         f"{get_token_prefix(self.request_token_url)}. " +
+                            f"Response text: {response.text}")
                 )
             self.request_token = dict(parse_qsl(response.text))
             self.request.session[

--- a/allauth/socialaccount/providers/oauth/views.py
+++ b/allauth/socialaccount/providers/oauth/views.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import logging
 from django.urls import reverse
 
 from allauth.socialaccount import providers
@@ -18,6 +19,7 @@ from allauth.socialaccount.providers.oauth.client import (
     OAuthError,
 )
 
+logger = logging.getLogger(__name__)
 
 class OAuthAdapter(object):
     def __init__(self, request):
@@ -76,6 +78,7 @@ class OAuthLoginView(OAuthLoginMixin, OAuthView):
         try:
             return client.get_redirect(auth_url, auth_params)
         except OAuthError as e:
+            logger.exception('Error processing OAuth')
             return render_authentication_error(
                 request, self.adapter.provider_id, exception=e
             )


### PR DESCRIPTION
This is similar to the way facebook/views.py logs an exception.

This feature was requested on https://github.com/pennersr/django-allauth/issues/2142.

The original (closed) PR: https://github.com/pennersr/django-allauth/pull/2175

Sample log:
```
Error processing OAuth
Traceback (most recent call last):
  File "/Users/ykdojo/Desktop/django-allauth/allauth/socialaccount/providers/oauth/views.py", line 79, in login
    return client.get_redirect(auth_url, auth_params)
  File "/Users/ykdojo/Desktop/django-allauth/allauth/socialaccount/providers/oauth/client.py", line 157, in get_redirect
    request_token = self._get_request_token()
  File "/Users/ykdojo/Desktop/django-allauth/allauth/socialaccount/providers/oauth/client.py", line 84, in _get_request_token
    raise OAuthError(
allauth.socialaccount.providers.oauth.client.OAuthError: Invalid response while obtaining request token from api.twitter.com. Response text: <?xml version='1.0' encoding='UTF-8'?><errors><error code="415">Callback URL not approved for this client application. Approved callback URLs can be adjusted in your application settings</error></errors>
```

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
