### PR TITLE
fix(headless): Do not create an empty session in app context on logout

### DIFF
--- a/allauth/headless/internal/authkit.py
+++ b/allauth/headless/internal/authkit.py
@@ -64,7 +64,7 @@ def authentication_context(request):
         request.allauth.headless._pre_user.pk
         yield
     finally:
-        if request.session.modified:
+        if request.session.modified and not request.session.is_empty():
             request.session.save()
         request.user = old_user
         request.session = old_session


### PR DESCRIPTION
# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

# Description

This commit complements #3785 . Even though the headless API won't attach a session token when user logs out, the empty session is still created in the database upon exiting the context manager `authentication_context()`. This patch fixes this by also checking if the session is empty within the context manager.

Note: this behavior is quite tricky to test, because normally there is no way to access the 'ghost' session. If the session backend is guaranteed to be database-backed, then one way is to check the number of sessions before and after logout. The test code may be slightly messy though - I'll add a test if requested.