### PR TITLE
feat(socialaccount): Authenticate by email

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -30,6 +30,9 @@ Note worthy changes
 
 - Fixed Twitter OAuth2 authentication by using basic auth and adding scope `tweet.read`.
 
+- Added (optional) support for authentication by email for social logins (see
+  ``SOCIALACCOUNT_EMAIL_AUTHENTICATION``).
+
 
 Security notice
 ---------------

--- a/allauth/account/managers.py
+++ b/allauth/account/managers.py
@@ -1,3 +1,4 @@
+import functools
 from datetime import timedelta
 
 from django.db import models
@@ -100,6 +101,13 @@ class EmailAddressManager(models.Manager):
 
     def is_verified(self, email):
         return self.filter(email__iexact=email, verified=True).exists()
+
+    def lookup(self, emails):
+        q_list = [Q(email__iexact=e) for e in emails]
+        if not q_list:
+            return self.none()
+        q = functools.reduce(lambda a, b: a | b, q_list)
+        return self.filter(q)
 
 
 class EmailConfirmationManager(models.Manager):

--- a/allauth/socialaccount/app_settings.py
+++ b/allauth/socialaccount/app_settings.py
@@ -85,6 +85,25 @@ class AppSettings(object):
         return self._setting("EMAIL_VERIFICATION", account_settings.EMAIL_VERIFICATION)
 
     @property
