### PR TITLE
fix(readme): Update cloning URL to use SSH format

### DIFF
--- a/examples/regular-django/README.rst
+++ b/examples/regular-django/README.rst
@@ -7,7 +7,7 @@ django-allauth example application in this directory:
 
 ::
 
-    $ git clone git://github.com/pennersr/django-allauth.git
+    $ git clone git@github.com:pennersr/django-allauth.git
     $ cd django-allauth/examples/regular-django
     $ virtualenv venv
     $ . venv/bin/activate


### PR DESCRIPTION
The README's cloning instructions using the git:// URL have been updated to the SSH format. This change addresses the deprecation of unauthenticated git protocol (git://) by GitHub, which is no longer supported as of their security policy update.

See GitHub's security announcement for more details: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
