### PR TITLE
feat(account): Add `ACCOUNT_CHANGE_EMAIL` flow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ indent_size = 4
 [*.py]
 indent_size = 4
 
+[*.html]
+indent_size = 4
+
 [Makefile]
 indent_style = tab
 indent_size = 8

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -16,6 +16,11 @@ Note worthy changes
 - It is now possible to manage OpenID Connect providers via the Django
   admin. Simply add a `SocialApp` for each OpenID Connect provider.
 
+- There is now a new flow for changing the email address. When enabled
+  (``ACCOUNT_CHANGE_EMAIL``), users are limited to having exactly one email
+  address that they can change by adding a temporary second email address that,
+  when verified, replaces the current email address.
+
 
 Security notice
 ---------------

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -480,7 +480,7 @@ class DefaultAccountAdapter(object):
             return False
         email_address.set_as_primary(conditional=True)
         email_address.save(update_fields=["verified", "primary"])
-        if app_settings.MAX_EMAIL_ADDRESSES == 1:
+        if app_settings.CHANGE_EMAIL:
             for instance in EmailAddress.objects.filter(
                 user_id=email_address.user_id
             ).exclude(pk=email_address.pk):

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -478,7 +478,7 @@ class DefaultAccountAdapter(object):
 
         if not email_address.set_verified(commit=False):
             return False
-        email_address.set_as_primary(conditional=True)
+        email_address.set_as_primary(conditional=(not app_settings.CHANGE_EMAIL))
         email_address.save(update_fields=["verified", "primary"])
         if app_settings.CHANGE_EMAIL:
             for instance in EmailAddress.objects.filter(

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -474,10 +474,17 @@ class DefaultAccountAdapter(object):
         """
         Marks the email address as confirmed on the db
         """
+        from allauth.account.models import EmailAddress
+
         if not email_address.set_verified(commit=False):
             return False
         email_address.set_as_primary(conditional=True)
         email_address.save(update_fields=["verified", "primary"])
+        if app_settings.MAX_EMAIL_ADDRESSES == 1:
+            for instance in EmailAddress.objects.filter(
+                user_id=email_address.user_id
+            ).exclude(pk=email_address.pk):
+                instance.remove()
         return True
 
     def set_password(self, user, password):

--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -1,3 +1,6 @@
+from django.core.exceptions import ImproperlyConfigured
+
+
 class AppSettings(object):
     class AuthenticationMethod:
         USERNAME = "username"
@@ -35,6 +38,11 @@ class AppSettings(object):
             )
         if self.MAX_EMAIL_ADDRESSES is not None:
             assert self.MAX_EMAIL_ADDRESSES > 0
+        if self.CHANGE_EMAIL:
+            if self.MAX_EMAIL_ADDRESSES is not None and self.MAX_EMAIL_ADDRESSES != 2:
+                raise ImproperlyConfigured(
+                    "Invalid combination of ACCOUNT_CHANGE_EMAIL and ACCOUNT_MAX_EMAIL_ADDRESSES"
+                )
 
     def _setting(self, name, dflt):
         from django.conf import settings
@@ -118,6 +126,10 @@ class AppSettings(object):
     @property
     def MAX_EMAIL_ADDRESSES(self):
         return self._setting("MAX_EMAIL_ADDRESSES", None)
+
+    @property
+    def CHANGE_EMAIL(self):
+        return self._setting("CHANGE_EMAIL", False)
 
     @property
     def AUTHENTICATION_METHOD(self):

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -499,7 +499,7 @@ class AddEmailForm(UserForm):
         return value
 
     def save(self, request):
-        if app_settings.MAX_EMAIL_ADDRESSES == 1:
+        if app_settings.CHANGE_EMAIL:
             return EmailAddress.objects.add_change_email(
                 request, self.user, self.cleaned_data["email"]
             )

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -500,7 +500,7 @@ class AddEmailForm(UserForm):
 
     def save(self, request):
         if app_settings.CHANGE_EMAIL:
