### PR TITLE
feat(oauth2): add method to handle access token refresh process

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -12,6 +12,8 @@ Note worthy changes
   include minor documented backwards incompatibilities. Always read the release
   notes before upgrading.
 
+- OAuth2 adapter: Added a method to handle the process of refreshing an access token intended
+  to be used in custom workflows or future attempts to create a common middleware
 
 0.63.3 (2024-05-31)
 *******************


### PR DESCRIPTION
# Description

This PR adds a method to handle the process of refreshing an access token to the OAuth2 Adapter.
The purpose for this is to give developers an option to create custom workflows in their projects, and possibly create future middleware in allauth codebase to handle the most common use cases for this.

This was based on the solution provided by https://github.com/pennersr/django-allauth/issues/420#issuecomment-1684303097

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] ~JavaScript code should adhere to [StandardJS](https://standardjs.com).~
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] ~If your change is substantial, feel free to add yourself to `AUTHORS`.~