### PR TITLE
feat(facebook): Make Graph API URL configurable

### DIFF
--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -27,7 +27,11 @@ GRAPH_API_VERSION = (
     .get("facebook", {})
     .get("VERSION", "v13.0")
 )
-GRAPH_API_URL = "https://graph.facebook.com/" + GRAPH_API_VERSION
+GRAPH_API_URL = (
+    getattr(settings, "SOCIALACCOUNT_PROVIDERS", {})
+    .get("facebook", {})
+    .get("GRAPH_API_URL", "https://graph.facebook.com/{}".format(GRAPH_API_VERSION))
+)
 
 NONCE_SESSION_KEY = "allauth_facebook_nonce"
 NONCE_LENGTH = 32

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -632,6 +632,7 @@ The following Facebook settings are available:
             'LOCALE_FUNC': 'path.to.callable',
             'VERIFIED_EMAIL': False,
             'VERSION': 'v13.0',
+            'GRAPH_API_URL': 'https://graph.facebook.com/v13.0',
         }
     }
 


### PR DESCRIPTION
This change makes the Facebook Graph API URL configurable via a provider setting which enables use-cases such as overriding the endpoint during integration tests to talk to a fake version of the API.