### PR TITLE
fix(i18n): Load i18n in account base template

### DIFF
--- a/allauth/templates/account/base.html
+++ b/allauth/templates/account/base.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
In b82ed9efcc592eb45cc7f28a9e9f00035c55f050, `trans` tags have been introduced in the account/base.html template but the i18n module has not been loaded, resulting in errors when trying to render the default templates.