### PR TITLE
fix: upgrade to Exist.io API v2

### DIFF
--- a/allauth/socialaccount/providers/exist/provider.py
+++ b/allauth/socialaccount/providers/exist/provider.py
@@ -4,14 +4,13 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class ExistAccount(ProviderAccount):
     def get_profile_url(self):
-        username = self.account.extra_data.get("username")
-        return "https://exist.io/api/1/users/{}/profile/".format(username)
+        return "https://exist.io/api/2/accounts/profile/"
 
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar")
 
     def to_str(self):
-        name = super(ExistAccount, self).to_str()
+        name = super().to_str()
         return self.account.extra_data.get("name", name)
 
 
@@ -21,19 +20,22 @@ class ExistProvider(OAuth2Provider):
     account_class = ExistAccount
 
     def extract_uid(self, data):
-        return data.get("id")
+        return data.get("username")
 
     def extract_common_fields(self, data):
-        extra_common = super(ExistProvider, self).extract_common_fields(data)
+        extra_common = super().extract_common_fields(data)
         extra_common.update(
             username=data.get("username"),
             first_name=data.get("first_name"),
             last_name=data.get("last_name"),
+            avatar=data.get("avatar"),
+            timezone=data.get("timezone"),
+            local_time=data.get("local_time"),
         )
         return extra_common
 
     def get_default_scope(self):
-        return ["read"]
+        return ["mood_read", "health_read", "productivity_read"]
 
 
 provider_classes = [ExistProvider]

--- a/allauth/socialaccount/providers/exist/views.py
+++ b/allauth/socialaccount/providers/exist/views.py
@@ -13,7 +13,7 @@ class ExistOAuth2Adapter(OAuth2Adapter):
     provider_id = ExistProvider.id
     access_token_url = "https://exist.io/oauth2/access_token"
     authorize_url = "https://exist.io/oauth2/authorize"
-    profile_url = "https://exist.io/api/1/users/$self/profile/"
+    profile_url = "https://exist.io/api/2/accounts/profile/"
 
     def complete_login(self, request, app, token, **kwargs):
         headers = {"Authorization": "Bearer {0}".format(token.token)}

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -582,7 +582,9 @@ During development set the callback url to:
 In production replace localhost with whatever domain you're hosting your app on.
 
 If your app is writing to certain attributes you need to specify this during the
-creation of the app.
+creation of the app. For a full list of scopes see:
+
+https://developer.exist.io/reference/authentication/oauth2/#scopes
 
 The following Exist settings are available:
 
@@ -590,17 +592,17 @@ The following Exist settings are available:
 
     SOCIALACCOUNT_PROVIDERS = {
         'exist': {
-            'SCOPE': ['read+write'],
+            'SCOPE': ['mood_read', 'health_read', 'productivity_read'],
         }
     }
 
 SCOPE:
-    The default scope is ``read``. If you'd like to change this set the scope to
-    ``read+write``.
+    The default scopes are listed above. For reading additional attributes or writing data see
+    https://developer.exist.io/reference/authentication/oauth2/#scopes.
 
 For more information:
-OAuth documentation: http://developer.exist.io/#oauth2-authentication
-API documentation: http://developer.exist.io/
+OAuth documentation: https://developer.exist.io/reference/authentication/oauth2
+API documentation: https://developer.exist.io/reference/important_values/
 
 
 Facebook


### PR DESCRIPTION
The v1 API has been removed completely.

- Fixed the profile url.
- Fixed the payload returned from the profile url.
- Set the default scopes when accessing attribute data.