### PR TITLE
chore(i18n): Add japanese translation and fix mistranslation

### DIFF
--- a/allauth/locale/ja/LC_MESSAGES/django.po
+++ b/allauth/locale/ja/LC_MESSAGES/django.po
@@ -464,7 +464,7 @@ msgstr "ログイン"
 
 #: templates/account/confirm_login_code.html:9
 msgid "Enter Sign-In Code"
-msgstr ""
+msgstr "ログインコードを入力"
 
 #: templates/account/confirm_login_code.html:15
 #, python-format
@@ -472,6 +472,8 @@ msgid ""
 "We’ve sent a code to %(email_link)s. The code expires shortly, so please "
 "enter it soon."
 msgstr ""
+"コードを %(email_link)s に送信しました。コードの有効期限はまもなく切れますので、お早"
+"めにご入力ください。"
 
 #: templates/account/confirm_login_code.html:34
 #: templates/account/request_login_code.html:31
@@ -541,6 +543,15 @@ msgid ""
 "\n"
 "%(password_reset_url)s"
 msgstr ""
+"このメールを受信しているのは、あなたまたは誰かが次のメールアドレスを使用してアカウントの"
+"サインアップを試みたためです：\n"
+"\n"
+"%(email)s\n"
+"\n"
+"しかし、そのメールアドレスを使用したアカウントが既に存在しています。もしアカウントの存在を"
+"忘れていた場合は、パスワードを忘れた手続きを利用してアカウントを回復してください：\n"
+"\n"
+"%(password_reset_url)s"
 
 #: templates/account/email/account_already_exists_subject.txt:3
 msgid "Account Already Exists"
@@ -565,6 +576,7 @@ msgid ""
 "You are receiving this mail because the following change was made to your "
 "account:"
 msgstr ""
+"あなたのアカウントに以下の変更が加えられたため、このメールが届いています:"
 
 #: templates/account/email/base_notification.txt:10
 #, python-format
@@ -576,11 +588,17 @@ msgid ""
 "- Browser: %(user_agent)s\n"
 "- Date: %(timestamp)s"
 msgstr ""
+"この変更が認識できない場合は、直ちに適切なセキュリティ対策を講じてください。あなたの"
+"アカウントに対するこの変更の起源は以下の通りです：\n"
+"\n"
+"- IPアドレス: %(ip)s\n"
+"- ブラウザ: %(user_agent)s\n"
+"- 日付: %(timestamp)s"
 
 #: templates/account/email/email_changed_message.txt:4
 #, python-format
 msgid "Your email has been changed from %(from_email)s to %(to_email)s."
-msgstr ""
+msgstr "あなたのメールアドレスは %(from_email)s から %(to_email)s に変更されました。"
 
 #: templates/account/email/email_changed_subject.txt:3
 msgid "Email Changed"
@@ -626,12 +644,13 @@ msgstr "メールアドレスの削除"
 msgid ""
 "Your sign-in code is listed below. Please enter it in your open browser "
 "window."
-msgstr ""
+msgstr "以下にあなたのログインコードが記載されています。開いているブラウザのウィンドウ"
+"に入力してください。"
 
 #: templates/account/email/login_code_message.txt:9
 #: templates/account/email/unknown_account_message.txt:6
 msgid "This mail can be safely ignored if you did not initiate this action."
-msgstr ""
+msgstr "この操作があなたによるものではない場合、このメールは無視しても差し支えありません。"
 
 #: templates/account/email/login_code_subject.txt:3
 #, fuzzy
@@ -696,10 +715,13 @@ msgid ""
 "an account with email %(email)s. However, we do not have any record of such "
 "an account in our database."
 msgstr ""
+"このメールは、あなたまたは他の誰かが %(email)s のメールアドレスを持つアカウントにアクセス"
+"しようとしたために送信されています。ただし、私たちのデータベースにはそのようなアカウントの記"
+"録はありません。"
 
 #: templates/account/email/unknown_account_message.txt:8
 msgid "If it was you, you can sign up for an account using the link below."
-msgstr ""
+msgstr "もしそれがあなたなら、以下のリンクからアカウントを登録することができます。"
 
 #: templates/account/email/unknown_account_subject.txt:3
 #, fuzzy
@@ -718,7 +740,7 @@ msgstr "現在のメールアドレス"
 
 #: templates/account/email_change.html:31
 msgid "Changing to"
