### PR TITLE
Fix instagram provider scope "basic" is not valid

### DIFF
--- a/allauth/socialaccount/providers/instagram/provider.py
+++ b/allauth/socialaccount/providers/instagram/provider.py
@@ -23,7 +23,7 @@ class InstagramProvider(OAuth2Provider):
         return data
 
     def get_default_scope(self):
-        return ["basic"]
+        return ["user_profile", "user_media"]
 
     def extract_uid(self, data):
         return str(data["id"])


### PR DESCRIPTION
Closes #3226