### PR TITLE
fix(accounts): Allow dynamic redirect to ALLOWED_HOSTS after login

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -501,7 +501,7 @@ class DefaultAccountAdapter(object):
                 is_safe_url as url_has_allowed_host_and_scheme,
             )
 
-        return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
+        return url_has_allowed_host_and_scheme(url, allowed_hosts=settings.ALLOWED_HOSTS)
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         """Constructs the email confirmation (activation) url.

--- a/allauth/account/tests.py
+++ b/allauth/account/tests.py
@@ -1515,6 +1515,11 @@ class UtilsTests(TestCase):
             content = t.render(Context({"user": user}))
             self.assertEqual(content, expected_name)
 
+    @override_settings(ALLOWED_HOSTS=['allowed_host'])
+    def test_is_safe_url_allowed_hosts(self):
+        self.assertTrue(get_adapter().is_safe_url('http://allowed_host/'))
+        self.assertFalse(get_adapter().is_safe_url('http://other_host/'))
+
 
 class ConfirmationViewTests(TestCase):
     def _create_user(self, username="john", password="doe"):


### PR DESCRIPTION
### Description
Nowadays, many products separate their monoliths into services. In this case, the authorization service is a backend for a bunch of others, and we need to take some parameter in order to understand where the user came from and where to return him upon successful authentication. For example, Microsoft active-directory [suggests](https://learn.microsoft.com/en-us/azure/active-directory/develop/reply-url#use-a-state-parameter:~:text=redirect%20users%20to%20the%20same%20page%20from%20which%20they%20started)  to use `state` for that, but judging by the existing django-allauth code, it is obvious that the `next` parameter is suitable for this. The code even already implements a check for the validity of the host, but for some reason any host is perceived as invalid.

This issue has been open for 5 years now: https://github.com/pennersr/django-allauth/issues/1766
With at least 4 abandoned fix attempts: https://github.com/pennersr/django-allauth/pull/1782, https://github.com/pennersr/django-allauth/pull/2411, https://github.com/pennersr/django-allauth/pull/2442, https://github.com/pennersr/django-allauth/pull/2874
I think it's time to finally fix the issue.

### Implementation
The problem is that we are passing `None` as `allowed_hosts` to [url_has_allowed_host_and_scheme](https://github.com/mecampbellsoup/django-allauth/blob/2fa7038a53e77dad504624584d2a533d08a3e7d1/allauth/account/adapter.py#L438). Instead, I suggest passing there Django's [ALLOWED_HOSTS](https://docs.djangoproject.com/en/4.1/ref/settings/#allowed-hosts).
If you think it's better to have a separate parameter, then let me know. But please don't ignore it by just creating one another dead topic.

# Submitting Pull Requests
## General
- [x]  Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
Examples: "`fix(google): Fixed foobar bug`", "`feat(accounts): Added foobar feature`".
- [x]  All Python code must formatted using Black, and clean from pep8 and isort issues.
- [ ]  JavaScript code should adhere to [StandardJS](https://standardjs.com/).
- [ ]  If your changes are significant, please update `ChangeLog.rst`.
- [ ]  If your change is substantial, feel free to add yourself to `AUTHORS`.

## Provider Specifics
In case you add a new provider:
- [ ]  Make sure unit tests are available.
- [ ]  Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ]  Add documentation to `docs/providers.rst`.
- [ ]  Add an entry to the list of supported providers over at `docs/overview.rs`t.
