### PR TITLE
fix(microsoft) get_avatar_url does not work

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,4 +1,4 @@
-0.61.0 (unreleased)
+0.61.0 (2024-02-07)
 *******************
 
 Note worthy changes
@@ -8,6 +8,20 @@ Note worthy changes
   ``ACCOUNT_EMAIL_NOTIFICATIONS = True``, email notifications such as "Your
   password was changed", including information on user agent / IP address from where the change
   originated, will be emailed.
+
+- Google: Starting from 0.52.0, the ``id_token`` is being used for extracting
+  user information.  To accommodate for scenario's where django-allauth is used
+  in contexts where the ``id_token`` is not posted, the provider now looks up
+  the required information from the ``/userinfo`` endpoint based on the access
+  token if the ``id_token`` is absent.
+
+
+Security notice
+---------------
+
+- MFA: It was possible to reuse a valid TOTP code within its time window. This
+  has now been addressed. As a result, a user can now only login once per 30
+  seconds (``MFA_TOTP_PERIOD``).
 
 
 Backwards incompatible changes

--- a/allauth/__init__.py
+++ b/allauth/__init__.py
@@ -8,7 +8,7 @@ r"""
 
 """
 
-VERSION = (0, 61, 0, "dev", 0)
+VERSION = (0, 61, 0, "final", 0)
 
 __title__ = "django-allauth"
 __version_info__ = VERSION

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -39,7 +39,7 @@ def get_next_redirect_url(request, redirect_field_name="next"):
     via the request.
     """
     redirect_to = get_request_param(request, redirect_field_name)
-    if not get_adapter().is_safe_url(redirect_to):
+    if redirect_to and not get_adapter().is_safe_url(redirect_to):
         redirect_to = None
     return redirect_to
 

--- a/allauth/mfa/totp.py
+++ b/allauth/mfa/totp.py
@@ -7,6 +7,7 @@ import time
 from io import BytesIO
 from urllib.parse import quote
 
+from django.core.cache import cache
 from django.utils.http import urlencode
 
 import qrcode
@@ -104,5 +105,20 @@ class TOTP:
         self.instance.delete()
 
     def validate_code(self, code):
+        if self._is_code_used(code):
+            return False
+
         secret = decrypt(self.instance.data["secret"])
-        return validate_totp_code(secret, code)
+        valid = validate_totp_code(secret, code)
+        if valid:
+            self._mark_code_used(code)
+        return valid
+
+    def _get_used_cache_key(self, code):
+        return f"allauth.mfa.totp.used?user={self.instance.user_id}&code={code}"
+
+    def _is_code_used(self, code):
+        return cache.get(self._get_used_cache_key(code)) == "y"
+
+    def _mark_code_used(self, code):
+        cache.set(self._get_used_cache_key(code), "y", timeout=app_settings.TOTP_PERIOD)

--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -13,11 +13,13 @@ from django.urls import reverse
 import pytest
 
 from allauth.account import app_settings as account_settings
-from allauth.account.adapter import get_adapter
+from allauth.account.adapter import get_adapter as get_account_adapter
 from allauth.account.models import EmailAddress, EmailConfirmation
 from allauth.account.signals import user_signed_up
-from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.adapter import get_adapter
+from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.socialaccount.providers.apple.client import jwt_encode
+from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import TestCase, mocked_response
 
@@ -155,7 +157,7 @@ class GoogleTests(OAuth2TestsMixin, TestCase):
         self.client.cookies[settings.SESSION_COOKIE_NAME] = store.session_key
         request = RequestFactory().get("/")
         request.session = self.client.session
-        adapter = get_adapter()
+        adapter = get_account_adapter()
         adapter.stash_verified_email(request, self.email)
         request.session.save()
 
@@ -271,3 +273,70 @@ def test_login_by_token(db, client, settings_with_google_provider):
                     assert resp.status_code == 302
                     socialaccount = SocialAccount.objects.get(uid="123sub")
                     assert socialaccount.user.email == "raymond@example.com"
+
+
+@pytest.mark.parametrize(
+    "id_key,verified_key",
+    [
+        ("id", "email_verified"),
+        ("sub", "verified_email"),
+    ],
+)
+@pytest.mark.parametrize("verified", [False, True])
+def test_extract_data(
+    id_key, verified_key, verified, settings_with_google_provider, db
+):
+    data = {
+        "email": "a@b.com",
+    }
+    data[id_key] = "123"
+    data[verified_key] = verified
+    provider = get_adapter().get_provider(None, GoogleProvider.id)
+    assert provider.extract_uid(data) == "123"
+    emails = provider.extract_email_addresses(data)
+    assert len(emails) == 1
+    assert emails[0].verified == verified
+    assert emails[0].email == "a@b.com"
+
+
+@pytest.mark.parametrize(
+    "fetch_userinfo,id_token_has_picture,response,expected_uid, expected_picture",
+    [
+        (True, True, {"id_token": "123"}, "uid-from-id-token", "pic-from-id-token"),
+        (True, False, {"id_token": "123"}, "uid-from-id-token", "pic-from-userinfo"),
+        (True, True, {"access_token": "123"}, "uid-from-userinfo", "pic-from-userinfo"),
+    ],
+)
+def test_complete_login_variants(
+    response,
+    settings_with_google_provider,
+    db,
+    fetch_userinfo,
+    expected_uid,
+    expected_picture,
+    id_token_has_picture,
+):
+    with patch.object(
+        GoogleOAuth2Adapter,
+        "_fetch_user_info",
+        return_value={
+            "id": "uid-from-userinfo",
+            "picture": "pic-from-userinfo",
+        },
+    ):
+        id_token = {"sub": "uid-from-id-token"}
+        if id_token_has_picture:
+            id_token["picture"] = "pic-from-id-token"
+        with patch.object(
+            GoogleOAuth2Adapter,
+            "_decode_id_token",
+            return_value=id_token,
+        ):
+            request = None
+            app = None
+            adapter = GoogleOAuth2Adapter(request)
+            adapter.fetch_userinfo = fetch_userinfo
+            token = SocialToken()
+            login = adapter.complete_login(request, app, token, response)
+            assert login.account.uid == expected_uid
+            assert login.account.extra_data["picture"] == expected_picture

--- a/allauth/socialaccount/providers/microsoft/provider.py
+++ b/allauth/socialaccount/providers/microsoft/provider.py
@@ -6,7 +6,10 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class MicrosoftGraphAccount(ProviderAccount):
     def get_avatar_url(self):
-        return self.account.extra_data.get("photo")
+        return "data:{format};base64, {data}".format(
+            format=self.account.extra_data.get('photo_metadata', {}).get('@odata.mediaContentType', 'image/jpeg'),
+            data=self.account.extra_data.get('photo')
+        )
 
     def to_str(self):
         dflt = super(MicrosoftGraphAccount, self).to_str()


### PR DESCRIPTION
Issue
------
This pull request fixes an with get_avatar_url for the Microsoft provider which as far as I can tell, does not work at all.

Solution
--------
To fix the issue two additional requests were necessary. Firstly, to get a little metadata about the return type for the user photo and then to pull the user photo itself. I proposed a new setting that will enable/disable this behaviour as clearly we have the opportunity to save time for the majority of requests that do not need a user photo. 

I chose to entirely replace the get_avatar_url method in the provider. That could be a little controversial since maybe somewhere out there somebody has an app that actually returns a valid URL but I am reasonably confident that this is not possible.  As far as I can tell, the only endpoint from which any user photo can be accessed is via "https://graph.microsoft.com/v1.0/me/photo" and the only way to access the photo is as a binary stream (rather than a url).

The get_avatar_url method will provide a base64 encoded image stream directly instead of a url. I would have preferred the url option but apparently not with Microsoft. Nonetheless this solution will still render the image in place exactly as a valid url would. I think therefore that it is consistent with the original intent of this function but please let me know if you disagree.

To do
-----
I am happy to update the documentation on this if it looks like something that can be accepted. 
