### PR TITLE
feat(mfa): allow overriding form of `GenerateRecoveryCodesView`

### DIFF
--- a/allauth/mfa/views.py
+++ b/allauth/mfa/views.py
@@ -219,6 +219,11 @@ class GenerateRecoveryCodesView(FormView):
         ret["user"] = self.request.user
         return ret
 
+    def get_form_class(self):
+        return get_form_class(
+            app_settings.FORMS, "generate_recovery_codes", self.form_class
+        )
+
 
 generate_recovery_codes = GenerateRecoveryCodesView.as_view()
 

--- a/docs/mfa/configuration.rst
+++ b/docs/mfa/configuration.rst
@@ -15,6 +15,7 @@ Available settings:
         'reauthenticate': 'allauth.mfa.forms.AuthenticateForm',
         'activate_totp': 'allauth.mfa.forms.ActivateTOTPForm',
         'deactivate_totp': 'allauth.mfa.forms.DeactivateTOTPForm',
+        'generate_recovery_codes': 'allauth.mfa.forms.GenerateRecoveryCodesForm',
     }
 
 ``MFA_RECOVERY_CODE_COUNT`` (default: ``10``)

--- a/docs/mfa/forms.rst
+++ b/docs/mfa/forms.rst
@@ -23,7 +23,7 @@ Example override::
         'reauthenticate': 'mysite.forms.MyCustomAuthenticateForm',
     }
 
-ActivateTOTP
+Activate TOTP
 ************
 
 *Path*
@@ -44,7 +44,7 @@ Example override::
         'activatetotp': 'mysite.forms.MyCustomActivateTOTPForm',
     }
 
-DeactivateTOTP
+Deactivate TOTP
 **************
 
 *Path*
@@ -63,4 +63,25 @@ Example override::
 
     MFA_FORMS = {
         'deactivatetotp': 'mysite.forms.MyCustomDeactivateTOTPForm',
+    }
+
+Generate Recovery Codes
+**************
+
+*Path*
+  ``allauth.mfa.forms.GenerateRecoveryCodesForm``
+
+*Used on*:
+  GenerateRecoveryCodesView used when a user generates recovery codes.
+
+Example override::
+
+    from allauth.mfa.forms import GenerateRecoveryCodesForm
+    class MyCustomGenerateRecoveryCodesForm(GenerateRecoveryCodesForm):
+      pass
+
+``settings.py``::
+
+    MFA_FORMS = {
+        'generate_recovery_codes': 'mysite.forms.MyCustomGenerateRecoveryCodesForm',
     }


### PR DESCRIPTION
Even though `GenerateRecoveryCodesForm` has no fields, one possible use case for overriding it is setting the [`default_renderer`](https://docs.djangoproject.com/en/5.0/ref/forms/api/#django.forms.Form.default_renderer) property.

Additionally, these changes make `GenerateRecoveryCodesView` more consistent with other views that override `form_class`. Currently, `GenerateRecoveryCodesView` is the only view that overrides `form_class` _without_ overriding `get_form_class` (and thus making the form configurable).

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] If your change is substantial, feel free to add yourself to `AUTHORS`.

 ## Provider Specifics

 In case you add a new provider:

- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers/<provider name>.rst` and `docs/providers/index.rst` Provider Specifics toctree.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
