### PR TITLE
fix(openid-connect): add missing email to common fields

### DIFF
--- a/allauth/socialaccount/providers/openid_connect/provider.py
+++ b/allauth/socialaccount/providers/openid_connect/provider.py
@@ -42,6 +42,7 @@ class OpenIDConnectProvider(OAuth2Provider):
 
     def extract_common_fields(self, data):
         return dict(
+            email=data.get("email"),
             username=data.get("preferred_username"),
             name=data.get("name"),
             user_id=data.get("user_id"),


### PR DESCRIPTION
only common fields are used to populate user attributes and email was missing

Closes #3241
