### PR TITLE
Add a "remove pending email address" button

### DIFF
--- a/allauth/templates/account/email_change.html
+++ b/allauth/templates/account/email_change.html
@@ -28,6 +28,9 @@
                     {% element button type="submit" name="action_send" %}
                         {% trans 'Re-send Verification' %}
                     {% endelement %}
+                    {% element button type="submit" name="action_remove" %}
+                        {% trans 'Remove pending email address' %}
+                    {% endelement %}
                 {% endslot %}
             {% endelement %}
         {% endif %}


### PR DESCRIPTION
Adds a button to remove an address that's still pending verification. 
Without it users may get stuck being unable to revert a change.

This works without any required changes in the view.
