### PR TITLE
fix(slack): Handle new slack openid endpoint and token response

### DIFF
--- a/allauth/socialaccount/providers/slack/provider.py
+++ b/allauth/socialaccount/providers/slack/provider.py
@@ -22,9 +22,14 @@ class SlackProvider(OAuth2Provider):
     oauth2_adapter_class = SlackOAuth2Adapter
 
     def extract_uid(self, data):
+        team_id = data.get("https://slack.com/team_id")
+        user_id = data.get("https://slack.com/user_id")
+        if not (team_id and user_id):
+            team_id = data.get("team").get("id")
+            user_id = data.get("user").get("id")
         return "%s_%s" % (
-            str(data.get("team").get("id")),
-            str(data.get("user").get("id")),
+            str(team_id),
+            str(user_id),
         )
 
     def extract_common_fields(self, data):

--- a/allauth/socialaccount/providers/slack/views.py
+++ b/allauth/socialaccount/providers/slack/views.py
@@ -10,9 +10,9 @@ from allauth.socialaccount.providers.oauth2.views import (
 class SlackOAuth2Adapter(OAuth2Adapter):
     provider_id = "slack"
 
-    access_token_url = "https://slack.com/api/oauth.access"
-    authorize_url = "https://slack.com/oauth/authorize"
-    identity_url = "https://slack.com/api/users.identity"
+    access_token_url = "https://slack.com/api/openid.connect.token"
+    authorize_url = "https://slack.com//openid/connect/authorize"
+    identity_url = "https://slack.com/api/openid.connect.userInfo"
 
     def complete_login(self, request, app, token, **kwargs):
         extra_data = self.get_data(token.token)


### PR DESCRIPTION
The problem I am having is when oauth from Slack I always get a login failure error. After comparing with Slack document I think the issue is due to Slack new endpoint and oauth response change. I have tested this patch in my app and can sign in Slack.

From Slack [document](https://api.slack.com/authentication/sign-in-with-slack#discover)
The new endpoints are:
```
    "authorization_endpoint": "https://slack.com/openid/connect/authorize",
    "token_endpoint": "https://slack.com/api/openid.connect.token",
    "userinfo_endpoint": "https://slack.com/api/openid.connect.userInfo",
``` 
And team_id along with user_id are changed too from [here](https://api.slack.com/authentication/sign-in-with-slack#response)
```
  "https://slack.com/team_id": "T0123ABC456",
  "https://slack.com/user_id": "U123ABC456",
```

Hey, it's my first time sending PR here. Please let me know if any more detail I need to add or any linting/testing I should do beside testing slack sign in in my app.
