### PR TITLE
fix(accounts): Typo fix in password reset message

### DIFF
--- a/allauth/templates/account/email/password_reset_key_message.txt
+++ b/allauth/templates/account/email/password_reset_key_message.txt
@@ -1,7 +1,7 @@
 {% extends "account/email/base_message.txt" %}
 {% load i18n %}
 
-{% block content %}{% autoescape off %}{% blocktrans %}You're receiving this e-mail because you or someone else has requested a password for your user account.
+{% block content %}{% autoescape off %}{% blocktrans %}You're receiving this e-mail because you or someone else has requested a password reset for your user account.
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
 
 {{ password_reset_url }}{% if username %}


### PR DESCRIPTION
The email sent when a password reset is requested by a user states that a password was requested. Added reset to improve clarity 