### PR TITLE
fix(keycloak): use keycloak_callback reversed URL for Keycloak provider instead of openid_connect_callback reversed URL.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,7 +4,11 @@
 Note worthy changes
 -------------------
 
-- ...
+- Fix retrieval of callback URL for Keycloak provider which was computed by
+  reversing `openid_connect_callback` instead of `keycloak_callback`. Even if
+  both reversed URL would be the same, this resulted in a `NoReverseMatch`
+  error when `allauth.socialaccount.providers.openid_connect` was not present
+  in `INSTALLED_APPS`.
 
 
 0.55.0 (2023-08-22)

--- a/allauth/socialaccount/providers/keycloak/views.py
+++ b/allauth/socialaccount/providers/keycloak/views.py
@@ -6,11 +6,11 @@ from allauth.socialaccount.providers.oauth2.views import (
     OAuth2LoginView,
 )
 from allauth.socialaccount.providers.openid_connect.views import (
-    OpenIDConnectAdapter,
+    BaseOpenIDConnectAdapter,
 )
 
 
-class KeycloakOAuth2Adapter(OpenIDConnectAdapter):
+class KeycloakOAuth2Adapter(BaseOpenIDConnectAdapter):
     provider_id = KeycloakProvider.id
 
     @property
@@ -32,15 +32,5 @@ class KeycloakOAuth2Adapter(OpenIDConnectAdapter):
         )
 
 
-def oauth2_login(request):
-    view = OAuth2LoginView.adapter_view(
-        KeycloakOAuth2Adapter(request, KeycloakProvider.id)
-    )
-    return view(request)
-
-
-def oauth2_callback(request):
-    view = OAuth2CallbackView.adapter_view(
-        KeycloakOAuth2Adapter(request, KeycloakProvider.id)
-    )
-    return view(request)
+oauth2_login = OAuth2LoginView.adapter_view(KeycloakOAuth2Adapter)
+oauth2_callback = OAuth2CallbackView.adapter_view(KeycloakOAuth2Adapter)

--- a/allauth/socialaccount/providers/openid_connect/views.py
+++ b/allauth/socialaccount/providers/openid_connect/views.py
@@ -10,12 +10,8 @@ from allauth.socialaccount.providers.oauth2.views import (
 from allauth.utils import build_absolute_uri
 
 
-class OpenIDConnectAdapter(OAuth2Adapter):
+class BaseOpenIDConnectAdapter(OAuth2Adapter):
     supports_state = True
-
-    def __init__(self, request, provider_id):
-        self.provider_id = provider_id
-        super().__init__(request)
 
     @property
     def openid_config(self):
@@ -54,6 +50,12 @@ class OpenIDConnectAdapter(OAuth2Adapter):
         response.raise_for_status()
         extra_data = response.json()
         return self.get_provider().sociallogin_from_response(request, extra_data)
+
+
+class OpenIDConnectAdapter(BaseOpenIDConnectAdapter):
+    def __init__(self, request, provider_id):
+        self.provider_id = provider_id
+        super().__init__(request)
 
     def get_callback_url(self, request, app):
         callback_url = reverse(


### PR DESCRIPTION
Issue #3396 

Fix retrieval of callback URL for Keycloak provider which was computed by reversing `openid_connect_callback` instead
  of `keycloak_callback`. Even if resulting URL would be the same when all `allauth.urls` are installed, this could
  result in a `NoReverseMatch` error when OpenIDConnect provider's URLs are not included in project's URLs.