### PR TITLE
fix steam login problem

### DIFF
--- a/allauth/socialaccount/providers/steam/provider.py
+++ b/allauth/socialaccount/providers/steam/provider.py
@@ -41,7 +41,7 @@ def request_steam_account_summary(api_key, steam_id):
     method = "ISteamUser/GetPlayerSummaries/v0002/"
     params = {"key": api_key, "steamids": steam_id}
 
-    resp = get_adapter().get_requests_session().get(api_base + method, params)
+    resp = get_adapter().get_requests_session().get(api_base + method, prams=params)
     resp.raise_for_status()
     data = resp.json()
 


### PR DESCRIPTION
Fixes following error when trying to sign in using Steam provider
```

TypeError at /accounts/steam/callback/

Session.get() takes 2 positional arguments but 3 were given
```