### PR TITLE
fix(microsoft): Fixed issue where get_avatar_url does not work

### DIFF
--- a/allauth/socialaccount/providers/microsoft/provider.py
+++ b/allauth/socialaccount/providers/microsoft/provider.py
@@ -6,7 +6,10 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class MicrosoftGraphAccount(ProviderAccount):
     def get_avatar_url(self):
-        return self.account.extra_data.get("photo")
+        return "data:{format};base64, {data}".format(
+            format=self.account.extra_data.get('photo_metadata', {}).get('@odata.mediaContentType', 'image/jpeg'),
+            data=self.account.extra_data.get('photo')
+        )
 
     def to_str(self):
         dflt = super(MicrosoftGraphAccount, self).to_str()


### PR DESCRIPTION
 Issue
---------
This pull request fixes an with get_avatar_url for the Microsoft provider which as far as I can tell, does not work at all.

Solution
---------
To fix the issue two additional requests were necessary. Firstly, to get a little metadata about the return type for the user photo and then to pull the user photo itself. I proposed a new setting that will enable/disable this behaviour as clearly we have the opportunity to save time for the majority of requests that do not need a user photo.

I chose to entirely replace the get_avatar_url method in the provider. That could be a little controversial since maybe somewhere out there somebody has an app that actually returns a valid URL but I am reasonably confident that this is not possible. As far as I can tell, the only endpoint from which any user photo can be accessed is via "https://graph.microsoft.com/v1.0/me/photo" and the only way to access the photo is as a binary stream (rather than a url).

The get_avatar_url method will provide a base64 encoded image stream directly instead of a url. I would have preferred the url option but apparently not with Microsoft. Nonetheless this solution will still render the image in place exactly as a valid url would. I think therefore that it is consistent with the original intent of this function but please let me know if you disagree.

To do
---------
I am happy to update the documentation on this if it looks like something that can be accepted.