### PR TITLE
feat: Separate dependencies for socialaccount

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -7,6 +7,18 @@ Note worthy changes
 - Added a dummy provider, useful for testing purposes: ``allauth.socialaccount.providers.dummy``.
 
 
+Backwards incompatible changes
+------------------------------
+
+- The django-allauth required dependencies are now more fine grained.  If you do
+  not use any of the social account functionality, a `pip install
+  django-allauth` will, e.g., no longer pull in dependencies for handling
+  JWT. If you are using social account functionality, install using `pip install
+  django-allauth[socialaccount]`.  That will install the dependencies covering
+  most common providers. If you are using the Steam provider, install using `pip
+  install django-allauth[socialaccount,steam]`.
+
+
 0.61.1 (2024-02-09)
 *******************
 

--- a/docs/installation/quickstart.rst
+++ b/docs/installation/quickstart.rst
@@ -1,9 +1,14 @@
 Quickstart
 ==========
 
-First, Install the python package::
+First, install the python package. If you do not need any of the social account
+related functionality, install using::
 
     pip install django-allauth
+
+Otherwise, install using::
+
+    pip install django-allauth[socialaccount]
 
 Then, assuming you have a Django project up and running, add the following to
 the ``settings.py`` of your project::
@@ -43,6 +48,8 @@ the ``settings.py`` of your project::
 
         'allauth',
         'allauth.account',
+
+        # Optional -- requires install using `django-allauth[socialacocunt]`.
         'allauth.socialaccount',
         # ... include the providers you want to enable:
         'allauth.socialaccount.providers.agave',

--- a/docs/socialaccount/introduction.rst
+++ b/docs/socialaccount/introduction.rst
@@ -1,7 +1,9 @@
 Introduction
 ============
 
-A social account is a user account where authentication is delegated to an external identity provider. The ``allauth.socialaccount`` app is responsible for managing social accounts. It supports:
+A social account is a user account where authentication is delegated to an
+external identity provider. The ``allauth.socialaccount`` app is responsible for
+managing social accounts. It supports:
 
 - Connecting one or more social accounts to a local/regular account
 
@@ -9,3 +11,8 @@ A social account is a user account where authentication is delegated to an exter
   only the local account remains
 
 - Optional instant-signup for social accounts -- no questions asked
+
+Note that in order to use this functionality you need to install the ``socialaccount``
+extras of the ``django-allauth`` package::
+
+  pip install django-allauth[socialaccount]

--- a/docs/socialaccount/providers/openid.rst
+++ b/docs/socialaccount/providers/openid.rst
@@ -1,11 +1,16 @@
 OpenID
 ------
 
-The OpenID provider does not require any settings per se. However, a typical
-OpenID login page presents the user with a predefined list of OpenID providers
-and allows the user to input their own OpenID identity URL in case their
-provider is not listed by default. The list of providers displayed by the
-builtin templates can be configured as follows:
+The OpenID provider requires dependencies that are not installed by
+default. Install using::
+
+    $ pip install django-allauth[socialaccount,openid]
+
+The provider does not require any settings per se. However, a typical OpenID
+login page presents the user with a predefined list of OpenID providers and
+allows the user to input their own OpenID identity URL in case their provider is
+not listed by default. The list of providers displayed by the builtin templates
+can be configured as follows:
 
 .. code-block:: python
 

--- a/docs/socialaccount/providers/steam.rst
+++ b/docs/socialaccount/providers/steam.rst
@@ -4,6 +4,11 @@ Steam
 Steam is an OpenID-compliant provider. However, the `steam` provider allows
 access to more of the user's details such as username, full name, avatar, etc.
 
+Its implementation requires dependencies that are not installed by
+default. Install using::
+
+    $ pip install django-allauth[socialaccount,steam]
+
 You need to register an API key here:
     https://steamcommunity.com/dev/apikey
 

--- a/examples/react-spa/backend/requirements.txt
+++ b/examples/react-spa/backend/requirements.txt
@@ -1,1 +1,1 @@
-django-allauth==0.60.1
+django-allauth[mfa,socialaccount]==0.60.1

--- a/examples/regular-django/README.org
+++ b/examples/regular-django/README.org
@@ -20,7 +20,7 @@ django-allauth example application in this directory:
   cd django-allauth/examples/regular-django
   virtualenv venv
   . venv/bin/activate
-  pip install "../..[mfa,saml]"
+  pip install "../..[mfa,saml,socialaccount]"
 #+end_src
 
 Now we need to create the database tables and an admin user.

--- a/examples/regular-django/requirements.txt
+++ b/examples/regular-django/requirements.txt
@@ -1,1 +1,1 @@
-django-allauth[mfa,saml]==0.60.1
+django-allauth[mfa,saml,socialaccount]==0.60.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,15 +47,20 @@ tests_require =
     pytest-django >= 4.5.2
 install_requires =
     Django >= 3.2
+
+[options.extras_require]
+mfa =
+    qrcode >= 7.0.0
+openid =
     python3-openid >= 3.0.8
+saml =
+    python3-saml>=1.15.0,<2.0.0
+steam =
+    python3-openid >= 3.0.8
+socialaccount =
     requests-oauthlib >= 0.3.0
     requests >= 2.0.0
     pyjwt[crypto] >= 1.7
-
-[options.extras_require]
-saml = python3-saml>=1.15.0,<2.0.0
-mfa =
-    qrcode >= 7.0.0
 
 [options.packages.find]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,9 @@ deps =
     python3-saml>=1.15.0,<2.0.0
 extras =
     mfa
+    openid
+    socialaccount
+    steam
 commands =
     coverage run -m pytest {posargs:allauth}
     coverage report


### PR DESCRIPTION
When using allauth without any of the social account functionality, do not pull in requests, JWT, ...