### PR TITLE
fix(account): Custom user without first/last name

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -16,6 +16,7 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import EmailMessage, EmailMultiAlternatives
+from django.db.models import CharField, EmailField
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import resolve_url
 from django.template import TemplateDoesNotExist
@@ -483,15 +484,11 @@ class DefaultAccountAdapter(object):
 
     def get_user_search_fields(self):
         user = get_user_model()()
-        return filter(
-            lambda a: a and hasattr(user, a),
-            [
-                app_settings.USER_MODEL_USERNAME_FIELD,
-                "first_name",
-                "last_name",
-                "email",
-            ],
-        )
+        return [
+            f.name
+            for f in user._meta.fields
+            if type(f) in [CharField, EmailField] and f.name != "password"
+        ]
 
     def is_safe_url(self, url):
         try:


### PR DESCRIPTION
If a custom user model is used that doesn't contain fields for first name or last name, a search in EmailAddressAdmin fails with a FieldError:

> Related Field got invalid lookup: first_name

If someone can improve this pull request by adding a regression test, please do! 🙏🏻 

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
