### PR TITLE
feat(loginform): use EmailInput widget

### DIFF
--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -107,9 +107,8 @@ class LoginForm(forms.Form):
         self.request = kwargs.pop("request", None)
         super(LoginForm, self).__init__(*args, **kwargs)
         if app_settings.AUTHENTICATION_METHOD == AuthenticationMethod.EMAIL:
-            login_widget = forms.TextInput(
+            login_widget = forms.EmailInput(
                 attrs={
-                    "type": "email",
                     "placeholder": _("Email address"),
                     "autocomplete": "email",
                 }


### PR DESCRIPTION
By utilizing Django's built-in EmailInput widget within the LoginForm instead of the general TextInput, we eliminate the need to override the LoginForm class for maintaining uniformity with other occurrences of EmailInput.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers/<provider name>.rst` and `docs/providers/index.rst` Provider Specifics toctree.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.
