### PR TITLE
fix(socialaccount): Allow account connections page to establish SITE_ID from request

### DIFF
--- a/allauth/socialaccount/models.py
+++ b/allauth/socialaccount/models.py
@@ -144,7 +144,7 @@ class SocialAccount(models.Model):
         return provider
 
     def get_provider_account(self):
-        return self.get_provider().wrap_account(self)
+        return self.get_provider(context.request).wrap_account(self)
 
 
 class SocialToken(models.Model):


### PR DESCRIPTION
Similar to the fix in https://github.com/pennersr/django-allauth/pull/3548 , the subprovider refactoring in 0.55 created the necessity to identity SITE_ID based on the request in get_provider_account, which is used in the Django template for the Account Connections page.