### PR TITLE
fix(accounts): Make `request` object available to AccountAdapter during sing-up

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -283,6 +283,7 @@ class BaseSignupForm(_base_signup_form_class()):
     )
 
     def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
         email_required = kwargs.pop("email_required", app_settings.EMAIL_REQUIRED)
         self.username_required = kwargs.pop(
             "username_required", app_settings.USERNAME_REQUIRED
@@ -365,7 +366,7 @@ class BaseSignupForm(_base_signup_form_class()):
         return value
 
     def validate_unique_email(self, value):
-        return get_adapter().validate_unique_email(value)
+        return get_adapter(self.request).validate_unique_email(value)
 
     def clean(self):
         cleaned_data = super(BaseSignupForm, self).clean()

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -233,6 +233,11 @@ class SignupView(
     def dispatch(self, request, *args, **kwargs):
         return super(SignupView, self).dispatch(request, *args, **kwargs)
 
+    def get_form_kwargs(self):
+        kwargs = super(SignupView, self).get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
+
     def get_form_class(self):
         return get_form_class(app_settings.FORMS, "signup", self.form_class)
 


### PR DESCRIPTION
The `request` object is already forwarded from LoginView -> LoginForm -> DefaultAccountAdapter. This does the same for SignupView -> BaseSignupForm -> DefaultAccountAdapter.

The purpose is to enable lib users who override `DefaultAccountAdapter` to make sign-up decisions based on `request`. For example, handling signups differently for different Sites.
