### PR TITLE
docs(mfa): Added instructions for settings.py

### DIFF
--- a/docs/mfa/introduction.rst
+++ b/docs/mfa/introduction.rst
@@ -13,3 +13,14 @@ Authentication. It supports:
 Note that in order to use this functionality you need to install the ``mfa`` extras of the ``django-allauth`` package::
 
   pip install django-allauth[mfa]
+
+Remember to add the app to
+the ``settings.py`` of your project::
+
+    INSTALLED_APPS = [
+        ...
+        # The required `allauth` apps
+        ...
+        'allauth.mfa',
+        ...
+    ]


### PR DESCRIPTION
Being pretty new to Django, I couldn't get mfa up and running just by looking at the docs, and I found an [SO question](https://stackoverflow.com/q/77186177/10753968) that shows other users have also had this issue.

The missing instruction was to include the `allauth.mfa` app in `settings.py` so I added that to the docs.