### PR TITLE
fix(socialaccount): Allow account connections page to establish SITE_ID from request

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -143,8 +143,8 @@ class SocialAccount(models.Model):
         )
         return provider
 
-    def get_provider_account(self):
-        return self.get_provider().wrap_account(self)
+    def get_provider_account(self, request=None):
+        return self.get_provider(request).wrap_account(self)
 
 
 class SocialToken(models.Model):

--- a/allauth/socialaccount/templatetags/socialaccount.py
+++ b/allauth/socialaccount/templatetags/socialaccount.py
@@ -67,7 +67,7 @@ def get_social_accounts(user):
 @register.simple_tag(takes_context=True)
 def get_provider_account(context, base_account):
     """
-    Returns the provider account in the contest of the current site ID
+    Returns the provider account in the context of the current site ID
 
     Usage: `{% get_provider_account base_account as account %}`.
     """

--- a/allauth/socialaccount/templatetags/socialaccount.py
+++ b/allauth/socialaccount/templatetags/socialaccount.py
@@ -65,6 +65,17 @@ def get_social_accounts(user):
 
 
 @register.simple_tag(takes_context=True)
+def get_provider_account(context, base_account):
+    """
+    Returns the provider account in the contest of the current site ID
+
+    Usage: `{% get_provider_account base_account as account %}`.
+    """
+    request = context["request"]
+    return base_account.get_provider_account(request)
+
+
+@register.simple_tag(takes_context=True)
 def get_providers(context):
     """
     Returns a list of social authentication providers.

--- a/allauth/socialaccount/views.py
+++ b/allauth/socialaccount/views.py
@@ -128,7 +128,7 @@ class ConnectionsView(AjaxCapableProcessFormViewMixin, FormView):
     def get_ajax_data(self):
         account_data = []
         for account in SocialAccount.objects.filter(user=self.request.user):
-            provider_account = account.get_provider_account()
+            provider_account = account.get_provider_account(self.request)
             account_data.append(
                 {
                     "id": account.pk,

--- a/allauth/templates/socialaccount/connections.html
+++ b/allauth/templates/socialaccount/connections.html
@@ -1,6 +1,7 @@
 {% extends "socialaccount/base_manage.html" %}
 {% load i18n %}
 {% load allauth %}
+{% load socialaccount %}
 {% block head_title %}
     {% trans "Account Connections" %}
 {% endblock head_title %}
@@ -17,7 +18,7 @@
             {% slot body %}
                 {% csrf_token %}
                 {% for acc in form.fields.account.choices %}
-                    {% with account=acc.0.instance.get_provider_account %}
+                    {% get_provider_account acc.0.instance as account %}
                         {% setvar radio_id %}
                             id_account_{{ account.account.pk }}
                         {% endsetvar %}
@@ -32,7 +33,6 @@
                                 {% endelement %}
                             {% endslot %}
                         {% endelement %}
-                    {% endwith %}
                 {% endfor %}
             {% endslot %}
             {% slot actions %}


### PR DESCRIPTION
Similar to the fix in #3548 , the subprovider refactoring in 0.55 created the necessity to identity SITE_ID based on the request in get_provider_account, which is used in the Django template for the Account Connections page.

This was the simplest way I could find to resolve the problem and get this page working again.  I know next to nothing about Django, so I'm open to feedback.  This and the previous PR may indicate a systemic challenge with the subprovider implementation that may require a different refactoring if related issues arise in the future.