-            return EmailAddress.objects.add_change_email(
+            return EmailAddress.objects.add_new_email(
                 request, self.user, self.cleaned_data["email"]
             )
         return EmailAddress.objects.add_email(

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -499,6 +499,10 @@ class AddEmailForm(UserForm):
         return value
 
     def save(self, request):
+        if app_settings.MAX_EMAIL_ADDRESSES == 1:
+            return EmailAddress.objects.add_change_email(
+                request, self.user, self.cleaned_data["email"]
+            )
         return EmailAddress.objects.add_email(
             request, self.user, self.cleaned_data["email"], confirm=True
         )

--- a/allauth/account/managers.py
+++ b/allauth/account/managers.py
@@ -29,7 +29,7 @@ class EmailAddressManager(models.Manager):
             self.model.objects.filter(user=user, verified=False).order_by("pk").last()
         )
 
-    def add_change_email(self, request, user, email):
+    def add_new_email(self, request, user, email):
         """
         Adds an email address the user wishes to change to, replacing his
         current email address once confirmed.

--- a/allauth/account/managers.py
+++ b/allauth/account/managers.py
@@ -10,10 +10,46 @@ from . import app_settings
 class EmailAddressManager(models.Manager):
     def can_add_email(self, user):
         ret = True
-        if app_settings.MAX_EMAIL_ADDRESSES:
+        if app_settings.MAX_EMAIL_ADDRESSES == 1:
+            # We always alow adding an email in this case, as adding
+            # actually adds a temporary email that the user wants to change
+            # to.
+            return True
+        elif app_settings.MAX_EMAIL_ADDRESSES:
             count = self.filter(user=user).count()
             ret = count < app_settings.MAX_EMAIL_ADDRESSES
         return ret
+
+    def add_change_email(self, request, user, email):
+        """
+        Adds an email address the user wishes to change to, replacing his
+        current email address once confirmed.
+        """
+        qs = self.model.objects.filter(user=user).order_by("pk")
+        count = qs.count()
+        instance = None
+        if count > 1:
+            # There are already more than 1 email addresses attached, yet,
+            # there should only be 1 + a temporary one. So, try and find the best
+            # temporary one to reuse.
+            instance = qs.filter(verified=False, primary=False).last()
+            if not instance:
+                instance = qs.filter(verified=False, primary=True).last()
+            if not instance:
+                instance = qs.filter(verified=True, primary=False).last()
+            if not instance:
+                instance = qs.last()
+        if not instance:
+            instance = self.model.objects.create(user=user, email=email)
+        else:
+            # Apparently, the user was already in the process of changing his
+            # email.  Reuse that temporary email address.
+            instance.email = email
+            instance.verified = False
+            instance.primary = False
+            instance.save()
+        instance.send_confirmation(request)
+        return instance
 
     def add_email(self, request, user, email, confirm=False, signup=False):
         email_address, created = self.get_or_create(

--- a/allauth/account/managers.py
+++ b/allauth/account/managers.py
@@ -10,28 +10,27 @@ from . import app_settings
 class EmailAddressManager(models.Manager):
     def can_add_email(self, user):
         ret = True
-        if app_settings.MAX_EMAIL_ADDRESSES == 1:
-            # We always alow adding an email in this case, as adding
-            # actually adds a temporary email that the user wants to change
-            # to.
+        if app_settings.CHANGE_EMAIL:
+            #  We always allow adding an email in this case, regardless of
+            # `MAX_EMAIL_ADDRESSES`, as adding actually adds a temporary email
+            # that the user wants to change to.
             return True
         elif app_settings.MAX_EMAIL_ADDRESSES:
             count = self.filter(user=user).count()
             ret = count < app_settings.MAX_EMAIL_ADDRESSES
         return ret
 
-    def add_change_email(self, request, user, email):
+    def get_change_email(self, user):
         """
-        Adds an email address the user wishes to change to, replacing his
-        current email address once confirmed.
+        Returns the email address the user is in the process of changing to.
         """
+        assert app_settings.CHANGE_EMAIL
         qs = self.model.objects.filter(user=user).order_by("pk")
         count = qs.count()
         instance = None
         if count > 1:
-            # There are already more than 1 email addresses attached, yet,
-            # there should only be 1 + a temporary one. So, try and find the best
-            # temporary one to reuse.
+            # There are already more than 1 email addresses attached, yet, there
+            # should only be one + a temporary one. Let's find it.
             instance = qs.filter(verified=False, primary=False).last()
             if not instance:
                 instance = qs.filter(verified=False, primary=True).last()
@@ -39,6 +38,15 @@ class EmailAddressManager(models.Manager):
                 instance = qs.filter(verified=True, primary=False).last()
             if not instance:
                 instance = qs.last()
+        return instance
+
+    def add_change_email(self, request, user, email):
+        """
+        Adds an email address the user wishes to change to, replacing his
+        current email address once confirmed.
+        """
+        assert app_settings.CHANGE_EMAIL
+        instance = self.get_change_email(user)
         if not instance:
             instance = self.model.objects.create(user=user, email=email)
         else:

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -75,9 +75,7 @@ class EmailAddress(models.Model):
             old_primary.save()
         self.primary = True
         self.save()
-        user_email(self.user, self.email)
-        if app_settings.USER_MODEL_EMAIL_FIELD:
-            self.user.save(update_fields=[app_settings.USER_MODEL_EMAIL_FIELD])
+        user_email(self.user, self.email, commit=True)
         return True
 
     def send_confirmation(self, request=None, signup=False):

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -67,6 +67,9 @@ class EmailAddress(models.Model):
         return self.verified
 
     def set_as_primary(self, conditional=False):
+        """Marks the email address as primary. In case of `conditional`, it is
+        only marked as primary if there is no other primary email address set.
+        """
         old_primary = EmailAddress.objects.get_primary(self.user)
         if old_primary:
             if conditional:

--- a/allauth/account/tests/test_change_email.py
+++ b/allauth/account/tests/test_change_email.py
@@ -244,7 +244,7 @@ def test_change_email(user_factory, client, settings):
     settings.ACCOUNT_CHANGE_EMAIL = True
     settings.ACCOUNT_EMAIL_CONFIRMATION_HMAC = True
 
-    user = user_factory(email_verified=False)
+    user = user_factory(email_verified=True)
     client.force_login(user)
     current_email = EmailAddress.objects.get(user=user)
     resp = client.post(

--- a/allauth/account/tests/test_change_email.py
+++ b/allauth/account/tests/test_change_email.py
@@ -240,8 +240,8 @@ def test_delete_email_wipes_user_email(user_factory, client):
     assert user_email(user) == ""
 
 
-def test_change_email_with_max_1(user_factory, client, settings):
-    settings.ACCOUNT_MAX_EMAIL_ADDRESSES = 1
+def test_change_email(user_factory, client, settings):
+    settings.ACCOUNT_CHANGE_EMAIL = True
     settings.ACCOUNT_EMAIL_CONFIRMATION_HMAC = True
 
     user = user_factory(email_verified=False)

--- a/allauth/account/tests/test_change_email.py
+++ b/allauth/account/tests/test_change_email.py
@@ -252,9 +252,12 @@ def test_change_email(user_factory, client, settings):
         {"action_add": "", "email": "change-to@this.org"},
     )
     assert resp.status_code == 302
-    change_email = EmailAddress.objects.get(email="change-to@this.org")
-    key = EmailConfirmationHMAC(change_email).key
+    new_email = EmailAddress.objects.get(email="change-to@this.org")
+    key = EmailConfirmationHMAC(new_email).key
     resp = client.post(reverse("account_confirm_email", args=[key]))
     assert resp.status_code == 302
     assert not EmailAddress.objects.filter(pk=current_email.pk).exists()
     assert EmailAddress.objects.filter(user=user).count() == 1
+    new_email.refresh_from_db()
+    assert new_email.verified
+    assert new_email.primary

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -565,10 +565,18 @@ class EmailView(AjaxCapableProcessFormViewMixin, FormView):
 
     def get_context_data(self, **kwargs):
         ret = super(EmailView, self).get_context_data(**kwargs)
-        # NOTE: For backwards compatibility
-        ret["add_email_form"] = ret.get("form")
-        # (end NOTE)
-        ret["can_add_email"] = EmailAddress.objects.can_add_email(self.request.user)
+        add_changes_email = app_settings.CHANGE_EMAIL
+        ret.update(
+            {
+                "add_email_form": ret.get("form"),
+                "can_add_email": EmailAddress.objects.can_add_email(self.request.user),
+                "add_changes_email": add_changes_email,
+            }
+        )
+        if add_changes_email:
+            ret["change_email"] = EmailAddress.objects.get_change_email(
+                self.request.user
+            )
         return ret
 
     def get_ajax_data(self):

--- a/allauth/templates/account/email.html
+++ b/allauth/templates/account/email.html
@@ -45,12 +45,16 @@
 {% endif %}
 
   {% if can_add_email %}
-    <h2>{% trans "Add E-mail Address" %}</h2>
+<h2>
+  {% if add_changes_email %}{% trans "Change E-mail Address" %}{% else %}{% trans "Add E-mail Address" %}{% endif %}
+</h2>
 
     <form method="post" action="{% url 'account_email' %}" class="add_email">
         {% csrf_token %}
         {{ form.as_p }}
-        <button name="action_add" type="submit">{% trans "Add E-mail" %}</button>
+        <button name="action_add" type="submit">
+          {% if add_changes_email %}{% trans "Change E-mail" %}{% else %}{% trans "Add E-mail" %}{% endif %}
+        </button>
     </form>
   {% endif %}
 

--- a/allauth/templates/account/email.html
+++ b/allauth/templates/account/email.html
@@ -6,18 +6,18 @@
 
 {% block content %}
     <h1>{% trans "E-mail Addresses" %}</h1>
-{% if user.emailaddress_set.all %}
+{% if emailaddresses %}
 <p>{% trans 'The following e-mail addresses are associated with your account:' %}</p>
 
 <form action="{% url 'account_email' %}" class="email_list" method="post">
 {% csrf_token %}
 <fieldset class="blockLabels">
 
-  {% for emailaddress in user.emailaddress_set.all %}
+  {% for emailaddress in emailaddresses %}
 <div class="ctrlHolder">
       <label for="email_radio_{{forloop.counter}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
 
-      <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary or user.emailaddress_set.count == 1 %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
+      <input id="email_radio_{{forloop.counter}}" type="radio" name="email" {% if emailaddress.primary or emailaddresses|length == 1 %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
 
 {{ emailaddress.email }}
     {% if emailaddress.verified %}
@@ -40,21 +40,16 @@
 </form>
 
 {% else %}
-<p><strong>{% trans 'Warning:'%}</strong> {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}</p>
-
+{% include "account/snippets/warn_no_email.html" %}
 {% endif %}
 
   {% if can_add_email %}
-<h2>
-  {% if add_changes_email %}{% trans "Change E-mail Address" %}{% else %}{% trans "Add E-mail Address" %}{% endif %}
-</h2>
+    <h2>{% trans "Add E-mail Address" %}</h2>
 
     <form method="post" action="{% url 'account_email' %}" class="add_email">
         {% csrf_token %}
         {{ form.as_p }}
-        <button name="action_add" type="submit">
-          {% if add_changes_email %}{% trans "Change E-mail" %}{% else %}{% trans "Add E-mail" %}{% endif %}
-        </button>
+        <button name="action_add" type="submit">{% trans "Add E-mail" %}</button>
     </form>
   {% endif %}
 

--- a/allauth/templates/account/email_change.html
+++ b/allauth/templates/account/email_change.html
@@ -1,0 +1,33 @@
+{% extends "account/base.html" %}
+{% load i18n %}
+{% block head_title %}
+    {% trans "E-mail Address" %}
+{% endblock %}
+{% block content %}
+    <h1>{% trans "E-mail Address" %}</h1>
+    {% if emailaddresses %}
+        {% if current_emailaddress %}
+            <p>
+                {% trans 'The following e-mail address is associated with your account:' %} <a href="mailto:{{ current_emailaddress.email }}">{{ current_emailaddress.email }}</a>
+            </p>
+        {% endif %}
+        {% if new_emailaddress %}
+            <p>
+                {% trans 'Your e-mail address is still pending verification:' %} <a href="mailto:{{ new_emailaddress.email }}">{{ new_emailaddress.email }}</a>
+            </p>
+            <form method="post" action="{% url 'account_email' %}">
+                {% csrf_token %}
+                <input type="hidden" name="email" value="{{ new_emailaddress.email }}">
+                <button type="submit" name="action_send">{% trans 'Re-send Verification' %}</button>
+            </form>
+        {% endif %}
+    {% else %}
+        {% include "account/snippets/warn_no_email.html" %}
+    {% endif %}
+    <h2>{% trans "Change E-mail Address" %}</h2>
+    <form method="post" action="{% url 'account_email' %}">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button name="action_add" type="submit">{% trans "Change E-mail" %}</button>
+    </form>
+{% endblock %}

--- a/allauth/templates/account/snippets/warn_no_email.html
+++ b/allauth/templates/account/snippets/warn_no_email.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+<p>
+    <strong>{% trans 'Warning:' %}</strong> {% trans "You currently do not have any e-mail address set up. You should really add an e-mail address so you can receive notifications, reset your password, etc." %}
+</p>

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -20,12 +20,11 @@ ACCOUNT_AUTHENTICATION_METHOD (="username" | "email" | "username_email")
   Setting this to "email" requires ACCOUNT_EMAIL_REQUIRED=True
 
 ACCOUNT_CHANGE_EMAIL (=False)
-  When disabled (``False``), users can either add one or more email addresses
-  (up to a maximum of ``ACCOUNT_MAX_EMAIL_ADDRESSES``) to their account and
-  freely manage those email addresses. When enabled (``True``), users are
-  limited to having exactly one email address that they can change by adding a
-  temporary second email address that, when verified, replaces the current email
-  address.
+  When disabled (``False``), users can add one or more email addresses (up to a
+  maximum of ``ACCOUNT_MAX_EMAIL_ADDRESSES``) to their account and freely manage
+  those email addresses. When enabled (``True``), users are limited to having
+  exactly one email address that they can change by adding a temporary second
+  email address that, when verified, replaces the current email address.
 
 ACCOUNT_CONFIRM_EMAIL_ON_GET (=False)
   Determines whether or not an e-mail address is automatically confirmed by

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,6 +19,14 @@ ACCOUNT_AUTHENTICATION_METHOD (="username" | "email" | "username_email")
   entering their username, e-mail address, or either one of both.
   Setting this to "email" requires ACCOUNT_EMAIL_REQUIRED=True
 
+ACCOUNT_CHANGE_EMAIL (=False)
+  When disabled (``False``), users can either add one or more email addresses
+  (up to a maximum of ``ACCOUNT_MAX_EMAIL_ADDRESSES``) to their account and
+  freely manage those email addresses. When enabled (``True``), users are
+  limited to having exactly one email address that they can change by adding a
+  temporary second email address that, when verified, replaces the current email
+  address.
+
 ACCOUNT_CONFIRM_EMAIL_ON_GET (=False)
   Determines whether or not an e-mail address is automatically confirmed by
   a GET request. `GET is not designed to modify the server state
@@ -94,9 +102,7 @@ ACCOUNT_MAX_EMAIL_ADDRESSES(=None)
   is safe to change this setting for an already running project -- it will not
   negatively affect users that already exceed the allowed amount. Note that if
   you set the maximum to 1, users will not be able to change their email address
-  as they are unable to add the new address, followed by removing the old
-  address.
-
+  unless you enable ``ACCOUNT_CHANGE_EMAIL``.
 
 ACCOUNT_FORMS (={})
   Used to override forms, for example:


### PR DESCRIPTION
With these changes, when `ACCOUNT_MAX_EMAIL_ADRESSES=1`, the user can still change his email. The user is allowed to add an extra email, and when that email is confirmed, the former email is removed. So, the user is allowed to go over the maximum of 1 for the purpose of changing his email.
