### PR TITLE
fix(docs): fix typo in mfa configuration document

### DIFF
--- a/docs/mfa/configuration.rst
+++ b/docs/mfa/configuration.rst
@@ -16,5 +16,5 @@ Available settings:
 ``MFA_TOTP_DIGITS`` (default: ``6``)
   The number of digits for TOTP codes.
 
-``MFA_TOTP_ISSUES`` (default: ``""``)
+``MFA_TOTP_ISSUER`` (default: ``""``)
   The issuer (appearing in the TOTP QR code).


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [] If your changes are significant, please update `ChangeLog.rst`.
 - [] If your change is substantial, feel free to add yourself to `AUTHORS`.


During development, I noticed that the MFA configuration documentation references a setting key named `MFA_TOTP_ISSUES`. However, it appears that the accurate key should be `MFA_TOTP_ISSUER`.
This pull request corrects the `MFA_TOTP_ISSUES` key to the accurate `MFA_TOTP_ISSUER` in the documentation. This minor adjustment will help to prevent potential confusion for developers who refer to the document in the future, ensuring that they utilize the correct setting key without hesitation.
This change solely affects the documentation and does not impact the codebase or its functionality in any way.

Thank you.