### PR TITLE
Add SAML_METADATA_URL_TRAILING_SLASH option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -176,6 +176,7 @@ Volodymyr Yatsyk
 Vuong Nguyen
 Vlad Dmitrievich
 Wendy Edwards
+William Abbott
 Will Gordon
 Will Ross
 William Li

--- a/AUTHORS
+++ b/AUTHORS
@@ -176,7 +176,6 @@ Volodymyr Yatsyk
 Vuong Nguyen
 Vlad Dmitrievich
 Wendy Edwards
-William Abbott
 Will Gordon
 Will Ross
 William Li

--- a/allauth/socialaccount/providers/saml/utils.py
+++ b/allauth/socialaccount/providers/saml/utils.py
@@ -1,5 +1,6 @@
 from urllib.parse import parse_qsl, urlparse
 
+from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
@@ -41,6 +42,8 @@ def build_sp_config(request, provider_config, org):
     acs_url = request.build_absolute_uri(reverse("saml_acs", args=[org]))
     sls_url = request.build_absolute_uri(reverse("saml_sls", args=[org]))
     metadata_url = request.build_absolute_uri(reverse("saml_metadata", args=[org]))
+    if not getattr(settings, "SAML_METADATA_URL_TRAILING_SLASH", False):
+        metadata_url = metadata_url.rstrip("/")
     sp_config = {
         "entityId": metadata_url,
         "assertionConsumerService": {


### PR DESCRIPTION
**As per**

- #3650

**This PR does 2 primary things:**

- Switches the default behaviour of placing a trailing slash on the published metadata url to removing it
- Allows control by setting a SAML_METADATA_URL_TRAILING_SLASH in settings.py