### PR TITLE
feat(socialaccount): Add new socialaccount signal after user and socialaccount save

### DIFF
--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -21,7 +21,7 @@ from ..utils import (
     serialize_instance,
     valid_email_or_none,
 )
-from . import app_settings
+from . import app_settings, signals
 
 
 class DefaultSocialAccountAdapter(object):
@@ -88,6 +88,7 @@ class DefaultSocialAccountAdapter(object):
         else:
             get_account_adapter().populate_username(request, u)
         sociallogin.save(request)
+        signals.post_user_and_socialaccount_save.send(self.__class__, sociallogin=sociallogin)
         return u
 
     def populate_user(self, request, sociallogin, data):

--- a/allauth/socialaccount/adapter.py
+++ b/allauth/socialaccount/adapter.py
@@ -21,7 +21,7 @@ from ..utils import (
     serialize_instance,
     valid_email_or_none,
 )
-from . import app_settings, signals
+from . import app_settings
 
 
 class DefaultSocialAccountAdapter(object):
@@ -88,7 +88,6 @@ class DefaultSocialAccountAdapter(object):
         else:
             get_account_adapter().populate_username(request, u)
         sociallogin.save(request)
-        signals.post_user_and_socialaccount_save.send(self.__class__, sociallogin=sociallogin)
         return u
 
     def populate_user(self, request, sociallogin, data):

--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -262,6 +262,9 @@ class SocialLogin(object):
         user.save()
         self.account.user = user
         self.account.save()
+        signals.post_user_and_socialaccount_save.send(
+            self.__class__, user=user, account=self.account
+        )
         if app_settings.STORE_TOKENS and self.token:
             self.token.account = self.account
             self.token.save()

--- a/allauth/socialaccount/signals.py
+++ b/allauth/socialaccount/signals.py
@@ -22,3 +22,7 @@ social_account_updated = Signal()
 # account.
 # Provides the arguments "request", "socialaccount"
 social_account_removed = Signal()
+
+# Sent after a user instance and user's social account are saved to the db.
+# Provides the argument "sociallogin"
+post_user_and_socialaccount_save = Signal()

--- a/allauth/socialaccount/signals.py
+++ b/allauth/socialaccount/signals.py
@@ -24,5 +24,5 @@ social_account_updated = Signal()
 social_account_removed = Signal()
 
 # Sent after a user instance and user's social account are saved to the db.
-# Provides the argument "sociallogin"
+# Provides the arguments "user", "socialaccount"
 post_user_and_socialaccount_save = Signal()

--- a/docs/socialaccount/signals.rst
+++ b/docs/socialaccount/signals.rst
@@ -24,3 +24,6 @@ hook to them for your own needs.
 - ``allauth.socialaccount.signals.social_account_removed(request, socialaccount)``
     Sent after a user disconnects a social account from their local
     account.
+
+- ``allauth.socialaccount.signals.post_user_and_socialaccount_save(sociallogin)``
+    Sent after a user instance and user's social account are saved to the db.

--- a/docs/socialaccount/signals.rst
+++ b/docs/socialaccount/signals.rst
@@ -25,5 +25,5 @@ hook to them for your own needs.
     Sent after a user disconnects a social account from their local
     account.
 
-- ``allauth.socialaccount.signals.post_user_and_socialaccount_save(sociallogin)``
+- ``allauth.socialaccount.signals.post_user_and_socialaccount_save(user, socialaccount)``
     Sent after a user instance and user's social account are saved to the db.


### PR DESCRIPTION
The post_user_and_socialaccount_save signal is triggered after the user and the user's socialaccount are saved to the db.

I found myself in need to create/update user's related model using data from `socialaccount.extra_data` after user logs in with a social account but I couldn't use any of the existing signals, because:
- `allauth.socialaccount.signals.pre_social_login` is triggered before the user and the user's socialaccount are saved to the DB, so can't create a related model instance that has ForeignKey / OneToOne relation to the user.
- `allauth.socialaccount.signals.social_account_added` is only triggered after connection to an existing account,
- `allauth.socialaccount.signals.social_account_updated` in my case is only triggered after the user logs out and logs back in because of the settings I use:
```python
SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
SOCIALACCOUNT_EMAIL_VERIFICATION = "none"
```
\+ `"VERIFIED_EMAIL": True,` for every provider.