### PR TITLE
feat(socialaccounts):  Check in User.email for account matching email address

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -338,6 +338,14 @@ class SocialLogin(object):
                 self.connect(context.request, address.user)
             else:
                 self.user = address.user
+            return
+
+        user = get_user_model().objects.filter(email__in=emails).first()
+        if user:
+            if app_settings.EMAIL_AUTHENTICATION_AUTO_CONNECT:
+                self.connect(context.request, user)
+            else:
+                self.user = user
 
     def get_redirect_url(self, request):
         url = self.state.get("next")


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.


Currently when EMAIL_AUTHENTIFICATION is True, we only checks for other socialaccount accounts and not for accounts in User. The usecase is when migrating the authentification system to one using User.email to store emails to allauth which use EmailAddress.emails

This probably should be behind a configuration flag, I'm not an Django expert so maybe there is better way to do this.
