### PR TITLE
fix(providers): Load providers using their app name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ James Rivett-Carnac
 James Thompson
 Jannis Leidel
 Jannis Vajen
+Jason Wallace
 Jeff Bowen
 Jeff Triplett
 Jeremy Satterfield

--- a/allauth/socialaccount/providers/__init__.py
+++ b/allauth/socialaccount/providers/__init__.py
@@ -1,7 +1,7 @@
 import importlib
 from collections import OrderedDict
 
-from django.conf import settings
+from django.apps import apps
 
 
 class ProviderRegistry(object):
@@ -33,9 +33,11 @@ class ProviderRegistry(object):
         # mechanism is way to magical and depends on the import order et al, so
         # all of this really needs to be revisited.
         if not self.loaded:
-            for app in settings.INSTALLED_APPS:
+            for app_config in apps.get_app_configs():
                 try:
-                    provider_module = importlib.import_module(app + ".provider")
+                    provider_module = importlib.import_module(
+                        app_config.name + ".provider"
+                    )
                 except ImportError:
                     pass
                 else:

--- a/allauth/socialaccount/tests.py
+++ b/allauth/socialaccount/tests.py
@@ -7,6 +7,7 @@ import warnings
 from urllib.parse import parse_qs, urlparse
 
 import django
+from django.apps import AppConfig, apps
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.middleware import MessageMiddleware
@@ -826,3 +827,54 @@ class SocialAccountTests(TestCase):
         user = User(username="test")
         sa = SocialAccount(user=user)
         self.assertEqual("A custom str builder for test", str(sa))
+
+
+class CustomFacebookAppConfig(AppConfig):
+    name = "allauth.socialaccount.providers.facebook"
+    label = "allauth_facebook"
+
+
+class ProviderRegistryTests(TestCase):
+    @override_settings(
+        INSTALLED_APPS=[
+            "allauth.socialaccount.providers.facebook",
+        ]
+    )
+    def test_load_provider_with_default_app_config(self):
+        registry = providers.ProviderRegistry()
+        provider_list = registry.get_list()
+
+        self.assertTrue(registry.loaded)
+        self.assertEqual(1, len(provider_list))
+        self.assertIsInstance(
+            provider_list[0],
+            providers.facebook.provider.FacebookProvider,
+        )
+
+        app_config_list = list(apps.get_app_configs())
+        self.assertEqual(1, len(app_config_list))
+        app_config = app_config_list[0]
+        self.assertEqual("allauth.socialaccount.providers.facebook", app_config.name)
+        self.assertEqual("facebook", app_config.label)
+
+    @override_settings(
+        INSTALLED_APPS=[
+            "allauth.socialaccount.tests.CustomFacebookAppConfig",
+        ]
+    )
+    def test_load_provider_with_custom_app_config(self):
+        registry = providers.ProviderRegistry()
+        provider_list = registry.get_list()
+
+        self.assertTrue(registry.loaded)
+        self.assertEqual(1, len(provider_list))
+        self.assertIsInstance(
+            provider_list[0],
+            providers.facebook.provider.FacebookProvider,
+        )
+
+        app_config_list = list(apps.get_app_configs())
+        self.assertEqual(1, len(app_config_list))
+        app_config = app_config_list[0]
+        self.assertEqual("allauth.socialaccount.providers.facebook", app_config.name)
+        self.assertEqual("allauth_facebook", app_config.label)


### PR DESCRIPTION
Resolves https://github.com/pennersr/django-allauth/issues/393

This PR allows you to relabel a provider's overly generic app label (i.e., `facebook`, `google`, etc.) by defining a custom `AppConfig` subclass. This allows you to resolve conflicting app labels within your Django project. For example:

```python
# example/apps.py
class CustomFacebookAppConfig(AppConfig):
    name = "allauth.socialaccount.providers.facebook"
    label = "allauth_facebook" # Let's relabel allauth's Facebook provider app. 


# example/settings.py
INSTALLED_APPS = [
    # ...
    "example.apps.CustomFacebookAppConfig",
    "facebook", # Now we can have an app called "facebook" in our Django project.
    # ...
]
```

Previously, using a custom `AppConfig` resulted in the provider not being loaded at all because of how [`allauth` accesses the `INSTALLED_APPS` setting directly](https://github.com/pennersr/django-allauth/blob/e1acb766f5bc578009ceb4db414f5730ce02adab/allauth/socialaccount/providers/__init__.py#L36) instead of through Django's app registry, as [Django recommends](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-INSTALLED_APPS):
>  Use the application registry for introspection
> Your code should never access [INSTALLED_APPS](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-INSTALLED_APPS) directly. Use [django.apps.apps](https://docs.djangoproject.com/en/4.1/ref/applications/#django.apps.apps) instead.

This PR does the following:
1. Adds tests for `ProviderRegistry` that confirms the bug https://github.com/pennersr/django-allauth/commit/f090096f2f558639aa8038e7105535bce6b8386d
2. Fixes the bug by loading providers by their app name https://github.com/pennersr/django-allauth/commit/3a882f1c18ad7dc6755b8331f4cb0dcccb6cd867
3. Adds my name to the author's list 👀 https://github.com/pennersr/django-allauth/commit/9ed7637cb251e9a16dec9ef44689e490650d681c

---

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - <s>JavaScript code should adhere to [StandardJS](https://standardjs.com).</s>
 - <s>If your changes are significant, please update `ChangeLog.rst`.</s>
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [x] Make sure unit tests are available.
- <s>Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.</s>
- <s>Add documentation to `docs/providers.rst`.</s>
- <s>Add an entry to the list of supported providers over at `docs/overview.rst`.</s>
