### PR TITLE
chore: fix typos

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -378,7 +378,7 @@ class BaseSignupForm(_base_signup_form_class()):
         email and return a standard "email verification sent" response.
         """
         if self.account_already_exists:
-            # Don't create a new acount, only send an email informing the user
+            # Don't create a new account, only send an email informing the user
             # that (s)he already has one...
             email = self.cleaned_data["email"]
             adapter = get_adapter()

--- a/allauth/socialaccount/providers/notion/provider.py
+++ b/allauth/socialaccount/providers/notion/provider.py
@@ -32,7 +32,7 @@ class NotionProvider(OAuth2Provider):
 
     def extract_uid(self, data):
         """
-        The unique identifer for Notion is a combination of the User ID
+        The unique identifier for Notion is a combination of the User ID
         and the Workspace ID they have authorized the application with.
         """
         user_id = data["owner"]["user"]["id"]

--- a/docs/account/forms.rst
+++ b/docs/account/forms.rst
@@ -99,7 +99,7 @@ Change Password
 *Used on*:
   `account_change_password <views.html#password-management>`__ view.
 
-Example overrride::
+Example override::
 
     from allauth.account.forms import ChangePasswordForm
     class MyCustomChangePasswordForm(ChangePasswordForm):

--- a/docs/account/views.rst
+++ b/docs/account/views.rst
@@ -98,6 +98,6 @@ email is sent pointing to the
 ``allauth.account.views.ConfirmEmailView`` view.
 
 The setting ``ACCOUNT_CONFIRM_EMAIL_ON_GET`` determines whether users
-have to manually confirm the address by submiting a confirmation form,
+have to manually confirm the address by submitting a confirmation form,
 or whether the address is automatically confirmed by a mere GET
 request.

--- a/docs/mfa/introduction.rst
+++ b/docs/mfa/introduction.rst
@@ -10,6 +10,6 @@ Authentication. It supports:
 
 - Viewing, downloading and regenerating recovery codes.
 
-Note that in order to use this functionality you need to instal the ``mfa`` extras of the ``django-allauth`` package::
+Note that in order to use this functionality you need to install the ``mfa`` extras of the ``django-allauth`` package::
 
   pip install django-allauth[mfa]

--- a/docs/socialaccount/providers/miro.rst
+++ b/docs/socialaccount/providers/miro.rst
@@ -1,7 +1,7 @@
 Miro
 ----
 
-Create your app here and aquire Client ID and Client Secret
+Create your app here and acquire Client ID and Client Secret
     https://miro.com/app/settings/user-profile/apps
 
 Development callback URL


### PR DESCRIPTION
# Submitting Pull Requests

Hi @pennersr, this is my first PR. I fix a few typos.

I guess this should read `YandexAccount` (not YandexAccout)
https://github.com/pennersr/django-allauth/blob/711395cf7ac0322beedd7b97fd900671a95bda5f/allauth/socialaccount/providers/yandex/provider.py#L7

But I was unsure, because this might break something.

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
