### PR TITLE
fix: Cannot serialize BinaryField wihout a value

### DIFF
--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -168,7 +168,8 @@ def serialize_instance(instance):
         try:
             field = instance._meta.get_field(k)
             if isinstance(field, BinaryField):
-                v = force_str(base64.b64encode(v))
+                if v:
+                    v = force_str(base64.b64encode(v))
             elif isinstance(field, FileField):
                 if v and not isinstance(v, str):
                     v = {

--- a/allauth/utils.py
+++ b/allauth/utils.py
@@ -168,7 +168,7 @@ def serialize_instance(instance):
         try:
             field = instance._meta.get_field(k)
             if isinstance(field, BinaryField):
-                if v:
+                if v is not None:
                     v = force_str(base64.b64encode(v))
             elif isinstance(field, FileField):
                 if v and not isinstance(v, str):


### PR DESCRIPTION
When serializing BinaryField(blank=True, null=True) containing None value an exception is thrown:

```
TypeError at /accounts/google/login/callback/ a bytes-like object is required, not 'None Type'
```

This patch kinda fixes the problem.