### PR TITLE
fix(mfa): Add types to `allauth.mfa` flows

### DIFF
--- a/allauth/mfa/adapter.py
+++ b/allauth/mfa/adapter.py
@@ -85,7 +85,7 @@ class DefaultMFAAdapter(BaseAdapter):
         text = encrypted_text
         return text
 
-    def can_delete_authenticator(self, authenticator) -> bool:
+    def can_delete_authenticator(self, authenticator: Authenticator) -> bool:
         return True
 
     def send_notification_mail(self, *args, **kwargs):
@@ -103,5 +103,5 @@ class DefaultMFAAdapter(BaseAdapter):
         return qs.exists()
 
 
-def get_adapter():
+def get_adapter() -> DefaultMFAAdapter:
     return import_attribute(app_settings.ADAPTER)()

--- a/allauth/mfa/internal/flows/authentication.py
+++ b/allauth/mfa/internal/flows/authentication.py
@@ -3,8 +3,10 @@ from allauth.mfa.models import Authenticator
 
 
 def post_authentication(
-    request, authenticator: Authenticator, reauthenticated: bool = False
-):
+    request,
+    authenticator: Authenticator,
+    reauthenticated: bool = False,
+) -> None:
     authenticator.record_usage()
     extra_data = {
         "id": authenticator.pk,

--- a/allauth/mfa/internal/flows/totp.py
+++ b/allauth/mfa/internal/flows/totp.py
@@ -30,7 +30,7 @@ def activate_totp(request, form) -> Tuple[Authenticator, Optional[Authenticator]
     return totp_auth, rc_auth
 
 
-def deactivate_totp(request, authenticator: Authenticator):
+def deactivate_totp(request, authenticator: Authenticator) -> None:
     raise_if_reauthentication_required(request)
     delete_and_cleanup(request, authenticator)
     adapter = get_account_adapter(request)

--- a/allauth/mfa/models.py
+++ b/allauth/mfa/models.py
@@ -47,6 +47,6 @@ class Authenticator(models.Model):
             self.type
         ](self)
 
-    def record_usage(self):
+    def record_usage(self) -> None:
         self.last_used_at = timezone.now()
         self.save(update_fields=["last_used_at"])

--- a/allauth/mfa/recovery_codes.py
+++ b/allauth/mfa/recovery_codes.py
@@ -3,6 +3,7 @@ import hmac
 import os
 import struct
 from hashlib import sha1
+from typing import List, Optional
 
 from allauth.mfa import app_settings
 from allauth.mfa.models import Authenticator
@@ -10,11 +11,11 @@ from allauth.mfa.utils import decrypt, encrypt
 
 
 class RecoveryCodes:
-    def __init__(self, instance):
+    def __init__(self, instance: Authenticator) -> None:
         self.instance = instance
 
     @classmethod
-    def activate(cls, user):
+    def activate(cls, user) -> "RecoveryCodes":
         instance = Authenticator.objects.filter(
             user=user, type=Authenticator.Type.RECOVERY_CODES
         ).first()
@@ -32,16 +33,16 @@ class RecoveryCodes:
         return cls(instance)
 
     @classmethod
-    def generate_seed(self):
+    def generate_seed(self) -> str:
         key = binascii.hexlify(os.urandom(20)).decode("ascii")
         return key
 
-    def _get_migrated_codes(self):
+    def _get_migrated_codes(self) -> Optional[List[str]]:
         codes = self.instance.data.get("migrated_codes")
         if codes is not None:
             return [decrypt(code) for code in codes]
 
-    def generate_codes(self):
+    def generate_codes(self) -> List[str]:
         migrated_codes = self._get_migrated_codes()
         if migrated_codes is not None:
             return migrated_codes
@@ -57,17 +58,17 @@ class RecoveryCodes:
             ret.append(fmt_value)
         return ret
 
-    def _is_code_used(self, i):
+    def _is_code_used(self, i: int) -> bool:
         used_mask = self.instance.data["used_mask"]
         return bool(used_mask & (1 << i))
 
-    def _mark_code_used(self, i):
+    def _mark_code_used(self, i: int) -> None:
         used_mask = self.instance.data["used_mask"]
         used_mask |= 1 << i
         self.instance.data["used_mask"] = used_mask
         self.instance.save()
 
-    def get_unused_codes(self):
+    def get_unused_codes(self) -> List[str]:
         migrated_codes = self._get_migrated_codes()
         if migrated_codes is not None:
             return migrated_codes
@@ -79,7 +80,7 @@ class RecoveryCodes:
             ret.append(code)
         return ret
 
-    def _validate_migrated_code(self, code):
+    def _validate_migrated_code(self, code: str) -> Optional[bool]:
         migrated_codes = self._get_migrated_codes()
         if migrated_codes is None:
             return None

--- a/allauth/mfa/recovery_codes.py
+++ b/allauth/mfa/recovery_codes.py
@@ -41,6 +41,7 @@ class RecoveryCodes:
         codes = self.instance.data.get("migrated_codes")
         if codes is not None:
             return [decrypt(code) for code in codes]
+        return None
 
     def generate_codes(self) -> List[str]:
         migrated_codes = self._get_migrated_codes()
@@ -90,6 +91,7 @@ class RecoveryCodes:
             return False
         else:
             migrated_codes = self.instance.data["migrated_codes"]
+            assert isinstance(migrated_codes, list)
             migrated_codes.pop(idx)
             self.instance.data["migrated_codes"] = migrated_codes
             self.instance.save()

--- a/allauth/mfa/totp.py
+++ b/allauth/mfa/totp.py
@@ -18,12 +18,12 @@ from allauth.mfa.utils import decrypt, encrypt
 SECRET_SESSION_KEY = "mfa.totp.secret"
 
 
-def generate_totp_secret(length=20):
+def generate_totp_secret(length: int = 20) -> str:
     random_bytes = secrets.token_bytes(length)
     return base64.b32encode(random_bytes).decode("utf-8")
 
 
-def get_totp_secret(regenerate=False):
+def get_totp_secret(regenerate: bool = False) -> str:
     secret = None
     if not regenerate:
         secret = context.request.session.get(SECRET_SESSION_KEY)
@@ -32,12 +32,12 @@ def get_totp_secret(regenerate=False):
     return secret
 
 
-def hotp_counter_from_time():
+def hotp_counter_from_time() -> int:
     current_time = int(time.time())  # Get the current Unix timestamp
     return current_time // app_settings.TOTP_PERIOD
 
 
-def hotp_value(secret, counter):
+def hotp_value(secret: str, counter: int) -> int:
     # Convert the counter to a byte array using big-endian encoding
     counter_bytes = struct.pack(">Q", counter)
     secret_enc = base64.b32decode(secret.encode("ascii"), casefold=True)
@@ -55,7 +55,7 @@ def hotp_value(secret, counter):
     return value
 
 
-def build_totp_url(label, issuer, secret):
+def build_totp_url(label: str, issuer: str, secret: str) -> str:
     params = {
         "secret": secret,
         # This is the default
@@ -69,15 +69,15 @@ def build_totp_url(label, issuer, secret):
     return f"otpauth://totp/{quote(label)}?{urlencode(params)}"
 
 
-def format_hotp_value(value):
+def format_hotp_value(value: int) -> str:
     return f"{value:0{app_settings.TOTP_DIGITS}}"
 
 
-def _is_insecure_bypass(code):
+def _is_insecure_bypass(code: str) -> bool:
     return code and app_settings.TOTP_INSECURE_BYPASS_CODE == code
 
 
-def validate_totp_code(secret, code):
+def validate_totp_code(secret: str, code: str) -> bool:
     if _is_insecure_bypass(code):
         return True
     value = hotp_value(secret, hotp_counter_from_time())
@@ -85,11 +85,11 @@ def validate_totp_code(secret, code):
 
 
 class TOTP:
-    def __init__(self, instance):
+    def __init__(self, instance: Authenticator) -> None:
         self.instance = instance
 
     @classmethod
-    def activate(cls, user, secret):
+    def activate(cls, user, secret: str) -> "TOTP":
         instance = Authenticator(
             user=user, type=Authenticator.Type.TOTP, data={"secret": encrypt(secret)}
         )
@@ -108,11 +108,11 @@ class TOTP:
             self._mark_code_used(code)
         return valid
 
-    def _get_used_cache_key(self, code):
+    def _get_used_cache_key(self, code: str) -> str:
         return f"allauth.mfa.totp.used?user={self.instance.user_id}&code={code}"
 
-    def _is_code_used(self, code):
+    def _is_code_used(self, code: str) -> bool:
         return cache.get(self._get_used_cache_key(code)) == "y"
 
-    def _mark_code_used(self, code):
+    def _mark_code_used(self, code: str) -> None:
         cache.set(self._get_used_cache_key(code), "y", timeout=app_settings.TOTP_PERIOD)

--- a/allauth/mfa/totp.py
+++ b/allauth/mfa/totp.py
@@ -74,7 +74,7 @@ def format_hotp_value(value: int) -> str:
 
 
 def _is_insecure_bypass(code: str) -> bool:
-    return code and app_settings.TOTP_INSECURE_BYPASS_CODE == code
+    return bool(code and app_settings.TOTP_INSECURE_BYPASS_CODE == code)
 
 
 def validate_totp_code(secret: str, code: str) -> bool:


### PR DESCRIPTION
This PR adds a bunch of types to `allauth.mfa`'s internals.

Our app needs to set up MFA with a slightly custom flow, so we can't use the forms or headless features, so I needed to delve a bit into how things work under the hood, and figured it'd be useful if types were documented technically too, for IDEs etc.

Feels like `TOTP` and `RecoveryCodes` should have a superclass, but that's beyond the scope of this PR...