### PR TITLE
fix(cern): Updated to new SSO w/ OIDC

### DIFF
--- a/allauth/socialaccount/providers/cern/provider.py
+++ b/allauth/socialaccount/providers/cern/provider.py
@@ -1,32 +1,40 @@
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from allauth.socialaccount.providers.openid_connect.provider import (
+    OpenIDConnectProvider,
+    OpenIDConnectProviderAccount,
+)
 
 
-class CernAccount(ProviderAccount):
+class CernAccount(OpenIDConnectProviderAccount):
     def to_str(self):
         dflt = super(CernAccount, self).to_str()
         return self.account.extra_data.get("name", dflt)
 
 
-class CernProvider(OAuth2Provider):
+class CernProvider(OpenIDConnectProvider):
+    """
+    Child class for logging into CERN, using OIDC.
+    """
+
     id = "cern"
     name = "Cern"
+
+    # Well-known config for CERN
+    _server_url = (
+        "https://auth.cern.ch/auth/realms/cern/.well-known/openid-configuration"
+    )
     account_class = CernAccount
 
-    def get_auth_params(self, request, action):
-        data = super(CernProvider, self).get_auth_params(request, action)
-        data["scope"] = "read:user"
-        return data
-
     def extract_uid(self, data):
-        return str(data.get("id"))
+        return str(data.get("sub"))
 
     def extract_common_fields(self, data):
         return dict(
             email=data.get("email"),
-            username=data.get("username"),
-            first_name=data.get("first_name"),
-            last_name=data.get("last_name"),
+            username=data.get("preferred_username"),
+            first_name=data.get("given_name"),
+            last_name=data.get("family_name"),
             name=data.get("name"),
         )
 

--- a/allauth/socialaccount/providers/cern/tests.py
+++ b/allauth/socialaccount/providers/cern/tests.py
@@ -1,28 +1,48 @@
-from allauth.socialaccount.tests import OAuth2TestsMixin
+from allauth.socialaccount.tests import OpenIDConnectTests
 from allauth.tests import MockedResponse, TestCase
 
 from .provider import CernProvider
 
 
-class CernTests(OAuth2TestsMixin, TestCase):
+class CernTests(OpenIDConnectTests, TestCase):
     provider_id = CernProvider.id
 
     def get_mocked_response(self):
         return MockedResponse(
             200,
             """
-        {
-            "name":"Max Mustermann",
-            "username":"mmuster",
-            "id":8173921,
-            "personid":924225,
-            "email":"max.mustermann@cern.ch",
-            "first_name":"Max",
-            "last_name":"Mustermann",
-            "identityclass":"CERN Registered",
-            "federation":"CERN",
-            "phone":null,
-            "mobile":null
-        }
-        """,
+            {
+                "exp": 9999999999,
+                "iat": 9999999999,
+                "auth_time": 9999999999,
+                "jti": "Random",
+                "iss": "https://auth.cern.ch/auth/realms/cern",
+                "aud": "test-audience",
+                "sub": "mmuster",
+                "typ": "ID",
+                "azp": "test-audience",
+                "session_state": "Random",
+                "at_hash": "Random",
+                "sid": "Random",
+                "resource_access": {
+                    "test-audience": {
+                        "roles": [
+                            "default-role"
+                        ]
+                    }
+                },
+                "cern_person_id": "924225",
+                "name": "Max Mustermann",
+                "cern_mail_upn": "max.mustermann@cern.ch",
+                "preferred_username": "mmuster",
+                "given_name": "Max",
+                "cern_roles": [
+                    "default-role"
+                ],
+                "cern_preferred_language": "EN",
+                "family_name": "Mustermann",
+                "email": "max.mustermann@cern.ch",
+                "cern_upn": "mmuster"
+            }
+            """,
         )

--- a/allauth/socialaccount/providers/cern/urls.py
+++ b/allauth/socialaccount/providers/cern/urls.py
@@ -1,4 +1,4 @@
-from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
+from allauth.socialaccount.providers.openid_connect.urls import default_urlpatterns
 
 from .provider import CernProvider
 

--- a/docs/providers/cern.rst
+++ b/docs/providers/cern.rst
@@ -1,7 +1,7 @@
 CERN
 ----
 App registration (get your key and secret here)
-    https://sso-management.web.cern.ch/OAuth/RegisterOAuthClient.aspx
+    https://application-portal.web.cern.ch/
 
 CERN OAuth2 Documentation
-    https://espace.cern.ch/authentication/CERN%20Authentication/OAuth.aspx
+    https://auth.docs.cern.ch/


### PR DESCRIPTION
## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] ~~JavaScript code should adhere to [StandardJS](https://standardjs.com).~~ (Does not apply)
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] ~~If your change is substantial, feel free to add yourself to `AUTHORS`.~~

## Provider Specifics

### CERN

CERN will be completely deprecating the current SSO solution by September 1st, 2023, making the current CERN `django-allauth` provider obsolete.

This PR updates the CERN provider to the ""new"" SSO solution, which is OIDC-based, using new URLs and response format. 
The most important thing to note is that two breaking changes have been introduced:

1. A formerly available attribute, `groups`, is no longer available. In its place, `cern_roles` have been added, and are provided by default by the JWT access token returned after logging in. Developers using this provider will have to update their applications to use `cern_roles` instead of `groups`.

	> **Note**
	> One solution could have been to just map `cern_roles` to `groups`, but, since they do not reflect the same information (i.e. multiple `groups` may be mapped to a single `cern_role`), it's better for the developers to update their applications to comply with this new concept. More information [here](https://auth.docs.cern.ch/applications/role-based-permissions).


2. The `uid` that was used previously (mapped to `id` in the old SSO response) **is no longer available.** This means that, if returning users attempt a login after `django-allauth` has been updated, there's no way to associate them with the existing `SocialAccount` entry, since the `uid` is now different. In its place, the `sub` field is now used, which is also [guaranteed to be unique](https://auth.docs.cern.ch/user-documentation/oidc/config/#what-will-be-in-your-tokens), and is already stored in the `extra_data` column of the `SocialAccount` table, so it would be easy to "migrate" the value to the `uid` column.
	I will try to come up with a "migration" script to update the existing `uid`s to be the `username` value in the `extra_data` column.
	To migrate:
	i. Enter your project's django shell:
	```bash
	python manage.py shell
	```
	ii. Use the `username` field (which has been renamed to `sub` in the new SSO) in the `extra_data` to update the `uid`:
	```python
	from allauth.socialaccount.models import SocialAccount
	sa = SocialAccount.objects.filter(provider="cern")
	for s in sa:
		if 'username' in s.extra_data:
			s.uid = s.extra_data["username"]
			s.save()
	```

 
All other functionality and setup should be intact.

