### PR TITLE
fix: prevent the browser caching the csrf token on login and signup views

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -175,3 +175,4 @@ William Li
 Yaroslav Muravsky
 Yuri Kriachko
 Youcef Mammar
+Marius Victor

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -9,6 +9,8 @@ from django.http import (
 from django.shortcuts import redirect
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic.base import TemplateResponseMixin, TemplateView, View
 from django.views.generic.edit import FormView
@@ -145,6 +147,8 @@ class LoginView(
     redirect_field_name = "next"
 
     @sensitive_post_parameters_m
+    @method_decorator(csrf_protect)
+    @method_decorator(never_cache)
     def dispatch(self, request, *args, **kwargs):
         return super(LoginView, self).dispatch(request, *args, **kwargs)
 
@@ -230,6 +234,8 @@ class SignupView(
     success_url = None
 
     @sensitive_post_parameters_m
+    @method_decorator(csrf_protect)
+    @method_decorator(never_cache)
     def dispatch(self, request, *args, **kwargs):
         return super(SignupView, self).dispatch(request, *args, **kwargs)
 

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -234,7 +234,6 @@ class SignupView(
     success_url = None
 
     @sensitive_post_parameters_m
-    @method_decorator(csrf_protect)
     @method_decorator(never_cache)
     def dispatch(self, request, *args, **kwargs):
         return super(SignupView, self).dispatch(request, *args, **kwargs)

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -297,7 +297,6 @@ signup = SignupView.as_view()
 
 
 class ConfirmEmailView(TemplateResponseMixin, LogoutFunctionalityMixin, View):
-
     template_name = "account/email_confirm." + app_settings.TEMPLATE_EXTENSION
 
     def get(self, *args, **kwargs):
@@ -847,7 +846,6 @@ password_reset_from_key_done = PasswordResetFromKeyDoneView.as_view()
 
 
 class LogoutView(TemplateResponseMixin, LogoutFunctionalityMixin, View):
-
     template_name = "account/logout." + app_settings.TEMPLATE_EXTENSION
     redirect_field_name = "next"
 


### PR DESCRIPTION
Added never_cache and csrf_protect decorators to LoginView and SignupView to prevent the browser caching the csrf token. This fixes #3297.

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.
