### PR TITLE
fix(accounts): Friendlier implementation of account enumeration protection

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,13 @@
+UNRELEASED
+*******************
+
+Note worthy changes
+-------------------
+
+- Make the account enumeration prevention in ``BaseSignupForm`` friendlier to
+  inheritance.
+
+
 0.54.0 (2023-03-31)
 *******************
 

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -436,10 +436,9 @@ class SignupForm(BaseSignupForm):
 
     def save(self, request):
         if self.account_already_exists:
-            # Don't create a new acount, only send an email informing the user
-            # that (s)he already has one...
-            self._send_account_already_exists_mail(request)
-            return
+            raise TypeError(
+                f"Cannot save changes through {self.__class__.__name__} form for an existing user."
+            )
         adapter = get_adapter(request)
         user = adapter.new_user(request)
         adapter.save_user(request, user, self)
@@ -447,23 +446,6 @@ class SignupForm(BaseSignupForm):
         # TODO: Move into adapter `save_user` ?
         setup_user_email(request, user, [])
         return user
-
-    def _send_account_already_exists_mail(self, request):
-        signup_url = build_absolute_uri(request, reverse("account_signup"))
-        password_reset_url = build_absolute_uri(
-            request, reverse("account_reset_password")
-        )
-        email = self.cleaned_data["email"]
-        context = {
-            "request": request,
-            "current_site": get_current_site(request),
-            "email": email,
-            "signup_url": signup_url,
-            "password_reset_url": password_reset_url,
-        }
-        get_adapter(request).send_mail(
-            "account/email/account_already_exists", email, context
-        )
 
 
 class UserForm(forms.Form):


### PR DESCRIPTION
Since commit a807e5db411c4762310552bb4b882ca9285888f1, the user returned
by `SignupForm.save()` can be `None`. That causes issues for subclasses
not designed to handle receiving `None` when the saving failed (see [1]).

Maintaining the old behavior is possible, the view should generate the
response and send the email, based on the form state. It also makes the
interface clearer: the form validates data, the view decides on how to
present it to users.

Prevent users from inadvertently calling `SignupForm.save()` on a form
instance with `account_already_exists=True`, which could result in
overwriting another user data. For example, that mistake could happen
when subclassing SignupView and forgetting to call
`super().form_valid()`.

[1]
```python
class MySignupForm(SignupForm):
    def save(self, request):
        user = super().save(request)
        # Does not expect user to be `None`.
        do_something_with_user(user)
        return user
```


# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers.rst`.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.