### PR TITLE
fix(mfa): Use "one-time-code" autocomplete hint

### DIFF
--- a/allauth/mfa/forms.py
+++ b/allauth/mfa/forms.py
@@ -48,7 +48,12 @@ class AuthenticateForm(forms.Form):
 
 
 class ActivateTOTPForm(forms.Form):
-    code = forms.CharField(label=_("Authenticator code"))
+    code = forms.CharField(
+        label=_("Authenticator code"),
+        widget=forms.TextInput(
+            attrs={"placeholder": _("Code"), "autocomplete": "one-time-code"},
+        ),
+    )
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user")

--- a/allauth/mfa/forms.py
+++ b/allauth/mfa/forms.py
@@ -14,7 +14,7 @@ class AuthenticateForm(forms.Form):
     code = forms.CharField(
         label=_("Code"),
         widget=forms.TextInput(
-            attrs={"placeholder": _("Code"), "autocomplete": "off"},
+            attrs={"placeholder": _("Code"), "autocomplete": "one-time-code"},
         ),
     )
 


### PR DESCRIPTION
This small change also makes it a little easier to detect the field in custom form templates (e.g. with `django-widget-tweaks`).

Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#sect16
