### PR TITLE
fix(is_safe_url): respect allowed_hosts

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -508,8 +508,8 @@ class DefaultAccountAdapter(object):
         allowed_hosts = {self.request.get_host()} | set(settings.ALLOWED_HOSTS)
 
         if "*" in allowed_hosts:
-            parsed_host = urlparse(url).netloc
-            return url_has_allowed_host_and_scheme(url, allowed_hosts={parsed_host})
+            parsed_host = {urlparse(url).netloc} if parsed_host else None
+            return url_has_allowed_host_and_scheme(url, allowed_hosts=parsed_host)
 
         return url_has_allowed_host_and_scheme(url, allowed_hosts=allowed_hosts)
 

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -2,6 +2,7 @@ import html
 import json
 import warnings
 from datetime import timedelta
+from urllib.parse import urlparse
 
 from django import forms
 from django.conf import settings
@@ -503,7 +504,14 @@ class DefaultAccountAdapter(object):
                 is_safe_url as url_has_allowed_host_and_scheme,
             )
 
-        return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
+        # get_host already validates the given host, so no need to check it again
+        allowed_hosts = {self.request.get_host()} | set(settings.ALLOWED_HOSTS)
+
+        if "*" in allowed_hosts:
+            parsed_host = urlparse(url).netloc
+            return url_has_allowed_host_and_scheme(url, allowed_hosts={parsed_host})
+
+        return url_has_allowed_host_and_scheme(url, allowed_hosts=allowed_hosts)
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         """Constructs the email confirmation (activation) url.

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -508,8 +508,9 @@ class DefaultAccountAdapter(object):
         allowed_hosts = {self.request.get_host()} | set(settings.ALLOWED_HOSTS)
 
         if "*" in allowed_hosts:
-            parsed_host = {urlparse(url).netloc} if parsed_host else None
-            return url_has_allowed_host_and_scheme(url, allowed_hosts=parsed_host)
+            parsed_host = urlparse(url).netloc
+            allowed_host = {parsed_host} if parsed_host else None
+            return url_has_allowed_host_and_scheme(url, allowed_hosts=allowed_host)
 
         return url_has_allowed_host_and_scheme(url, allowed_hosts=allowed_hosts)
 

--- a/allauth/account/tests/test_utils.py
+++ b/allauth/account/tests/test_utils.py
@@ -107,16 +107,19 @@ class UtilsTests(TestCase):
         get_adapter().clean_username("abc")
         self.assertRaises(ValidationError, lambda: get_adapter().clean_username("def"))
 
-    @override_settings(ALLOWED_HOSTS=["allowed_host"])
+    @override_settings(ALLOWED_HOSTS=["allowed_host", "testserver"])
     def test_is_safe_url_no_wildcard(self):
-        self.assertTrue(get_adapter().is_safe_url("http://allowed_host/"))
-        self.assertFalse(get_adapter().is_safe_url("http://other_host/"))
+        request = RequestFactory().get("/")
+        self.assertTrue(get_adapter(request).is_safe_url("http://allowed_host/"))
+        self.assertFalse(get_adapter(request).is_safe_url("http://other_host/"))
 
     @override_settings(ALLOWED_HOSTS=["*"])
     def test_is_safe_url_wildcard(self):
-        self.assertTrue(get_adapter().is_safe_url("http://foobar.com/"))
-        self.assertTrue(get_adapter().is_safe_url("http://other_host/"))
+        request = RequestFactory().get("/")
+        self.assertTrue(get_adapter(request).is_safe_url("http://foobar.com/"))
+        self.assertTrue(get_adapter(request).is_safe_url("http://other_host/"))
 
-    @override_settings(ALLOWED_HOSTS=["allowed_host"])
+    @override_settings(ALLOWED_HOSTS=["allowed_host", "testserver"])
     def test_is_safe_url_relative_path(self):
-        self.assertTrue(get_adapter().is_safe_url("/foo/bar"))
+        request = RequestFactory().get("/")
+        self.assertTrue(get_adapter(request).is_safe_url("/foo/bar"))

--- a/allauth/account/tests/test_utils.py
+++ b/allauth/account/tests/test_utils.py
@@ -106,3 +106,17 @@ class UtilsTests(TestCase):
     def test_username_validator(self):
         get_adapter().clean_username("abc")
         self.assertRaises(ValidationError, lambda: get_adapter().clean_username("def"))
+
+    @override_settings(ALLOWED_HOSTS=["allowed_host"])
+    def test_is_safe_url_no_wildcard(self):
+        self.assertTrue(get_adapter().is_safe_url("http://allowed_host/"))
+        self.assertFalse(get_adapter().is_safe_url("http://other_host/"))
+
+    @override_settings(ALLOWED_HOSTS=["*"])
+    def test_is_safe_url_wildcard(self):
+        self.assertTrue(get_adapter().is_safe_url("http://foobar.com/"))
+        self.assertTrue(get_adapter().is_safe_url("http://other_host/"))
+
+    @override_settings(ALLOWED_HOSTS=["allowed_host"])
+    def test_is_safe_url_relative_path(self):
+        self.assertTrue(get_adapter().is_safe_url("/foo/bar"))


### PR DESCRIPTION
Like those who have come before me (https://github.com/pennersr/django-allauth/pull/3264), I ran into an issue where I was unable to redirect to an absolute URL after a user successfully logs in. However, the above fix doesn't take into consideration wildcard ('*') domain matching. 

The main issue is that in `is_safe_url`, `allowed_hosts` defaults to `None` and doesn't take into account Django's standard ALLOWED_HOSTS setting.

Hopefully we can put this [issue](https://github.com/pennersr/django-allauth/issues/1766) to rest finally!

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.
