### PR TITLE
fix(socialaccount): Allow new sociallogin accounts to establish SITE_ID from request

### DIFF
--- a/allauth/socialaccount/helpers.py
+++ b/allauth/socialaccount/helpers.py
@@ -205,7 +205,7 @@ def _add_social_account(request, sociallogin):
 
 def complete_social_login(request, sociallogin):
     assert not sociallogin.is_existing
-    sociallogin.lookup()
+    sociallogin.lookup(request)
     try:
         get_adapter().pre_social_login(request, sociallogin)
         signals.pre_social_login.send(

--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -274,12 +274,12 @@ class SocialLogin(object):
             return False
         return get_user_model().objects.filter(pk=self.user.pk).exists()
 
-    def lookup(self):
+    def lookup(self, request=None):
         """Look up the existing local user account to which this social login
         points, if any.
         """
         if not self._lookup_by_socialaccount():
-            provider_id = self.account.get_provider().id
+            provider_id = self.account.get_provider(request).id
             if app_settings.EMAIL_AUTHENTICATION or app_settings.PROVIDERS.get(
                 provider_id, {}
             ).get("EMAIL_AUTHENTICATION", False):


### PR DESCRIPTION
Commit https://github.com/pennersr/django-allauth/commit/be779dfee5a328a3a42edc2c95320ad00a4c7833 broke the ability to create new sociallogin accounts in Mailman3 when using django sites framwork, because the request object is not passed down the call chain.  This eventually results in the error:

> Exception Type: ImproperlyConfigured at /accounts/google/login/callback/
> Exception Value: You're using the Django "sites framework" without having set the SITE_ID setting. Create a site in your database and set the SITE_ID setting or pass a request to Site.objects.get_current() to fix this error.

This patch (optionally) passes the request object to resolve this issue.