### PR TITLE
fix(google): Fix google AUTHORIZE_URL settings config name

### DIFF
--- a/allauth/socialaccount/providers/google/views.py
+++ b/allauth/socialaccount/providers/google/views.py
@@ -21,7 +21,7 @@ ACCESS_TOKEN_URL = (
 AUTHORIZE_URL = (
     getattr(settings, "SOCIALACCOUNT_PROVIDERS", {})
     .get("google", {})
-    .get("ACCESS_TOKEN_URL", "https://accounts.google.com/o/oauth2/v2/auth")
+    .get("AUTHORIZE_URL", "https://accounts.google.com/o/oauth2/v2/auth")
 )
 
 ID_TOKEN_ISSUER = (


### PR DESCRIPTION
Now the google provider will property use SOCIALACCOUNT_PROVIDERS["google"]["AUTHORIZE_URL"] as the AUTHORIZE_URL if overriden from the default.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
