### PR TITLE
fix(templates): HTML validation issues

### DIFF
--- a/allauth/templates/account/email_change.html
+++ b/allauth/templates/account/email_change.html
@@ -23,7 +23,7 @@
                 {% endelement %}
             {% endif %}
             {% if new_emailaddress %}
-                {% element field id="new_emailaddress" name="email" value=new_emailaddress.email disabled=True type="email" %}
+                {% element field id="new_emailaddress" value=new_emailaddress.email disabled=True type="email" %}
                     {% slot label %}
                         {% if not current_emailaddress %}
                             {% translate "Current email" %}:
@@ -44,7 +44,7 @@
                     {% endslot %}
                 {% endelement %}
             {% endif %}
-            {% element field id="email" name="email" value=form.email.value errors=form.email.errors type="email" %}
+            {% element field id=form.email.auto_id name="email" value=form.email.value errors=form.email.errors type="email" %}
                 {% slot label %}
                     {% translate "Change to" %}:
                 {% endslot %}

--- a/allauth/templates/account/email_change.html
+++ b/allauth/templates/account/email_change.html
@@ -16,14 +16,14 @@
         {% slot body %}
             {% csrf_token %}
             {% if current_emailaddress %}
-                {% element field disabled=True type="email" value=current_emailaddress.email %}
+                {% element field id="current_emailaddress" disabled=True type="email" value=current_emailaddress.email %}
                     {% slot label %}
                         {% translate "Current email" %}:
                     {% endslot %}
                 {% endelement %}
             {% endif %}
             {% if new_emailaddress %}
-                {% element field name="email" value=new_emailaddress.email disabled=True type="email" %}
+                {% element field id="new_emailaddress" name="email" value=new_emailaddress.email disabled=True type="email" %}
                     {% slot label %}
                         {% if not current_emailaddress %}
                             {% translate "Current email" %}:
@@ -44,7 +44,7 @@
                     {% endslot %}
                 {% endelement %}
             {% endif %}
-            {% element field name="email" value=form.email.value errors=form.email.errors type="email" %}
+            {% element field id="email" name="email" value=form.email.value errors=form.email.errors type="email" %}
                 {% slot label %}
                     {% translate "Change to" %}:
                 {% endslot %}

--- a/allauth/templates/account/email_change.html
+++ b/allauth/templates/account/email_change.html
@@ -16,14 +16,14 @@
         {% slot body %}
             {% csrf_token %}
             {% if current_emailaddress %}
-                {% element field id="current_emailaddress" disabled=True type="email" value=current_emailaddress.email %}
+                {% element field id="current_email" disabled=True type="email" value=current_emailaddress.email %}
                     {% slot label %}
                         {% translate "Current email" %}:
                     {% endslot %}
                 {% endelement %}
             {% endif %}
             {% if new_emailaddress %}
-                {% element field id="new_emailaddress" value=new_emailaddress.email disabled=True type="email" %}
+                {% element field id="new_email" value=new_emailaddress.email disabled=True type="email" %}
                     {% slot label %}
                         {% if not current_emailaddress %}
                             {% translate "Current email" %}:

--- a/allauth/templates/allauth/elements/field.html
+++ b/allauth/templates/allauth/elements/field.html
@@ -26,6 +26,9 @@
                type="{{ attrs.type }}">
     {% endif %}
     {% if slots.help_text %}
-        <span>{% slot help_text %}{% endslot %}</span>
+        <span>
+            {% slot help_text %}
+            {% endslot %}
+        </span>
     {% endif %}
 </p>

--- a/allauth/templates/allauth/elements/field.html
+++ b/allauth/templates/allauth/elements/field.html
@@ -26,7 +26,6 @@
                type="{{ attrs.type }}">
     {% endif %}
     {% if slots.help_text %}
-        <span>{% slot help_text %}</span>
-        {% endslot %}
+        <span>{% slot help_text %}{% endslot %}</span>
     {% endif %}
 </p>

--- a/allauth/templates/mfa/totp/activate_form.html
+++ b/allauth/templates/mfa/totp/activate_form.html
@@ -16,7 +16,7 @@
             {% element img src=totp_svg_data_uri alt=form.secret tags="mfa,totp,qr" %}
             {% endelement %}
             {% csrf_token %}
-            {% element field type="text" value=form.secret disabled=True %}
+            {% element field id="authenticator_secret" type="text" value=form.secret disabled=True %}
                 {% slot label %}
                     {% translate "Authenticator secret" %}
                 {% endslot %}
@@ -28,7 +28,7 @@
             {% endelement %}
         {% endslot %}
         {% slot actions %}
-            {% element button  type="submit" %}
+            {% element button type="submit" %}
                 {% trans "Activate" %}
             {% endelement %}
         {% endslot %}


### PR DESCRIPTION
I ran across a few HTML validation issues in the Django templates:
- an interleaved `slot` template tag that caused a closing `span` HTML tag to be dropped (for a field element with help text)
- some empty `for` attributes for `label`s on several pages


# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.
