### PR TITLE
chore(tests): Fix and add tests

### DIFF
--- a/allauth/account/tests/test_login.py
+++ b/allauth/account/tests/test_login.py
@@ -144,18 +144,22 @@ class LoginTests(TestCase):
                 self.assertFormError(
                     resp.context["form"],
                     None,
-                    "Too many failed login attempts. Try again later."
-                    if is_locked
-                    else "The username and/or password you specified are not correct.",
+                    (
+                        "Too many failed login attempts. Try again later."
+                        if is_locked
+                        else "The username and/or password you specified are not correct."
+                    ),
                 )
             else:
                 self.assertFormError(
                     resp,
                     "form",
                     None,
-                    "Too many failed login attempts. Try again later."
-                    if is_locked
-                    else "The username and/or password you specified are not correct.",
+                    (
+                        "Too many failed login attempts. Try again later."
+                        if is_locked
+                        else "The username and/or password you specified are not correct."
+                    ),
                 )
 
     @override_settings(
@@ -356,13 +360,9 @@ def test_login_while_authenticated(settings, client, user_factory):
     user_factory(username="jane", email="jane@example.org", password="doe")
     redirect_url = settings.LOGIN_REDIRECT_URL
 
-    resp = client.post(
-        reverse("account_login"), {"login": "john", "password": "doe"}
-    )
+    resp = client.post(reverse("account_login"), {"login": "john", "password": "doe"})
     assert resp.status_code == 302
     assert resp["location"] == redirect_url
-    resp = client.post(
-        reverse("account_login"), {"login": "jane", "password": "doe"}
-    )
+    resp = client.post(reverse("account_login"), {"login": "jane", "password": "doe"})
     assert resp.status_code == 302
     assert resp["location"] == redirect_url

--- a/allauth/account/tests/test_login.py
+++ b/allauth/account/tests/test_login.py
@@ -334,6 +334,26 @@ class LoginTests(TestCase):
         resp = self.client.get(reverse("account_login"))
         self.assertEqual(resp.status_code, 200)
 
+    @override_settings(
+        ACCOUNT_AUTHENTICATED_LOGIN_REDIRECTS=False,
+        ACCOUNT_EMAIL_VERIFICATION=app_settings.EmailVerificationMethod.OPTIONAL,
+    )
+    def test_login_while_authenticated(self):
+        self._create_user(username="john", password="doe")
+        self._create_user(username="jane", password="doe")
+        resp = self.client.post(
+            reverse("account_login"), {"login": "john", "password": "doe"}
+        )
+        self.assertRedirects(
+            resp, settings.LOGIN_REDIRECT_URL, fetch_redirect_response=False
+        )
+        resp = self.client.post(
+            reverse("account_login"), {"login": "jane", "password": "doe"}
+        )
+        self.assertRedirects(
+            resp, settings.LOGIN_REDIRECT_URL, fetch_redirect_response=False
+        )
+
 
 def test_login_password_forgotten_link_not_present(client, db):
     with patch("allauth.account.forms.reverse") as reverse_mock:

--- a/allauth/usersessions/tests/test_views.py
+++ b/allauth/usersessions/tests/test_views.py
@@ -20,7 +20,7 @@ def test_overall_flow(user, user_password):
     assert sessions[0].user_agent == "Mozilla Firefox"
     assert sessions[1].user_agent == "Nyxt"
     for client in [firefox, nyxt]:
-        resp = firefox.get(reverse("usersessions_list"))
+        resp = client.get(reverse("usersessions_list"))
         assert resp.status_code == 200
     resp = firefox.post(reverse("usersessions_list"))
     assert resp.status_code == 302

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     django40: Django==4.0.*
     django41: Django==4.1.*
     django42: Django==4.2.*
-    django50: Django==5.0a1
+    django50: Django==5.0.*
     djangomain: git+https://github.com/django/django.git@main#egg=django
     python3-saml>=1.15.0,<2.0.0
 extras =


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers/<provider name>.rst` and `docs/providers/index.rst` Provider Specifics toctree.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.

 ## Description

- Fixed a small typo in `account/test_login.py`.
- Added a new test which tests 'login while authenticated.' This fails in 0.62.1 and was problematic in case one wants to mimic the behavior of Django admin login view, where it allows to authenticate with new credentials if the current user is not permitted to access the admin pages. Fortunately, this got fixed in the current main branch ([code](https://github.com/pennersr/django-allauth/blame/55297fabe73328a711477d82a781e140ec178921/allauth/usersessions/models.py#L34)) but I thought it deserves a new test to prevent from breaking again in future developments (and perhaps a new entry in change log too?).
- Changed `tox` configuration to support official Django 5.0.X releases.
