### PR TITLE
Settings: Use module-level __getattr__ instead of sys.modules hack

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -377,11 +377,9 @@ class AppSettings(object):
         return token_generator
 
 
-# Ugly? Guido recommends this himself ...
-# http://mail.python.org/pipermail/python-ideas/2012-May/014969.html
-import sys  # noqa
+_app_settings = AppSettings("ACCOUNT_")
 
 
-app_settings = AppSettings("ACCOUNT_")
-app_settings.__name__ = __name__
-sys.modules[__name__] = app_settings
+def __getattr__(name):
+    # See https://peps.python.org/pep-0562/
+    return getattr(_app_settings, name)

--- a/allauth/socialaccount/app_settings.py
+++ b/allauth/socialaccount/app_settings.py
@@ -112,11 +112,9 @@ class AppSettings(object):
         return self._setting("SOCIALACCOUNT_STR", None)
 
 
-# Ugly? Guido recommends this himself ...
-# http://mail.python.org/pipermail/python-ideas/2012-May/014969.html
-import sys  # noqa
+_app_settings = AppSettings("SOCIALACCOUNT_")
 
 
-app_settings = AppSettings("SOCIALACCOUNT_")
-app_settings.__name__ = __name__
-sys.modules[__name__] = app_settings
+def __getattr__(name):
+    # See https://peps.python.org/pep-0562/
+    return getattr(_app_settings, name)


### PR DESCRIPTION
Module-level `__getattr__` is supported since Python 3.7.