### PR TITLE
fix: OpenID provider slug fallback when no server_id present (fixes #3282)

### DIFF
--- a/allauth/socialaccount/providers/openid_connect/provider.py
+++ b/allauth/socialaccount/providers/openid_connect/provider.py
@@ -32,7 +32,7 @@ class OpenIDConnectProvider(OAuth2Provider):
 
     @classmethod
     def get_slug(cls):
-        return cls._server_id if cls._server_id else "openid_connect"
+        return cls._server_id or super().get_slug()
 
     def get_default_scope(self):
         return ["openid", "profile", "email"]


### PR DESCRIPTION
Keycloak provider binds to wrong base url since the slug is inherited from the hard coded `OpenIDConnectProvder` `get_slug` method. Changed the method to fallback to `super().get_slug()`.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
