### PR TITLE
Adjusted check for verified email in mfa activate form clean method

### DIFF
--- a/allauth/mfa/forms.py
+++ b/allauth/mfa/forms.py
@@ -63,8 +63,8 @@ class ActivateTOTPForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user")
-        self.email_verified = not EmailAddress.objects.filter(
-            user=self.user, verified=False
+        self.email_verified = EmailAddress.objects.filter(
+            user=self.user, verified=True
         ).exists()
         super().__init__(*args, **kwargs)
         self.secret = totp.get_totp_secret(regenerate=not self.is_bound)

--- a/allauth/mfa/tests/test_views.py
+++ b/allauth/mfa/tests/test_views.py
@@ -93,7 +93,7 @@ def test_activate_totp_success(
 
 
 def test_activate_totp_success_with_unverified_secondary_email(
-        auth_client, user, totp_validation_bypass, reauthentication_bypass
+    auth_client, user, totp_validation_bypass, reauthentication_bypass
 ):
     EmailAddress.objects.create(
         user=user, primary=False, verified=False, email='secondary@example.com'


### PR DESCRIPTION
There is an issue where a user can have multiple email addresses associated with their account. Even though their primary email is verified and valid, if they have a secondary email address that is not verified, they cannot activate mfa.

 I'm not entirely sure the reason why you would want this behavior.