### PR TITLE
fix(socialaccount): Remove hard-coded redirect URL

### DIFF
--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -116,7 +116,6 @@ class DefaultSocialAccountAdapter(object):
         Returns the default URL to redirect to after successfully
         connecting a social account.
         """
-        assert request.user.is_authenticated
         url = reverse("socialaccount_connections")
         return url
 

--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -99,7 +99,10 @@ def _add_social_account(request, sociallogin):
     if request.user.is_anonymous:
         # This should not happen. Simply redirect to the connections
         # view (which has a login required)
-        return HttpResponseRedirect(reverse("socialaccount_connections"))
+        connect_redirect_url = get_adapter(request).get_connect_redirect_url(
+            request, sociallogin.account
+        )
+        return HttpResponseRedirect(connect_redirect_url)
     level = messages.INFO
     message = "socialaccount/messages/account_connected.txt"
     action = None
@@ -126,6 +129,7 @@ def _add_social_account(request, sociallogin):
         signals.social_account_added.send(
             sender=SocialLogin, request=request, sociallogin=sociallogin
         )
+    assert request.user.is_authenticated
     default_next = get_adapter(request).get_connect_redirect_url(
         request, sociallogin.account
     )


### PR DESCRIPTION
This pull request moves all uses of `reverse("socialaccount_connections")` into the social account adapter so that they can be consistently overwritten in just one place. There was already a helper method for to format the redirect URL, but it wasn't used in all edge cases.

Besides increasing code consistency, the changes in this pull request also fix using django-allauth in combination with [dj-rest-auth](https://github.com/iMerica/dj-rest-auth/) in the scenario where we have an existing account for a new social login. Previously, we would experience a crash unless a dummy URL is configured for `socialaccount_connections`. After the fix in this PR is merged, instead of setting this dummy URL we can now override the redirect URL in the adapter which is much cleaner.