-msgstr ""
+msgstr "変更中"
 
 #: templates/account/email_change.html:35
 msgid "Your email address is still pending verification."
@@ -726,11 +748,11 @@ msgstr "あなたのメールアドレスはまだ確認されていません。
 
 #: templates/account/email_change.html:41
 msgid "Cancel Change"
-msgstr ""
+msgstr "変更をキャンセル"
 
 #: templates/account/email_change.html:49
 msgid "Change to"
-msgstr ""
+msgstr "変更する"
 
 #: templates/account/email_change.html:55
 #: templates/allauth/layouts/base.html:29
@@ -783,7 +805,7 @@ msgstr "アカウントをまだお持ちでなければ、 %(link)sこちらか
 
 #: templates/account/login.html:41 templates/account/request_login_code.html:9
 msgid "Mail me a sign-in code"
-msgstr ""
+msgstr "ログインコードをメールする"
 
 #: templates/account/logout.html:4 templates/account/logout.html:8
 #: templates/account/logout.html:19 templates/allauth/layouts/base.html:32
@@ -827,7 +849,7 @@ msgstr "ログアウトしました。"
 #: templates/account/messages/login_code_sent.txt:2
 #, python-format
 msgid "A sign-in code has been mailed to %(email)s."
-msgstr ""
+msgstr "%(email)s にログインコードを送信しました。"
 
 #: templates/account/messages/password_changed.txt:2
 msgid "Password successfully changed."
@@ -917,6 +939,7 @@ msgid ""
 "You will receive an email containing a special code for a password-free sign-"
 "in."
 msgstr ""
+"パスワード不要のログイン用特別コードが記載されたEメールをお送りします。"
 
 #: templates/account/request_login_code.html:24
 #, fuzzy
@@ -1101,7 +1124,7 @@ msgid ""
 msgid_plural ""
 "There are %(unused_count)s out of %(total_count)s recovery codes available."
 msgstr[0] ""
-"利用可能なリカバリーコードは %(unused_count)s 個中 %(total_count)s 個です。"
+"利用可能なリカバリーコードは %(total_count)s 個中 %(unused_count)s 個です。"
 
 #: templates/mfa/index.html:50
 msgid "No recovery codes set up."
@@ -1222,6 +1245,7 @@ msgstr "外部アカウントを追加する"
 msgid ""
 "A third-party account from %(provider)s has been connected to your account."
 msgstr ""
+"%(provider)s のサードパーティアカウントがあなたのアカウントに接続されました。"
 
 #: templates/socialaccount/email/account_connected_subject.txt:3
 msgid "Third-Party Account Connected"
@@ -1233,6 +1257,7 @@ msgid ""
 "A third-party account from %(provider)s has been disconnected from your "
 "account."
 msgstr ""
+"%(provider)s のサードパーティアカウントがあなたのアカウントから切断されました。"
 
 #: templates/socialaccount/email/account_disconnected_subject.txt:3
 msgid "Third-Party Account Disconnected"
@@ -1305,7 +1330,7 @@ msgstr "外部アカウントを使用する"
 
 #: templates/usersessions/messages/sessions_logged_out.txt:2
 msgid "Signed out of all other sessions."
-msgstr ""
+msgstr "他のすべてのセッションからログアウトしました。"
 
 #: templates/usersessions/usersession_list.html:6
 #: templates/usersessions/usersession_list.html:10
@@ -1334,7 +1359,7 @@ msgstr "現在の"
 
 #: templates/usersessions/usersession_list.html:60
 msgid "Sign Out Other Sessions"
-msgstr ""
+msgstr "他のセッションをログアウトする"
 
 #: usersessions/apps.py:9
 msgid "User Sessions"


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers/<provider name>.rst` and `docs/providers/index.rst` Provider Specifics toctree.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.

## Description

The original translation mistakenly swapped the placeholders for `unused_count` and `total_count`. This error could lead to confusion regarding the number of available recovery codes. The correction ensures that the message accurately reflects the number of unused recovery codes out of the total available.

### Specific Change:

- Incorrect: "利用可能なリカバリーコードは %(unused_count)s 個中 %(total_count)s 個です。"
- Corrected: "利用可能なリカバリーコードは %(total_count)s 個中 %(unused_count)s 個です。"

This change rectifies the order of the placeholders to properly convey the intended message to the users.

Additionally, I have translated all remaining untranslated sections while making this correction.

