### PR TITLE
feat(account): Store emails lower case, treat case insensitive

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -4,6 +4,12 @@
 
 - New providers: TikTok, Lichess.
 
+- Starting since version 0.62.0, new email addresses are always stored as lower
+  case. In this version, we take the final step and also convert existing data
+  to lower case, alter the database indices and perform lookups
+  accordingly. Migrations are in place.  For rationale, see the note about email
+  case sensitivity in the documentation.
+
 
 0.62.1 (2024-04-24)
 *******************

--- a/allauth/account/managers.py
+++ b/allauth/account/managers.py
@@ -1,4 +1,3 @@
-import functools
 from datetime import timedelta
 
 from django.db import models
@@ -53,7 +52,7 @@ class EmailAddressManager(models.Manager):
     def add_email(self, request, user, email, confirm=False, signup=False):
         email = email.lower()
         email_address, created = self.get_or_create(
-            user=user, email__iexact=email, defaults={"email": email}
+            user=user, email=email, defaults={"email": email}
         )
 
         if created and confirm:
@@ -84,7 +83,7 @@ class EmailAddressManager(models.Manager):
         # this is a list rather than a generator because we probably want to
         # do a len() on it right away
         return [
-            address.user for address in self.filter(verified=True, email__iexact=email)
+            address.user for address in self.filter(verified=True, email=email.lower())
         ]
 
     def fill_cache_for_user(self, user, addresses):
@@ -101,26 +100,22 @@ class EmailAddressManager(models.Manager):
         addresses = getattr(user, cache_key, None)
         email = email.lower()
         if addresses is None:
-            ret = self.get(user=user, email__iexact=email)
+            ret = self.get(user=user, email=email)
             # To avoid additional lookups when e.g.
             # EmailAddress.set_as_primary() starts touching self.user
             ret.user = user
             return ret
         else:
             for address in addresses:
-                if address.email.lower() == email.lower():
+                if address.email == email:
                     return address
             raise self.model.DoesNotExist()
 
     def is_verified(self, email):
-        return self.filter(email__iexact=email, verified=True).exists()
+        return self.filter(email=email.lower(), verified=True).exists()
 
     def lookup(self, emails):
-        q_list = [Q(email__iexact=e) for e in emails]
-        if not q_list:
-            return self.none()
-        q = functools.reduce(lambda a, b: a | b, q_list)
-        return self.filter(q)
+        return self.filter(email__in=[e.lower() for e in emails])
 
 
 class EmailConfirmationManager(models.Manager):

--- a/allauth/account/migrations/0006_emailaddress_lower.py
+++ b/allauth/account/migrations/0006_emailaddress_lower.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from django.db import migrations
+from django.db.models.functions import Lower
+
+from allauth.account import app_settings
+
+
+def forwards(apps, schema_editor):
+    EmailAddress = apps.get_model("account.EmailAddress")
+    User = apps.get_model(settings.AUTH_USER_MODEL)
+    EmailAddress.objects.all().exclude(email=Lower("email")).update(
+        email=Lower("email")
+    )
+    email_field = app_settings.USER_MODEL_EMAIL_FIELD
+    if email_field:
+        User.objects.all().exclude(**{email_field: Lower(email_field)}).update(
+            **{email_field: Lower(email_field)}
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("account", "0005_emailaddress_idx_upper_email"),
+    ]
+
+    operations = [migrations.RunPython(forwards)]

--- a/allauth/account/migrations/0007_emailaddress_idx_email.py
+++ b/allauth/account/migrations/0007_emailaddress_idx_email.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+EMAIL_MAX_LENGTH = getattr(settings, "ACCOUNT_EMAIL_MAX_LENGTH", 254)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("account", "0006_emailaddress_lower"),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name="emailaddress",
+            name="account_emailaddress_upper",
+        ),
+        migrations.AlterField(
+            model_name="emailaddress",
+            name="email",
+            field=models.EmailField(
+                db_index=True, max_length=EMAIL_MAX_LENGTH, verbose_name="email address"
+            ),
+        ),
+    ]

--- a/allauth/account/models.py
+++ b/allauth/account/models.py
@@ -4,9 +4,8 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import signing
 from django.db import models
-from django.db.models import Index, Q
+from django.db.models import Q
 from django.db.models.constraints import UniqueConstraint
-from django.db.models.functions import Upper
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -22,6 +21,7 @@ class EmailAddress(models.Model):
         on_delete=models.CASCADE,
     )
     email = models.EmailField(
+        db_index=True,
         max_length=app_settings.EMAIL_MAX_LENGTH,
         verbose_name=_("email address"),
     )
@@ -42,7 +42,6 @@ class EmailAddress(models.Model):
                     condition=Q(verified=True),
                 )
             ]
-        indexes = [Index(Upper("email"), name="account_emailaddress_upper")]
 
     def __str__(self):
         return self.email
@@ -58,7 +57,7 @@ class EmailAddress(models.Model):
         if app_settings.UNIQUE_EMAIL:
             conflict = (
                 EmailAddress.objects.exclude(pk=self.pk)
-                .filter(verified=True, email__iexact=self.email)
+                .filter(verified=True, email=self.email)
                 .exists()
             )
         return not conflict

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -385,10 +385,7 @@ def sync_user_email_addresses(user):
     from .models import EmailAddress
 
     email = user_email(user)
-    if (
-        email
-        and not EmailAddress.objects.filter(user=user, email__iexact=email).exists()
-    ):
+    if email and not EmailAddress.objects.filter(user=user, email=email).exists():
         # get_or_create() to gracefully handle races
         EmailAddress.objects.get_or_create(
             user=user, email=email, defaults={"primary": False, "verified": False}
@@ -431,7 +428,8 @@ def filter_users_by_email(email, is_active=None, prefer_verified=False):
     from .models import EmailAddress
 
     User = get_user_model()
-    mails = EmailAddress.objects.filter(email__iexact=email).select_related("user")
+    email = email.lower()
+    mails = EmailAddress.objects.filter(email=email).select_related("user")
     mails = list(mails)
     is_verified = False
     if prefer_verified:
@@ -444,7 +442,7 @@ def filter_users_by_email(email, is_active=None, prefer_verified=False):
         if _unicode_ci_compare(e.email, email):
             users.append(e.user)
     if app_settings.USER_MODEL_EMAIL_FIELD and not is_verified:
-        q_dict = {app_settings.USER_MODEL_EMAIL_FIELD + "__iexact": email}
+        q_dict = {app_settings.USER_MODEL_EMAIL_FIELD: email}
         user_qs = User.objects.filter(**q_dict)
         for user in user_qs.iterator():
             user_email = getattr(user, app_settings.USER_MODEL_EMAIL_FIELD)


### PR DESCRIPTION
Formally, email addresses are case sensitive because the local part (the part before the "@") can be a case sensitive user name.  To deal with this, workarounds have been in place for a long time that store email addresses in their original case, while performing lookups in a case insensitive style. This approach led to subtle bugs in upstream code, and also comes at a performance cost (``__iexact`` lookups). The latter requires case insensitive index support, which not all databases support. Re-evaluating the approach in current times has led to the conclusion that the benefits do not outweigh the costs.  Therefore, email addresses are now always stored as lower case, and migrations are in place to address existing records.