### PR TITLE
fix(google): oauth id token parse issue on updated Google spec

### DIFF
--- a/allauth/socialaccount/providers/google/views.py
+++ b/allauth/socialaccount/providers/google/views.py
@@ -18,8 +18,11 @@ class GoogleOAuth2Adapter(OAuth2Adapter):
 
     def complete_login(self, request, app, token, response, **kwargs):
         try:
+            id_token = response["id_token"]
+            if type(id_token) is dict:
+                id_token = id_token["id_token"]
             identity_data = jwt.decode(
-                response["id_token"],
+                id_token,
                 # Since the token was received by direct communication
                 # protected by TLS between this library and Google, we
                 # are allowed to skip checking the token signature


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

Fixes the following bug:
```
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/jwt/api_jwt.py", line 168, in decode
    decoded = self.decode_complete(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/jwt/api_jwt.py", line 120, in decode_complete
    decoded = api_jws.decode_complete(
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/jwt/api_jws.py", line 191, in decode_complete
    payload, signing_input, header, signature = self._load(jwt)
                                                ^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/jwt/api_jws.py", line 247, in _load
    raise DecodeError(f"Invalid token type. Token must be a {bytes}")
jwt.exceptions.DecodeError: Invalid token type. Token must be a <class 'bytes'>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 55, in wrapped_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/django/views/generic/base.py", line 103, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/django/utils/decorators.py", line 46, in _wrapper
    return bound_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/django/views/decorators/debug.py", line 92, in sensitive_post_parameters_wrapper
    return view(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/dj_rest_auth/views.py", line 48, in dispatch
    return super().dispatch(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/dj_rest_auth/views.py", line 125, in post
    self.serializer.is_valid(raise_exception=True)
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/rest_framework/serializers.py", line 227, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/rest_framework/serializers.py", line 429, in run_validation
    value = self.validate(value)
            ^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/dj_rest_auth/registration/serializers.py", line 151, in validate
    login = self.get_social_login(adapter, app, social_token, response={'id_token': token})
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/.pyenv/versions/waifu/lib/python3.11/site-packages/dj_rest_auth/registration/serializers.py", line 60, in get_social_login
    social_login = adapter.complete_login(request, app, token, response=response)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/johnsuh/waifu/backend/conversation/oauth.py", line 33, in complete_login
    raise OAuth2Error("Invalid id_token") from e
oauthlib.oauth2.rfc6749.errors.OAuth2Error: (None) Invalid id_token

```
