### PR TITLE
fix(google): get_avatar_url sometimes returns None

### DIFF
--- a/allauth/socialaccount/providers/google/views.py
+++ b/allauth/socialaccount/providers/google/views.py
@@ -26,6 +26,7 @@ from .provider import GoogleProvider
 
 CERTS_URL = "https://www.googleapis.com/oauth2/v1/certs"
 
+IDENTITY_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
 
 ACCESS_TOKEN_URL = (
     getattr(settings, "SOCIALACCOUNT_PROVIDERS", {})
@@ -45,12 +46,20 @@ ID_TOKEN_ISSUER = (
     .get("ID_TOKEN_ISSUER", "https://accounts.google.com")
 )
 
+FETCH_USERINFO = (
+    getattr(settings,"SOCIALACCOUNT_PROVIDERS", {})
+    .get("google",{})
+    .get("FETCH_USERINFO",False)
+)
+
 
 class GoogleOAuth2Adapter(OAuth2Adapter):
     provider_id = GoogleProvider.id
     access_token_url = ACCESS_TOKEN_URL
     authorize_url = AUTHORIZE_URL
     id_token_issuer = ID_TOKEN_ISSUER
+    identity_url = IDENTITY_URL
+    fetch_userinfo = FETCH_USERINFO
 
     def complete_login(self, request, app, token, response, **kwargs):
         try:
@@ -73,6 +82,19 @@ class GoogleOAuth2Adapter(OAuth2Adapter):
             )
         except jwt.PyJWTError as e:
             raise OAuth2Error("Invalid id_token") from e
+
+        if self.fetch_userinfo and 'picture' not in identity_data:
+            resp = (
+                get_adapter()
+                .get_requests_session()
+                .get(
+                    self.identity_url, headers={"Authorization": "Bearer {}".format(token)}
+                )
+            )
+            if not resp.ok:
+                raise OAuth2Error("Request to user info failed")
+            identity_data['picture'] = resp.json()['picture']
+
         login = self.get_provider().sociallogin_from_response(request, identity_data)
         return login
 

--- a/docs/socialaccount/providers/google.rst
+++ b/docs/socialaccount/providers/google.rst
@@ -70,6 +70,23 @@ receive a refresh token on first login and on reauthentication requests
 without involving the user's browser). When unspecified, Google defaults
 to ``online``.
 
+By default, the userinfo endpoint will not be fetched. In most cases, 
+this will be fine, as most in scope user data is gained via decoding
+the JWT. However if users have a private style of avatar_url
+then this will not ordinarily be returned in the JWT and 
+as such, subsequent calls to get_avatar_url will return None.
+
+You can optionally specify the following setting so that the userinfo
+endpoint will be used to populate the avatar_url for those users
+who have a private style of avatar_url.
+
+.. code-block:: python
+
+    SOCIALACCOUNT_PROVIDERS = {
+        'google': {
+            'FETCH_USERINFO' : True
+        }
+    }
 
 One Tap Sign-In
 ***************


### PR DESCRIPTION
# Summary
The Google provider is configured to rely on data decoded from the JWT for populating the user details. This results in a situation where, for certain users, `get_avatar_url` returns `None` because the photo URL field is not always included in the JWT. An alternative approach is to hit the userinfo API, which consistently provides the user data across all accounts. The existing default scopes are sufficient to query this endpoint.

# Detail
The provider is currently configured to rely on data decoded from the JWT used in the login process for populating the user photo URL and other user attributes.

## User photos in Google
Google seems to maintain two types of user photos which we will call "public" and "private" even though both are technically publicly accessible given you have the right URL:
- Public user photo URLs contain ~100 characters. I found that my personal Gmail account had a public photo URL.
- Private user photo URLs are much longer and contain ~1000 characters. I think this is done to make them harder to discover. I found that my paid-for G Suite account had a private photo URL.

## JWT return values
I was able to establish via the Google OAuth 2 playground that the information encoded in a JWT differs based on the type of photo URL that an account has, such that:
- For public user photos, the returned JWT includes the user photo URL.
- For private user photos, the returned JWT does not include the user photo URL. Presumably, that is done to keep the overall size of the JWT down. 

Therefore, under the current approach, the user photo url is sometimes not populated into the backend as part of the "Extra data" json. Whether it is populated or not depends on what type of profile photo the user has. This is despite the fact that the default scopes are sufficient to access the photo url regardless of whether it is public or private. The relevant endpoint is just never used as part of the current approach.

## Alternative approach to accessing user details
Given that the current default scopes for the Google provider are sufficient to actually access the photo URL of each user, doing so only requires hitting the relevant "user.info" endpoint, which is "https://www.googleapis.com/oauth2/v2/userinfo." My view is that any field that is reasonably needed by django-allauth can be gained by hitting this endpoint and so I have commented out the existing code entirely and all user details are now gained via this endpoint rather than decoding the JWT. 

## Custom scopes
If an existing codebase has used custom scopes, this should not be an issue. From what I can tell any scope at all is sufficient to query the userinfo endpoint, but what is returned will vary depending on whether you included email and profile scopes which are included by default.

# Conclusion 
This pull request changes the methodology used by the google provider to grab the user details to use the relevant endpoint rather than simply decoding the JWT. This was done in order to fix inconsistently populated user photo URLs. I welcome any debate or feedback on this issue that is needed before this PR can be merged.

## Acknowledgement
Thank you so much for maintaining and providing such great open source software.
