### PR TITLE
fix(accounts): Login by code: also forbid A, E, and U

### DIFF
--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -746,7 +746,7 @@ class DefaultAccountAdapter(BaseAdapter):
         self.send_mail(template_prefix, email, ctx)
 
     def generate_login_code(self):
-        forbidden_chars = "0OI18B2Z"
+        forbidden_chars = "0OI18B2ZAEU"
         allowed_chars = string.ascii_uppercase + string.digits
         for ch in forbidden_chars:
             allowed_chars = allowed_chars.replace(ch, "")


### PR DESCRIPTION
Currently, the characters that are forbidden are just the ones that resemble other characters ([source](https://github.com/pennersr/django-allauth/blob/0.62.1/allauth/account/adapter.py#L749)):

1. `0` and `O`
1. `I` and `1`
1. `8` and `B`
1. `2` and `Z`

I think it would be good to also forbid A, E, and U. As it is now, it is possible for the code to spell something potentially offensive or off-putting such as "URLAME" or "CANCER".