### PR TITLE
docs: default prefix oidc provider

### DIFF
--- a/docs/socialaccount/providers/openid_connect.rst
+++ b/docs/socialaccount/providers/openid_connect.rst
@@ -42,5 +42,5 @@ This configuration example will create two independent provider instances,
 ``My Login Server`` and ``Other Login Server``.
 
 The OpenID Connect callback URL for each configured server is at
-``/accounts/{id}/login/callback/`` where ``{id}`` is the configured app's
+``/accounts/oidc/{id}/login/callback/`` where ``{id}`` is the configured app's
 ``provider_id`` value (``my-server`` or ``other-server`` in the above example).


### PR DESCRIPTION
As written in the documentation the default oidc prefix is SOCIALACCOUNT_OPENID_CONNECT_URL_PREFIX="oidc". Since the default callback URL needs this prefix as well. 

https://docs.allauth.org/en/latest/socialaccount/configuration.html

Verified with own Django Allauth setup.

# Submitting Pull Requests

## General

 - [x ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers/<provider name>.rst` and `docs/providers/index.rst` Provider Specifics toctree.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
