### PR TITLE
Fix LOGOUT_ON_PASSWORD_CHANGE settings not tested

### DIFF
--- a/allauth/account/tests/test_reset_password.py
+++ b/allauth/account/tests/test_reset_password.py
@@ -309,4 +309,4 @@ def test_password_change_ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE(settings, auth_client
         "password2": "newpass123"
     }
     resp = auth_client.post(reverse("account_change_password"), data)
-    assert resp['location'] == settings.ACCOUNT_LOGOUT_REDIRECT_URL
+    assert resp['location'] == settings.LOGOUT_REDIRECT_URL

--- a/allauth/account/tests/test_reset_password.py
+++ b/allauth/account/tests/test_reset_password.py
@@ -309,4 +309,4 @@ def test_password_change_ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE(settings, auth_client
         "password2": "newpass123"
     }
     resp = auth_client.post(reverse("account_change_password"), data)
-    assert resp['location'] == reverse("account_login")
+    assert resp['location'] == settings.ACCOUNT_LOGOUT_REDIRECT_URL

--- a/allauth/account/tests/test_reset_password.py
+++ b/allauth/account/tests/test_reset_password.py
@@ -280,6 +280,17 @@ class ResetPasswordTests(TestCase):
         # EmailVerificationMethod.MANDATORY sends us to the confirm-email page
         self.assertRedirects(resp, "/confirm-email/")
 
+    @override_settings(ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE=True)
+    def test_password_change_ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE(self):
+        user = self._create_user_and_login()
+        data = {
+            "oldpassword": "doe", 
+            "password1": "newpass123", 
+            "password2": "newpass123"
+        }
+        resp = self.client.post(reverse("account_change_password"), data)
+        self.assertRedirects(resp, reverse("account_login"))
+
     def _create_user(self, username="john", password="doe", **kwargs):
         user = get_user_model().objects.create(
             username=username, is_active=True, **kwargs

--- a/allauth/account/tests/test_reset_password.py
+++ b/allauth/account/tests/test_reset_password.py
@@ -280,17 +280,6 @@ class ResetPasswordTests(TestCase):
         # EmailVerificationMethod.MANDATORY sends us to the confirm-email page
         self.assertRedirects(resp, "/confirm-email/")
 
-    @override_settings(ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE=True)
-    def test_password_change_ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE(self):
-        user = self._create_user_and_login()
-        data = {
-            "oldpassword": "doe", 
-            "password1": "newpass123", 
-            "password2": "newpass123"
-        }
-        resp = self.client.post(reverse("account_change_password"), data)
-        self.assertRedirects(resp, reverse("account_login"))
-
     def _create_user(self, username="john", password="doe", **kwargs):
         user = get_user_model().objects.create(
             username=username, is_active=True, **kwargs
@@ -311,3 +300,13 @@ class ResetPasswordTests(TestCase):
     def _password_set_or_change_redirect(self, urlname, usable_password):
         self._create_user_and_login(usable_password)
         return self.client.get(reverse(urlname))
+
+def test_password_change_ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE(settings, auth_client, user_password):
+    settings.ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE = True
+    data = {
+        "oldpassword": user_password, 
+        "password1": "newpass123", 
+        "password2": "newpass123"
+    }
+    resp = auth_client.post(reverse("account_change_password"), data)
+    assert resp['location'] == reverse("account_login")

--- a/allauth/account/tests/test_reset_password.py
+++ b/allauth/account/tests/test_reset_password.py
@@ -301,12 +301,15 @@ class ResetPasswordTests(TestCase):
         self._create_user_and_login(usable_password)
         return self.client.get(reverse(urlname))
 
-def test_password_change_ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE(settings, auth_client, user_password):
+
+def test_password_change_ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE(
+    settings, auth_client, user_password
+):
     settings.ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE = True
     data = {
-        "oldpassword": user_password, 
-        "password1": "newpass123", 
-        "password2": "newpass123"
+        "oldpassword": user_password,
+        "password1": "newpass123",
+        "password2": "newpass123",
     }
     resp = auth_client.post(reverse("account_change_password"), data)
-    assert resp['location'] == settings.LOGOUT_REDIRECT_URL
+    assert resp["location"] == app_settings.LOGOUT_REDIRECT_URL

--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -628,13 +628,7 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
         return super(PasswordChangeView, self).dispatch(request, *args, **kwargs)
 
     def render_to_response(self, context, **response_kwargs):
-        if self.request.user.is_anonymous:
-            # We end up here when `ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE = True`.
-            redirect_url = get_adapter(self.request).get_logout_redirect_url(
-                self.request
-            )
-            return HttpResponseRedirect(redirect_url)
-        elif not self.request.user.has_usable_password():
+        if not self.request.user.has_usable_password():
             return HttpResponseRedirect(reverse("account_set_password"))
         return super(PasswordChangeView, self).render_to_response(
             context, **response_kwargs
@@ -658,6 +652,11 @@ class PasswordChangeView(AjaxCapableProcessFormViewMixin, FormView):
             request=self.request,
             user=self.request.user,
         )
+        if app_settings.LOGOUT_ON_PASSWORD_CHANGE:
+            redirect_url = get_adapter(self.request).get_logout_redirect_url(
+                self.request
+            )
+            return HttpResponseRedirect(redirect_url)
         return super(PasswordChangeView, self).form_valid(form)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

Let's test this and find out that it is bugged, then I'll ad a new commit to fix (TDD style)