+    def EMAIL_AUTHENTICATION(self):
+        """Consider a scenario where a social login occurs, and the social
+        account comes with a verified email address (verified by the account
+        provider), but that email address is already taken by a local user
+        account. Additionally, assume that the local user account does not have
+        any social account connected. Now, if the provider can be fully trusted,
+        you can argue that we should treat this scenario as a login to the
+        existing local user account even if the local account does not already
+        have the social account connected, because -- according to the provider
+        -- the user logging in has ownership of the email address.  This is how
+        this scenario is handled when `EMAIL_AUTHENTICATION` is set to
+        `True`. As this implies that an untrustworthy provider can login to any
+        local account by fabricating social account data, this setting defaults
+        to `False`. Only set it to `True` if you are using providers that can be
+        fully trusted.
+        """
+        return self._setting("EMAIL_AUTHENTICATION", False)
+
+    @property
     def ADAPTER(self):
         return self._setting(
             "ADAPTER",

--- a/allauth/socialaccount/conftest.py
+++ b/allauth/socialaccount/conftest.py
@@ -6,9 +6,9 @@ from allauth.socialaccount.models import SocialAccount, SocialLogin
 
 @pytest.fixture
 def sociallogin_factory(user_factory):
-    def factory(email=None, with_email=True):
+    def factory(email=None, with_email=True, provider="unittest-server", uid="123"):
         user = user_factory(email=email, commit=False, with_email=with_email)
-        account = SocialAccount(provider="unittest-server", uid="123")
+        account = SocialAccount(provider=provider, uid=uid)
         sociallogin = SocialLogin(user=user, account=account)
         if with_email:
             sociallogin.email_addresses = [

--- a/allauth/socialaccount/tests/test_login.py
+++ b/allauth/socialaccount/tests/test_login.py
@@ -3,27 +3,36 @@ import uuid
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.urls import reverse
+
+import pytest
 
 from allauth.socialaccount.helpers import complete_social_login
 from allauth.socialaccount.models import SocialAccount
 
 
+@pytest.mark.parametrize("setting", ["off", "on-global", "on-provider"])
 def test_email_authentication(
-    db, settings, user_factory, sociallogin_factory, client, rf, mailoutbox
+    db, setting, settings, user_factory, sociallogin_factory, client, rf, mailoutbox
 ):
     """Tests that when an already existing email is given at the social signup
     form, enumeration preventation kicks in.
     """
-    settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
     settings.ACCOUNT_EMAIL_REQUIRED = True
     settings.ACCOUNT_UNIQUE_EMAIL = True
     settings.ACCOUNT_USERNAME_REQUIRED = False
     settings.ACCOUNT_AUTHENTICATION_METHOD = "email"
     settings.ACCOUNT_EMAIL_VERIFICATION = "mandatory"
     settings.SOCIALACCOUNT_AUTO_SIGNUP = True
+    if setting == "on-global":
+        settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
+    elif setting == "on-provider":
+        settings.SOCIALACCOUNT_PROVIDERS["google"] = {"EMAIL_AUTHENTICATION": True}
+    else:
+        settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION = False
 
     user = user_factory()
-    account = SocialAccount.objects.create(
+    SocialAccount.objects.create(
         user=user,
         provider="google",
         uid=uuid.uuid4().hex,
@@ -37,4 +46,7 @@ def test_email_authentication(
     request.user = AnonymousUser()
 
     resp = complete_social_login(request, sociallogin)
-    assert resp["location"] == "/accounts/profile/"
+    if setting == "off":
+        assert resp["location"] == reverse("account_email_verification_sent")
+    else:
+        assert resp["location"] == "/accounts/profile/"

--- a/allauth/socialaccount/tests/test_login.py
+++ b/allauth/socialaccount/tests/test_login.py
@@ -1,0 +1,40 @@
+import uuid
+
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+
+from allauth.socialaccount.helpers import complete_social_login
+from allauth.socialaccount.models import SocialAccount
+
+
+def test_email_authentication(
+    db, settings, user_factory, sociallogin_factory, client, rf, mailoutbox
+):
+    """Tests that when an already existing email is given at the social signup
+    form, enumeration preventation kicks in.
+    """
+    settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
+    settings.ACCOUNT_EMAIL_REQUIRED = True
+    settings.ACCOUNT_UNIQUE_EMAIL = True
+    settings.ACCOUNT_USERNAME_REQUIRED = False
+    settings.ACCOUNT_AUTHENTICATION_METHOD = "email"
+    settings.ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+    settings.SOCIALACCOUNT_AUTO_SIGNUP = True
+
+    user = user_factory()
+    account = SocialAccount.objects.create(
+        user=user,
+        provider="google",
+        uid=uuid.uuid4().hex,
+    )
+
+    sociallogin = sociallogin_factory(email=user.email, provider="google")
+
+    request = rf.get("/")
+    SessionMiddleware(lambda request: None).process_request(request)
+    MessageMiddleware(lambda request: None).process_request(request)
+    request.user = AnonymousUser()
+
+    resp = complete_social_login(request, sociallogin)
+    assert resp["location"] == "/accounts/profile/"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -311,7 +311,16 @@ SOCIALACCOUNT_EMAIL_AUTHENTICATION (=False)
   ``SOCIALACCOUNT_EMAIL_AUTHENTICATION`` is set to ``True``. As this implies
   that an untrustworthy provider can login to any local account by fabricating
   social account data, this setting defaults to ``False``. Only set it to
-  ``True`` if you are using providers that can be fully trusted.
+  ``True`` if you are using providers that can be fully trusted. Instead of
+  turning this on globally, you can also turn it on selectively per provider,
+  for example::
+
+      SOCIALACCOUNT_PROVIDERS = {
+        'google': {
+            'EMAIL_AUTHENTICATION': True
+        }
+      }
+
 
 SOCIALACCOUNT_EMAIL_VERIFICATION (=ACCOUNT_EMAIL_VERIFICATION)
   As ``ACCOUNT_EMAIL_VERIFICATION``, but for social accounts.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -298,6 +298,21 @@ SOCIALACCOUNT_AUTO_SIGNUP (=True)
   arises due to a duplicate email address the signup form will still
   kick in.
 
+SOCIALACCOUNT_EMAIL_AUTHENTICATION (=False)
+  Consider a scenario where a social login occurs, and the social account comes
+  with a verified email address (verified by the account provider), but that
+  email address is already taken by a local user account. Additionally, assume
+  that the local user account does not have any social account connected. Now,
+  if the provider can be fully trusted, you can argue that we should treat this
+  scenario as a login to the existing local user account even if the local
+  account does not already have the social account connected, because --
+  according to the provider -- the user logging in has ownership of the email
+  address.  This is how this scenario is handled when
+  ``SOCIALACCOUNT_EMAIL_AUTHENTICATION`` is set to ``True``. As this implies
+  that an untrustworthy provider can login to any local account by fabricating
+  social account data, this setting defaults to ``False``. Only set it to
+  ``True`` if you are using providers that can be fully trusted.
+
 SOCIALACCOUNT_EMAIL_VERIFICATION (=ACCOUNT_EMAIL_VERIFICATION)
   As ``ACCOUNT_EMAIL_VERIFICATION``, but for social accounts.
 


### PR DESCRIPTION
Consider a scenario where a social login occurs, and the social account comes with a verified email address (verified by the account provider), but that email address is already taken by a local user account. Additionally, assume that the local user account does not have any social account connected. Now, if the provider can be fully trusted, you can argue that we should treat this scenario as a login to the existing local user account even if the local account does not already have the social account connected, because -- according to the provider -- the user logging in has ownership of the email address.  This is how this scenario is handled when `SOCIALACCOUNT_EMAIL_AUTHENTICATION` is set to `True`. As this implies that an untrustworthy provider can login to any local account by fabricating social account data, this setting defaults to `False`. Only set it to `True` if you are using providers that can be fully trusted. 