### PR TITLE
fix(openstreetmap): Update provider url

### DIFF
--- a/allauth/socialaccount/providers/openstreetmap/views.py
+++ b/allauth/socialaccount/providers/openstreetmap/views.py
@@ -12,7 +12,7 @@ from .provider import OpenStreetMapProvider
 
 
 class OpenStreetMapAPI(OAuth):
-    url = "https://www.openstreetmap.org/api/0.6/user/details"
+    url = "https://api.openstreetmap.org/api/0.6/user/details"
 
     def get_user_info(self):
         raw_xml = self.query(self.url)


### PR DESCRIPTION
### Switch to api.openstreetmap.org API host

Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)