### PR TITLE
Fix ACCOUNT_EMAIL_VERIFICATION setting name in checks.py message

### DIFF
--- a/allauth/account/checks.py
+++ b/allauth/account/checks.py
@@ -21,7 +21,7 @@ def settings_check(app_configs, **kwargs):
         if app_settings.EMAIL_VERIFICATION != app_settings.EmailVerificationMethod.NONE:
             ret.append(
                 Critical(
-                    msg="SOCIALACCOUNT_ONLY requires ACCOUNT_EMAIL_VERIFICATION_METHOD = 'none'"
+                    msg="SOCIALACCOUNT_ONLY requires ACCOUNT_EMAIL_VERIFICATION = 'none'"
                 )
             )
     return ret


### PR DESCRIPTION
This setting name appears to be incorrect (unless a change is pending that `main` does not yet reflect; sorry to waste your time in that case). Perhaps this will save someone a few minutes of confusion.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.


