### PR TITLE
chore: switch linting and formatting to ruff

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
  - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
        Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
- - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
+ - [ ] All Python code must formatted using `ruff format` and clean from `ruff check` issues.
  - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
  - [ ] If your changes are significant, please update `ChangeLog.rst`.
  - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        extra-env: ['docs', 'black', 'isort', 'flake8', 'standardjs', 'djlint', 'compilemessages']
+        extra-env: ['docs', 'ruff', 'standardjs', 'djlint', 'compilemessages']
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ mo:
 
 .PHONY: isort
 isort:
-	isort .
+	ruff --select=I --fix
 
 .PHONY: black
 black:
-	black allauth/ setup.py
+	ruff format
 
 .PHONY: test
 test:
@@ -34,7 +34,6 @@ test:
 
 .PHONY: qa
 qa:
-	flake8 allauth
-	isort --check-only --diff .
-	black --check .
+	ruff check
+	ruff format --check
 	djlint --check allauth examples

--- a/allauth/account/adapter.py
+++ b/allauth/account/adapter.py
@@ -452,7 +452,7 @@ class DefaultAccountAdapter(BaseAdapter):
         signal_kwargs,
         email,
         signup,
-        redirect_url
+        redirect_url,
     ):
         if not user.is_active:
             return self.respond_user_inactive(request, user)
@@ -466,7 +466,7 @@ class DefaultAccountAdapter(BaseAdapter):
         signal_kwargs,
         email,
         signup,
-        redirect_url
+        redirect_url,
     ):
         from .utils import get_login_redirect_url
 

--- a/allauth/account/utils.py
+++ b/allauth/account/utils.py
@@ -405,8 +405,9 @@ def filter_users_by_username(*username):
     else:
         ret = get_user_model()._default_manager.filter(
             **{
-                app_settings.USER_MODEL_USERNAME_FIELD
-                + "__in": [u.lower() for u in username]
+                app_settings.USER_MODEL_USERNAME_FIELD + "__in": [
+                    u.lower() for u in username
+                ]
             }
         )
     return ret

--- a/allauth/mfa/models.py
+++ b/allauth/mfa/models.py
@@ -40,9 +40,7 @@ class Authenticator(models.Model):
         return {
             self.Type.TOTP: TOTP,
             self.Type.RECOVERY_CODES: RecoveryCodes,
-        }[
-            self.type
-        ](self)
+        }[self.type](self)
 
     def record_usage(self):
         self.last_used_at = timezone.now()

--- a/allauth/socialaccount/internal/flows/login.py
+++ b/allauth/socialaccount/internal/flows/login.py
@@ -71,5 +71,5 @@ def record_authentication(request, sociallogin):
         **{
             "provider": sociallogin.account.provider,
             "uid": sociallogin.account.uid,
-        }
+        },
     )

--- a/allauth/socialaccount/providers/baidu/views.py
+++ b/allauth/socialaccount/providers/baidu/views.py
@@ -10,9 +10,7 @@ class BaiduOAuth2Adapter(OAuth2Adapter):
     provider_id = "baidu"
     access_token_url = "https://openapi.baidu.com/oauth/2.0/token"
     authorize_url = "https://openapi.baidu.com/oauth/2.0/authorize"
