### PR TITLE
refactor(mfa): Add totp_url to headless mfa activate response data

### DIFF
--- a/allauth/headless/mfa/response.py
+++ b/allauth/headless/mfa/response.py
@@ -38,11 +38,12 @@ class AuthenticatorDeletedResponse(APIResponse):
 
 
 class TOTPNotFoundResponse(APIResponse):
-    def __init__(self, request, secret):
+    def __init__(self, request, secret, totp_url):
         super().__init__(
             request,
             meta={
                 "secret": secret,
+                "totp_url": totp_url,
             },
             status=404,
         )

--- a/allauth/headless/mfa/tests/test_views.py
+++ b/allauth/headless/mfa/tests/test_views.py
@@ -152,6 +152,7 @@ def test_get_totp_not_active(
     assert resp.status_code == 404
     data = resp.json()
     assert len(data["meta"]["secret"]) == 32
+    assert len(data["meta"]["totp_url"]) == 145
 
 
 def test_get_totp(

--- a/allauth/mfa/adapter.py
+++ b/allauth/mfa/adapter.py
@@ -1,5 +1,7 @@
 from io import BytesIO
+from urllib.parse import quote
 
+from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 
 from allauth import app_settings as allauth_settings
@@ -55,6 +57,21 @@ class DefaultMFAAdapter(BaseAdapter):
         if not issuer:
             issuer = self._get_site_name()
         return issuer
+
+    def build_totp_url(self, user, secret: str) -> str:
+        label = self.get_totp_label(user)
+        issuer = self.get_totp_issuer()
+        params = {
+            "secret": secret,
+            # This is the default
+            # "algorithm": "SHA1",
+            "issuer": issuer,
+        }
+        if app_settings.TOTP_DIGITS != 6:
+            params["digits"] = app_settings.TOTP_DIGITS
+        if app_settings.TOTP_PERIOD != 30:
+            params["period"] = app_settings.TOTP_PERIOD
+        return f"otpauth://totp/{quote(label)}?{urlencode(params)}"
 
     def build_totp_svg(self, url: str) -> str:
         import qrcode

--- a/allauth/mfa/totp.py
+++ b/allauth/mfa/totp.py
@@ -4,10 +4,8 @@ import hmac
 import secrets
 import struct
 import time
-from urllib.parse import quote
 
 from django.core.cache import cache
-from django.utils.http import urlencode
 
 from allauth.core import context
 from allauth.mfa import app_settings
@@ -53,20 +51,6 @@ def hotp_value(secret: str, counter: int) -> int:
     # Apply modulo to get a value within the specified number of digits
     value %= 10**app_settings.TOTP_DIGITS
     return value
-
-
-def build_totp_url(label: str, issuer: str, secret: str) -> str:
-    params = {
-        "secret": secret,
-        # This is the default
-        # "algorithm": "SHA1",
-        "issuer": issuer,
-    }
-    if app_settings.TOTP_DIGITS != 6:
-        params["digits"] = app_settings.TOTP_DIGITS
-    if app_settings.TOTP_PERIOD != 30:
-        params["period"] = app_settings.TOTP_PERIOD
-    return f"otpauth://totp/{quote(label)}?{urlencode(params)}"
 
 
 def format_hotp_value(value: int) -> str:

--- a/allauth/mfa/views.py
+++ b/allauth/mfa/views.py
@@ -12,8 +12,8 @@ from allauth.account import app_settings as account_settings
 from allauth.account.decorators import reauthentication_required
 from allauth.account.stages import LoginStageController
 from allauth.account.views import BaseReauthenticateView
-from allauth.mfa import app_settings, totp
-from allauth.mfa.adapter import get_adapter
+from allauth.mfa import app_settings
+from allauth.mfa.adapter import DefaultMFAAdapter, get_adapter
 from allauth.mfa.forms import (
     ActivateTOTPForm,
     AuthenticateForm,
@@ -108,12 +108,8 @@ class ActivateTOTPView(FormView):
 
     def get_context_data(self, **kwargs):
         ret = super().get_context_data(**kwargs)
-        adapter = get_adapter()
-        totp_url = totp.build_totp_url(
-            adapter.get_totp_label(self.request.user),
-            adapter.get_totp_issuer(),
-            ret["form"].secret,
-        )
+        adapter: DefaultMFAAdapter = get_adapter()
+        totp_url = adapter.build_totp_url(self.request.user, ret["form"].secret)
         totp_svg = adapter.build_totp_svg(totp_url)
         base64_data = base64.b64encode(totp_svg.encode("utf8")).decode("utf-8")
         totp_data_uri = f"data:image/svg+xml;base64,{base64_data}"

--- a/docs/headless/openapi-specification/openapi.yaml
+++ b/docs/headless/openapi-specification/openapi.yaml
@@ -2458,8 +2458,14 @@ components:
                     description: |
                       A TOTP secret that can be used to setup a new authenticator.
                     example: J4ZKKXTK7NOVU7EPUVY23LCDV4T2QZYM
+                  totp_url:
+                    type: string
+                    description: |
+                      otpauth URI from which a QR code can be generated and scanned by OTP clients.
+                    example: otpauth://totp/Example:alice@fsf.org?secret=JBSWY3DPEHPK3PXP&issuer=Example
                 required:
                   - secret
+                  - totp_url
             required:
               - status
               - meta


### PR DESCRIPTION
# Description

Adds `totp_url` to `allauth.headless.mfa.response.TOTPNotFoundResponse`. The rationale is so that we get a ready-to-render TOTP URI for our frontend and I don't have to re-implement any of the `allauth.mfa.views.ActivateTOTPView.get_context_data` logic in my application or elsewhere/some other way.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.