### PR TITLE
Add honeypot to sign up form

### DIFF
--- a/allauth/account/app_settings.py
+++ b/allauth/account/app_settings.py
@@ -239,6 +239,13 @@ class AppSettings(object):
         return self._setting("SIGNUP_FORM_CLASS", None)
 
     @property
+    def SIGNUP_FORM_HONEYPOT_FIELD(self):
+        """
+        Honeypot field name. Empty string or None will disable honeypot behavior
+        """
+        return self._setting("SIGNUP_FORM_HONEYPOT_FIELD", None)
+
+    @property
     def USERNAME_REQUIRED(self):
         """
         The user is required to enter a username when signing up

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -328,7 +328,7 @@ class BaseSignupForm(_base_signup_form_class()):
         if honeypot_field_name := app_settings.SIGNUP_FORM_HONEYPOT_FIELD:
             # TODO: hide input field
             self.fields[honeypot_field_name] = forms.CharField(
-                label=None,
+                label=False,
                 widget=forms.TextInput(
                     attrs={
                         "style": "position: absolute; right: -99999px;"

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -329,6 +329,7 @@ class BaseSignupForm(_base_signup_form_class()):
             # TODO: hide input field
             self.fields[honeypot_field_name] = forms.CharField(
                 label=False,
+                required=False,
                 widget=forms.TextInput(
                     attrs={
                         "style": "position: absolute; right: -99999px;",

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -332,7 +332,8 @@ class BaseSignupForm(_base_signup_form_class()):
                 widget=forms.TextInput(
                     attrs={
                         "style": "position: absolute; right: -99999px;",
-                        "tabindex": "-1"
+                        "tabindex": "-1",
+                        "autocomplete": "nope",
                     }
                 ),
             )

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -331,7 +331,8 @@ class BaseSignupForm(_base_signup_form_class()):
                 label=False,
                 widget=forms.TextInput(
                     attrs={
-                        "style": "position: absolute; right: -99999px;"
+                        "style": "position: absolute; right: -99999px;",
+                        "tabindex": "-1"
                     }
                 ),
             )

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -328,8 +328,12 @@ class BaseSignupForm(_base_signup_form_class()):
         if honeypot_field_name := app_settings.SIGNUP_FORM_HONEYPOT_FIELD:
             # TODO: hide input field
             self.fields[honeypot_field_name] = forms.CharField(
-                label=honeypot_field_name,
-                widget=forms.TextInput(),
+                label=None,
+                widget=forms.TextInput(
+                    attrs={
+                        "style": "position: absolute; right: -99999px;"
+                    }
+                ),
             )
 
     def clean_username(self):

--- a/allauth/account/forms.py
+++ b/allauth/account/forms.py
@@ -385,6 +385,9 @@ class BaseSignupForm(_base_signup_form_class()):
         """Try and save the user. This can fail in case of a conflict on the
         email address, in that case we will send an "account already exists"
         email and return a standard "email verification sent" response.
+
+        If the honeypot was filled out then also send 'email verification sent'
+        response so that the bot thinks things worked.
         """
         if honeypot_field_name := app_settings.SIGNUP_FORM_HONEYPOT_FIELD:
             if self.cleaned_data[honeypot_field_name]:

--- a/allauth/account/tests/test_signup.py
+++ b/allauth/account/tests/test_signup.py
@@ -289,6 +289,38 @@ class SignupTests(TestCase):
                 ["This password is too short. It must contain at least 9 characters."],
             )
 
+    @override_settings(
+        ACCOUNT_SIGNUP_FORM_HONEYPOT_FIELD="phone_number"
+    )
+    def test_does_not_create_user_when_honeypot_filled_out(self):
+        resp = self.client.post(
+            reverse("account_signup"),
+            {
+                "username": "johndoe",
+                "email": "john@example.com",
+                "password1": "Password1@",
+                "password2": "Password1@",
+                "phone_number": "5551231234"
+            }
+        )
+        self.assertEqual(get_user_model().objects.all().count(), 0)
+
+    @override_settings(
+        ACCOUNT_SIGNUP_FORM_HONEYPOT_FIELD="phone_number"
+    )
+    def test_create_user_when_honeypot_not_filled_out(self):
+        resp = self.client.post(
+            reverse("account_signup"),
+            {
+                "username": "johndoe",
+                "email": "john@example.com",
+                "password1": "Password1@",
+                "password2": "Password1@",
+                "phone_number": ""
+            }
+        )
+        self.assertEqual(get_user_model().objects.all().count(), 1)
+
 
 def test_prevent_enumeration_with_mandatory_verification(
     settings, user_factory, email_factory

--- a/docs/account/configuration.rst
+++ b/docs/account/configuration.rst
@@ -233,6 +233,18 @@ Available settings:
   date). This class should implement a ``def signup(self, request, user)``
   method, where user represents the newly signed up user.
 
+``ACCOUNT_SIGNUP_FORM_HONEYPOT_FIELD`` (default: ``None``)
+  A string value that will be used as the HTML 'name' property
+  on a honeypot input field on the sign up form. Honeypot fields are hidden
+  to normal users but might be filled out by niave spam bots. When the field
+  is filled out the app will not create a new user and attempt to fool
+  the bot with a fake successful response. We recommend setting this
+  to some believable value that your app does not actually collect
+  on signup e.g. 'phone_number' or 'address'. Honeypots are not
+  always successful for sophisticated bots so this should be
+  used as one layer in a suite of spam detection tools if your
+  site is having trouble with spam.
+
 ``ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE`` (default: ``True``)
   When signing up, let the user type in their password twice to avoid typos.
 


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [ ] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [ ] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

This PR is for https://github.com/pennersr/django-allauth/issues/3728. I am adding an optional honeypot field to the sign up form that will not create an account if filled out.
