### PR TITLE
feat(account): Add SEND_ACCOUNT_ALREADY_EXISTS_EMAIL config

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -51,6 +51,10 @@ class AppSettings(object):
         return self._setting("PREVENT_ENUMERATION", True)
 
     @property
+    def SEND_ACCOUNT_ALREADY_EXISTS_EMAIL(self):
+        return self._setting("SEND_ACCOUNT_ALREADY_EXISTS_EMAIL", True)
+
+    @property
     def DEFAULT_HTTP_PROTOCOL(self):
         return self._setting("DEFAULT_HTTP_PROTOCOL", "http").lower()
 

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -449,6 +449,8 @@ class SignupForm(BaseSignupForm):
         return user
 
     def _send_account_already_exists_mail(self, request):
+        if not app_settings.SEND_ACCOUNT_ALREADY_EXISTS_EMAIL:
+            return
         signup_url = build_absolute_uri(request, reverse("account_signup"))
         password_reset_url = build_absolute_uri(
             request, reverse("account_reset_password")

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -170,11 +170,12 @@ ACCOUNT_PREVENT_ENUMERATION (=True)
   Controls whether or not information is revealed about whether or not a user
   account exists. For example, by entering random email addresses in the
   password reset form you can test whether or not those email addresses are
-  associated with an account. Enabling this setting prevents that, and an email
-  is always sent, regardless of whether or not the account exists. Note that
-  there is a slight usability tax to pay because there is no immediate feedback.
-  **Warning**: this is a work in progress, password reset is covered, yet,
-  signing up is not.
+  associated with an account. Enabling this setting prevents that, and sends
+  an email to the user (configurable through
+  ``ACCOUNT_SEND_ACCOUNT_ALREADY_EXISTS_EMAIL``), regardless of whether or not
+  the account exists. Note that there is a slight usability tax to pay because
+  there is no immediate feedback. **Warning**: this is a work in progress,
+  password reset is covered, yet, signing up is not.
 
 ACCOUNT_RATE_LIMITS
   In order to be secure out of the box various rate limits are in place. The
@@ -198,6 +199,12 @@ ACCOUNT_RATE_LIMITS
         "signup": "20/m",
         # NOTE: Login is already protected via `ACCOUNT_LOGIN_ATTEMPTS_LIMIT`
     }
+
+
+ACCOUNT_SEND_ACCOUNT_ALREADY_EXISTS_EMAIL (=True)
+  Control whether an email is sent to inform the user an account already
+  exists when they try signing up with the pre-existing email. See
+  ``ACCOUNT_PREVENT_ENUMERATION``.
 
 
 ACCOUNT_SESSION_REMEMBER (=None)


### PR DESCRIPTION
When `ACCOUNT_PREVENT_ENUMERATION` is set to `True`, signing up with an existing email address will send an "account already exists" email to the user. I'd like to skip sending that email and let it no-op silently.

I'm currently overriding the method in the form, and I think this would be a good configuration option to have.

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

n/a