### PR TITLE
fix(socialaccounts): stop ACCOUNT_PREVENT_ENUMERATION from silencing non-unique socialaccount email validation

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,12 @@
+UNRELEASED
+*******************
+
+Note worthy changes
+-------------------
+
+- Fixed bug (``IntegrityError``) after signing up with a social account when
+  ``ACCOUNT_PREVENT_ENUMERATION`` is turned on.
+
 0.52.0 (2022-12-29)
 *******************
 

--- a/allauth/socialaccount/forms.py
+++ b/allauth/socialaccount/forms.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 from django import forms
 
 from allauth.account.forms import BaseSignupForm
+from allauth.account.adapter import get_adapter as get_account_adapter
+from allauth.account import app_settings as account_settings
 
 from . import app_settings, signals
 from .adapter import get_adapter
@@ -37,6 +39,13 @@ class SignupForm(BaseSignupForm):
                 get_adapter().error_messages["email_taken"]
                 % self.sociallogin.account.get_provider().name
             )
+
+    def clean_email(self):
+        value = self.cleaned_data["email"]
+        value = get_account_adapter().clean_email(value)
+        if value and account_settings.UNIQUE_EMAIL:
+            value = self.validate_unique_email(value)
+        return value
 
 
 class DisconnectForm(forms.Form):


### PR DESCRIPTION
Assume the following settings to ensure [self.prevent_enumeration](https://github.com/pennersr/django-allauth/commit/a807e5db411c4762310552bb4b882ca9285888f1#diff-aca468f72aa7648b36b8ee86a25c3ade350120bc2769cd875e418b1f50574935R293) is `True`.

ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
ACCOUNT_EMAIL_REQUIRED = True
ACCOUNT_PREVENT_ENUMERATION = True (by default)

Let's say Bob creates an account using the account signup form soon after verifying his email. Bob comes back a few days later and wants to log in again, but his social login with the exact same email instead of the account login because he forgot. Since Bob hasn't associated his social account with his original account but is still trying to use the same email to log in, the auto sign-up will [fail](https://github.com/pennersr/django-allauth/commit/20f8dcd68765ff4e30bc266934692dcf6278dff1#diff-486770af5efe5e4a98cddf2e5f010886fad281966fee07a984e5b4f3ac49a941R121) and the social login view would redirect Bob to the socialaccount signup form, which would prompt him to enter an email and username (because `ACCOUNT_EMAIL_VERIFICATION` is mandatory). And once submitted, since the email is non-unique, the form would then display an error on submission asking for Bob to log into his original user account and then connect his social login to that account.

This flow was perfectly valid until a small oversight in a807e5d, where the addition of an `accounts` setting had an unintentional side effect on `socialaccounts`. Following a807e5d, the auto-sign up still fails, but now if Bob were to enter to same email, django-allauth throws `IntegrityError at ... UNIQUE constraint failed`

The `SignupForm` class in `socialaccount` inherits the `BaseSignupForm` class from `account`, unintentionally sharing the `BaseSignupForm.clean_email` method between `account` and `socialaccount` and bringing part of the `prevent_enumeration` accounts validation functionality to the social signup. Upon the social signup form's `is_valid` method, `BaseSignupForm.clean_email` is called, which silences unique constraint validation errors when `self.prevent_enumeration` is `True`. This allows the form to be incorrectly considered valid and forces the django to anyways try to save the invalid email to the database, throwing the constraint error.

My fix simply overwrites clean_email in SignupForm, copying the code from before a807e5d. I do understand that `ACCOUNT_PREVENT_ENUMERATION` is currently a work-in-progress, so it is possible for this to conflict with any future changes to the feature or related code.


# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers.rst`.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.
