### PR TITLE
add css class to password_reset_from_key form

### DIFF
--- a/allauth/templates/account/password_reset_from_key.html
+++ b/allauth/templates/account/password_reset_from_key.html
@@ -10,7 +10,7 @@
         {% url 'account_reset_password' as passwd_reset_url %}
         <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
     {% else %}
-        <form method="POST" action="{{ action_url }}">
+        <form method="POST" action="{{ action_url }}" class="password_reset_from_key">
             {% csrf_token %}
             {{ form.as_p }}
             <input type="submit" name="action" value="{% trans 'change password' %}"/>


### PR DESCRIPTION
This was the only form missing a css class needed to style the account's templates.