-    profile_url = (
-        "https://openapi.baidu.com/rest/2.0/passport/users/getLoggedInUser"  # noqa
-    )
+    profile_url = "https://openapi.baidu.com/rest/2.0/passport/users/getLoggedInUser"  # noqa
 
     def complete_login(self, request, app, token, **kwargs):
         resp = (

--- a/allauth/socialaccount/providers/battlenet/views.py
+++ b/allauth/socialaccount/providers/battlenet/views.py
@@ -12,6 +12,7 @@ Resources:
 * The Battle.net API forum:
     https://us.battle.net/en/forum/15051532/
 """
+
 from django.conf import settings
 
 from allauth.socialaccount.adapter import get_adapter

--- a/allauth/socialaccount/providers/drip/views.py
+++ b/allauth/socialaccount/providers/drip/views.py
@@ -1,4 +1,5 @@
 """Views for Drip API."""
+
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
@@ -8,7 +9,6 @@ from allauth.socialaccount.providers.oauth2.views import (
 
 
 class DripOAuth2Adapter(OAuth2Adapter):
-
     """OAuth2Adapter for Drip API v3."""
 
     provider_id = "drip"

--- a/allauth/socialaccount/providers/eventbrite/provider.py
+++ b/allauth/socialaccount/providers/eventbrite/provider.py
@@ -1,4 +1,5 @@
 """Customise Provider classes for Eventbrite API v3."""
+
 from allauth.account.models import EmailAddress
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.eventbrite.views import (
@@ -8,7 +9,6 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class EventbriteAccount(ProviderAccount):
-
     """ProviderAccount subclass for Eventbrite."""
 
     def get_avatar_url(self):
@@ -17,7 +17,6 @@ class EventbriteAccount(ProviderAccount):
 
 
 class EventbriteProvider(OAuth2Provider):
-
     """OAuth2Provider subclass for Eventbrite."""
 
     id = "eventbrite"

--- a/allauth/socialaccount/providers/eventbrite/tests.py
+++ b/allauth/socialaccount/providers/eventbrite/tests.py
@@ -1,4 +1,5 @@
 """Test Eventbrite OAuth2 v3 Flow."""
+
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
 
@@ -6,7 +7,6 @@ from .provider import EventbriteProvider
 
 
 class EventbriteTests(OAuth2TestsMixin, TestCase):
-
     """Test Class for Eventbrite OAuth2 v3."""
 
     provider_id = EventbriteProvider.id

--- a/allauth/socialaccount/providers/eventbrite/urls.py
+++ b/allauth/socialaccount/providers/eventbrite/urls.py
@@ -1,4 +1,5 @@
 """Register urls for EventbriteProvider"""
+
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
 
 from .provider import EventbriteProvider

--- a/allauth/socialaccount/providers/eventbrite/views.py
+++ b/allauth/socialaccount/providers/eventbrite/views.py
@@ -1,4 +1,5 @@
 """Views for Eventbrite API v3."""
+
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
@@ -8,7 +9,6 @@ from allauth.socialaccount.providers.oauth2.views import (
 
 
 class EventbriteOAuth2Adapter(OAuth2Adapter):
-
     """OAuth2Adapter for Eventbrite API v3."""
 
     provider_id = "eventbrite"

--- a/allauth/socialaccount/providers/hubspot/views.py
+++ b/allauth/socialaccount/providers/hubspot/views.py
@@ -1,4 +1,5 @@
 """Views for Hubspot API."""
+
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,

--- a/allauth/socialaccount/providers/linkedin_oauth2/provider.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/provider.py
@@ -99,9 +99,7 @@ class LinkedInOAuth2Account(ProviderAccount):
                 [
                     {},
                 ],
-            )[
-                0
-            ].get("identifier")
+            )[0].get("identifier")
             if to_return:
                 return to_return
         return super(LinkedInOAuth2Account, self).get_avatar_url()

--- a/allauth/socialaccount/providers/mailchimp/provider.py
+++ b/allauth/socialaccount/providers/mailchimp/provider.py
@@ -1,4 +1,5 @@
 """Customise Provider classes for MailChimp API v3."""
+
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.mailchimp.views import (
     MailChimpOAuth2Adapter,
@@ -7,7 +8,6 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class MailChimpAccount(ProviderAccount):
-
     """ProviderAccount subclass for MailChimp."""
 
     def get_profile_url(self):
@@ -20,7 +20,6 @@ class MailChimpAccount(ProviderAccount):
 
 
 class MailChimpProvider(OAuth2Provider):
-
     """OAuth2Provider subclass for MailChimp v3."""
 
     id = "mailchimp"

--- a/allauth/socialaccount/providers/mailchimp/tests.py
+++ b/allauth/socialaccount/providers/mailchimp/tests.py
@@ -1,4 +1,5 @@
 """Test MailChimp OAuth2 v3 Flow."""
+
 from allauth.socialaccount.tests import OAuth2TestsMixin
 from allauth.tests import MockedResponse, TestCase
 
@@ -6,7 +7,6 @@ from .provider import MailChimpProvider
 
 
 class MailChimpTests(OAuth2TestsMixin, TestCase):
-
     """Test Class for MailChimp OAuth2 v3."""
 
     provider_id = MailChimpProvider.id

--- a/allauth/socialaccount/providers/mailchimp/urls.py
+++ b/allauth/socialaccount/providers/mailchimp/urls.py
@@ -1,4 +1,5 @@
 """Register urls for MailChimpProvider"""
+
 from allauth.socialaccount.providers.oauth2.urls import default_urlpatterns
 
 from .provider import MailChimpProvider

--- a/allauth/socialaccount/providers/mailchimp/views.py
+++ b/allauth/socialaccount/providers/mailchimp/views.py
@@ -1,4 +1,5 @@
 """Views for MailChimp API v3."""
+
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.providers.oauth2.views import (
     OAuth2Adapter,
@@ -8,7 +9,6 @@ from allauth.socialaccount.providers.oauth2.views import (
 
 
 class MailChimpOAuth2Adapter(OAuth2Adapter):
-
     """OAuth2Adapter for MailChimp API v3."""
 
     provider_id = "mailchimp"

--- a/allauth/socialaccount/providers/patreon/provider.py
+++ b/allauth/socialaccount/providers/patreon/provider.py
@@ -1,6 +1,7 @@
 """
 Provider for Patreon
 """
+
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from allauth.socialaccount.providers.patreon.views import PatreonOAuth2Adapter

--- a/allauth/socialaccount/providers/quickbooks/views.py
+++ b/allauth/socialaccount/providers/quickbooks/views.py
@@ -10,7 +10,9 @@ class QuickBooksOAuth2Adapter(OAuth2Adapter):
     provider_id = "quickbooks"
     access_token_url = "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
     authorize_url = "https://appcenter.intuit.com/connect/oauth2"
-    profile_test = "https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo"  # NOQA
+    profile_test = (
+        "https://sandbox-accounts.platform.intuit.com/v1/openid_connect/userinfo"  # NOQA
+    )
     profile_url = "https://accounts.platform.intuit.com/v1/openid_connect/userinfo"
     profile_url_method = "GET"
     access_token_method = "POST"

--- a/allauth/socialaccount/providers/steam/views.py
+++ b/allauth/socialaccount/providers/steam/views.py
@@ -12,6 +12,7 @@ Resources:
 * Steam Partner API documentation
     https://partner.steamgames.com/doc/features/auth#website
 """
+
 from django.urls import reverse
 
 from allauth.socialaccount.providers.openid.views import (

--- a/allauth/socialaccount/providers/trainingpeaks/tests.py
+++ b/allauth/socialaccount/providers/trainingpeaks/tests.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-    Run just this suite:
-    python manage.py test allauth.socialaccount.providers.trainingpeaks.tests.TrainingPeaksTests
+Run just this suite:
+python manage.py test allauth.socialaccount.providers.trainingpeaks.tests.TrainingPeaksTests
 """
+
 from __future__ import unicode_literals
 
 from collections import namedtuple

--- a/allauth/socialaccount/providers/vimeo_oauth2/provider.py
+++ b/allauth/socialaccount/providers/vimeo_oauth2/provider.py
@@ -1,6 +1,7 @@
 """
 Provider for Patreon
 """
+
 from allauth.socialaccount.providers.base import ProviderAccount
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 from allauth.socialaccount.providers.vimeo_oauth2.views import (

--- a/allauth/socialaccount/sessions.py
+++ b/allauth/socialaccount/sessions.py
@@ -51,7 +51,7 @@ class LoginSession:
             path=urlparse(response.url).path,
             secure=settings.SESSION_COOKIE_SECURE,
             httponly=None,
-            **kwargs
+            **kwargs,
         )
 
     def delete(self):

--- a/allauth/socialaccount/tests/test_login.py
+++ b/allauth/socialaccount/tests/test_login.py
@@ -47,9 +47,9 @@ def test_email_authentication(
         settings.SOCIALACCOUNT_PROVIDERS = copy.deepcopy(
             settings.SOCIALACCOUNT_PROVIDERS
         )
-        settings.SOCIALACCOUNT_PROVIDERS["openid_connect"][
-            "EMAIL_AUTHENTICATION"
-        ] = True
+        settings.SOCIALACCOUNT_PROVIDERS["openid_connect"]["EMAIL_AUTHENTICATION"] = (
+            True
+        )
     else:
         settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION = False
     settings.SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = auto_connect

--- a/examples/react-spa/backend/backend/urls.py
+++ b/examples/react-spa/backend/backend/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import include, path
 

--- a/examples/react-spa/backend/manage.py
+++ b/examples/react-spa/backend/manage.py
@@ -1,5 +1,6 @@
 #!/nix/store/qp5zys77biz7imbk6yy85q5pdv7qk84j-python3-3.11.6/bin/python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
 [build-system]
 requires = ['setuptools>=40.8.0']
 build-backend = 'setuptools.build_meta'
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint.isort]
+from-first = false
+combine-as-imports = true
+lines-after-imports = 2
+extra-standard-library = ["types", "requests"]
+known-first-party = ["allauth"]
+section-order = ["future", "standard-library", "django", "third-party", "first-party", "local-folder"]
+
+[tool.ruff.lint.isort.sections]
+"django" = ["django"]
+
+[tool.ruff.lint]
+extend-select = ["I"]
+extend-ignore = ["E203", "E501", "E231"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,21 +66,3 @@ socialaccount =
 exclude =
     examples
     tests
-
-[isort]
-indent=4
-combine_star=1
-combine_as_imports=1
-include_trailing_comma=1
-multi_line_output=3
-lines_after_imports=2
-known_django=django
-extra_standard_library=types,requests
-known_first_party=allauth
-sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-
-
-[flake8]
-max-line-length = 88
-# Black
-ignore = E203, W503, E501, E231

--- a/shell.nix
+++ b/shell.nix
@@ -9,11 +9,10 @@ stdenv.mkDerivation {
         djlint
         nodejs
         python310
-        python310Packages.django
-        python310Packages.flake8
+        python310Packages.daphne
         python310Packages.debugpy
-        python310Packages.pycodestyle
-        python310Packages.pyls-flake8
+        python310Packages.django
+        python310Packages.pyls-ruff
         python310Packages.pylsp-rope
         python310Packages.pytest
         python310Packages.pytest-cov
@@ -22,10 +21,10 @@ stdenv.mkDerivation {
         python310Packages.python3-openid
         python310Packages.python3-saml
         python310Packages.qrcode
-        python310Packages.sphinx-rtd-theme
         python310Packages.requests-oauthlib
+        python310Packages.ruff
+        python310Packages.sphinx-rtd-theme
         python310Packages.tox
-        python310Packages.daphne
         sphinx
         twine
     ];

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,7 @@ envlist =
     py{310,311,312}-django{50}
     py{310,311,312}-djangomain
     docs
-    isort
-    black
-    flake8
+    ruff
     standardjs
     compilemessages
 
@@ -49,19 +47,13 @@ whitelist_externals = make
 commands =
     make -C {toxinidir}/docs html
 
-[testenv:isort]
+[testenv:ruff]
 skip_install = True
 deps =
-    isort==5.12.0
+    ruff==0.4.1
 commands =
-    isort --check-only --diff {posargs:{toxinidir}}
-
-[testenv:black]
-skip_install = True
-deps =
-    black==23.1.0
-commands =
-    black --check {posargs:{toxinidir}}
+    ruff check {posargs:{toxinidir}/allauth}
+    ruff format --check {posargs:{toxinidir}/allauth}
 
 [testenv:djlint]
 skip_install = True
@@ -70,19 +62,11 @@ deps =
 commands =
     djlint --configuration {posargs:{toxinidir}/.djlintrc} --check {posargs:{toxinidir}/allauth} {posargs:{toxinidir}/examples}
 
-[testenv:flake8]
-skip_install = True
-deps =
-    flake8==6.0.0
-commands =
-    flake8 {posargs:{toxinidir}/allauth}
-
 [testenv:compilemessages]
 skip_install = True
 deps = Django
 commands =
     /usr/bin/env bash -c "cd allauth; python ../manage.py compilemessages"
-
 
 [testenv:standardjs]
 skip_install = True


### PR DESCRIPTION
This PR proposes to switch the linting + formatting toolchain from flake8 + isort + black to [Ruff](https://github.com/astral-sh/ruff), a fast, very capable linter + formatter. 

I didn't enable any Ruff rules beyond those that were already enabled by the flake8 + isort configuration.
