### PR TITLE
fix(oauth2): Set PKCE Code Verifier length to 128

### DIFF
--- a/allauth/socialaccount/providers/oauth2/utils.py
+++ b/allauth/socialaccount/providers/oauth2/utils.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-import random
 
 
 try:
@@ -17,9 +16,8 @@ except ImportError:
 
 
 def generate_code_challenge():
-    # minimum length of 43 characters, maximum length of 128 characters
-    nbytes = random.randint(43, 128)
-    code_verifier = token_urlsafe(nbytes)
+    # Create a code verifier with a length of 128 characters
+    code_verifier = token_urlsafe(96)
     hashed_verifier = hashlib.sha256(code_verifier.encode("ascii"))
     code_challenge = base64.urlsafe_b64encode(hashed_verifier.digest())
     code_challenge_without_padding = code_challenge.rstrip(b"=")


### PR DESCRIPTION
Set the length of the generated PKCE code verifier to exactly 128 characters, as it is the maximum length allowed by RFC 7636. Using the maximum length adds entropy and, by this, security.

fixes pennersr/django-allauth#3237
