### PR TITLE
Feat(accounts): Use select_related instead of prefetch_related

### DIFF
--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -421,7 +421,7 @@ def filter_users_by_email(email, is_active=None, prefer_verified=False):
     from .models import EmailAddress
 
     User = get_user_model()
-    mails = EmailAddress.objects.filter(email__iexact=email).prefetch_related("user")
+    mails = EmailAddress.objects.filter(email__iexact=email).select_related("user")
     mails = list(mails)
     is_verified = False
     if prefer_verified:


### PR DESCRIPTION
Small performance improvement by replacing prefetch_related with select_related. We can do that here because it's a ForeignKey, not a M2M relationship. This leads to performing a single database request vs 2 when using prefetch.

`(0.001) SELECT "account_emailaddress"."id", "account_emailaddress"."user_id", "account_emailaddress"."email", "account_emailaddress"."verified", "account_emailaddress"."primary", "user_user"."last_login", "user_user"."created_at", "user_user"."updated_at", "user_user"."id", "user_user"."username", "user_user"."email", "user_user"."avatar", "user_user"."password", "user_user"."score", "user_user"."is_creator", "user_user"."date_of_birth", "user_user"."is_active", "user_user"."is_superuser", "user_user"."is_staff" FROM "account_emailaddress" INNER JOIN "user_user" ON ("account_emailaddress"."user_id" = "user_user"."id") WHERE UPPER("account_emailaddress"."email"::text) = UPPER('myemail@test.com'); args=('myemail@test.com',); alias=default`

