### PR TITLE
docs(openid_connect): Document usage of OAUTH_PKCE_ENABLED

### DIFF
--- a/docs/socialaccount/providers/openid_connect.rst
+++ b/docs/socialaccount/providers/openid_connect.rst
@@ -10,6 +10,9 @@ standalone OpenID Connect provider:
 
     SOCIALACCOUNT_PROVIDERS = {
         "openid_connect": {
+            # Optional PKCE defaults to False, but may be required by your provider
+            # Applies to all APPS.
+            "OAUTH_PKCE_ENABLED": True,
             "APPS": [
                 {
                     "provider_id": "my-server",


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [x] Make sure unit tests are available.
- [x] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [x] Add documentation to `docs/providers/<provider name>.rst` and `docs/providers/index.rst` Provider Specifics toctree.
- [x] Add an entry to the list of supported providers over at `docs/overview.rst`.

Previously the use of OAUTH_PKCE_ENABLED was not documented for the generic OIDC provider even though it's supported. This adds it to the example config to guide people to add it with the correct nesting, instead of as an APP specific configuration option. The example shows `True` since it's a more secure alternative than not enabling it.
