### PR TITLE
docs: fix table in templates.rst

### DIFF
--- a/docs/common/templates.rst
+++ b/docs/common/templates.rst
@@ -89,8 +89,8 @@ You can alter these layouts by providing these templates in your own project:
 Template file                               Description
 ==========================================  ===========
 allauth/layouts/base.html                   The overall base template.
-allauth/layouts/manage.html                 The entrance template, extending the base template.
-allauth/layouts/entrance.html               The account management template, extending the base template.
+allauth/layouts/entrance.html               The entrance template, extending the base template.
+allauth/layouts/manage.html                 The account management template, extending the base template.
 ==========================================  ===========
 
 


### PR DESCRIPTION
This is a quick fix to documentation. entrance.html refers to the entrance template, and manage.html refers to the management template, not the other way around.