### PR TITLE
Make to_str method return unique identifiers, not display name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ Daniel Eriksson
 Daniel Widerin
 David Ascher
 David Cain
+David D. Lowe
 David Evans
 David Friedman
 David Hummel

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -25,6 +25,10 @@ Note worthy changes
   the SocialAccount instance. This information was not previously saved in
   Amazon Cognito, Edmodo, and MediaWiki SocialAccount instances.
 
+- Changed the behaviour of the ``socialaccount_connections`` page to list
+  social accounts by their unique usernames or email addresses, rather than by
+  their non-unique display names.
+
 Security notice
 ---------------
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -21,6 +21,9 @@ Note worthy changes
 - Headless: When trying to sign up while a user is already logged in, you now get
   a 409.
 
+- Ensured that email address, given name and family name fields are stored in
+  the SocialAccount instance. This information was not previously saved in
+  Amazon Cognito, Edmodo, and MediaWiki SocialAccount instances.
 
 Security notice
 ---------------

--- a/allauth/socialaccount/providers/agave/provider.py
+++ b/allauth/socialaccount/providers/agave/provider.py
@@ -12,7 +12,7 @@ class AgaveAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(AgaveAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class AgaveProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/agave/provider.py
+++ b/allauth/socialaccount/providers/agave/provider.py
@@ -10,10 +10,6 @@ class AgaveAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar_url", "dflt")
 
-    def to_str(self):
-        dflt = super(AgaveAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class AgaveProvider(OAuth2Provider):
     id = "agave"

--- a/allauth/socialaccount/providers/agave/tests.py
+++ b/allauth/socialaccount/providers/agave/tests.py
@@ -29,3 +29,6 @@ class AgaveTests(OAuth2TestsMixin, TestCase):
         }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "jon@doe.edu"

--- a/allauth/socialaccount/providers/amazon/provider.py
+++ b/allauth/socialaccount/providers/amazon/provider.py
@@ -4,8 +4,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class AmazonAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("email", super().to_str())
+    pass
 
 
 class AmazonProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/amazon/provider.py
+++ b/allauth/socialaccount/providers/amazon/provider.py
@@ -5,7 +5,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class AmazonAccount(ProviderAccount):
     def to_str(self):
-        return self.account.extra_data.get("name", super(AmazonAccount, self).to_str())
+        return self.account.extra_data.get("email", super().to_str())
 
 
 class AmazonProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/amazon/tests.py
+++ b/allauth/socialaccount/providers/amazon/tests.py
@@ -19,3 +19,6 @@ class AmazonTests(OAuth2TestsMixin, TestCase):
                     }
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "johndoe@example.com"

--- a/allauth/socialaccount/providers/amazon_cognito/provider.py
+++ b/allauth/socialaccount/providers/amazon_cognito/provider.py
@@ -57,7 +57,10 @@ class AmazonCognitoProvider(OAuth2Provider):
         return {
             "address": data.get("address"),
             "birthdate": data.get("birthdate"),
+            "email": data.get("email"),
+            "family_name": data.get("family_name"),
             "gender": data.get("gender"),
+            "given_name": data.get("given_name"),
             "locale": data.get("locale"),
             "middlename": data.get("middlename"),
             "nickname": data.get("nickname"),

--- a/allauth/socialaccount/providers/amazon_cognito/provider.py
+++ b/allauth/socialaccount/providers/amazon_cognito/provider.py
@@ -12,8 +12,9 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 class AmazonCognitoAccount(ProviderAccount):
     def to_str(self):
         dflt = super(AmazonCognitoAccount, self).to_str()
-
-        return self.account.extra_data.get("username", dflt)
+        username = self.account.extra_data.get("username")
+        email = self.account.extra_data.get("email")
+        return email or username or dflt
 
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")

--- a/allauth/socialaccount/providers/amazon_cognito/provider.py
+++ b/allauth/socialaccount/providers/amazon_cognito/provider.py
@@ -49,26 +49,15 @@ class AmazonCognitoProvider(OAuth2Provider):
         )
 
     def extract_extra_data(self, data):
-        return {
-            "address": data.get("address"),
-            "birthdate": data.get("birthdate"),
-            "email": data.get("email"),
-            "family_name": data.get("family_name"),
-            "gender": data.get("gender"),
-            "given_name": data.get("given_name"),
-            "locale": data.get("locale"),
-            "middlename": data.get("middlename"),
-            "nickname": data.get("nickname"),
-            "phone_number": data.get("phone_number"),
-            "phone_number_verified": convert_to_python_bool_if_value_is_json_string_bool(
-                data.get("phone_number_verified")
-            ),
-            "picture": data.get("picture"),
-            "preferred_username": data.get("preferred_username"),
-            "profile": data.get("profile"),
-            "website": data.get("website"),
-            "zoneinfo": data.get("zoneinfo"),
-        }
+        ret = dict(data)
+        phone_number_verified = data.get("phone_number_verified")
+        if phone_number_verified is not None:
+            ret["phone_number_verified"] = (
+                convert_to_python_bool_if_value_is_json_string_bool(
+                    "phone_number_verified"
+                )
+            )
+        return ret
 
     @classmethod
     def get_slug(cls):

--- a/allauth/socialaccount/providers/amazon_cognito/provider.py
+++ b/allauth/socialaccount/providers/amazon_cognito/provider.py
@@ -10,12 +10,6 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class AmazonCognitoAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super(AmazonCognitoAccount, self).to_str()
-        username = self.account.extra_data.get("username")
-        email = self.account.extra_data.get("email")
-        return email or username or dflt
-
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 

--- a/allauth/socialaccount/providers/amazon_cognito/tests.py
+++ b/allauth/socialaccount/providers/amazon_cognito/tests.py
@@ -39,8 +39,10 @@ class AmazonCognitoTestCase(OAuth2TestsMixin, TestCase):
 
     def get_mocked_response(self):
         mocked_payload = json.dumps(_get_mocked_claims())
-
         return MockedResponse(status_code=200, content=mocked_payload)
+
+    def get_expected_to_str(self):
+        return "jdoe@example.com"
 
     @override_settings(SOCIALACCOUNT_PROVIDERS={"amazon_cognito": {}})
     def test_oauth2_adapter_raises_if_domain_settings_is_missing(

--- a/allauth/socialaccount/providers/angellist/provider.py
+++ b/allauth/socialaccount/providers/angellist/provider.py
@@ -12,10 +12,6 @@ class AngelListAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("image")
 
-    def to_str(self):
-        dflt = super(AngelListAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class AngelListProvider(OAuth2Provider):
     id = "angellist"

--- a/allauth/socialaccount/providers/angellist/provider.py
+++ b/allauth/socialaccount/providers/angellist/provider.py
@@ -14,7 +14,7 @@ class AngelListAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(AngelListAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class AngelListProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/angellist/tests.py
+++ b/allauth/socialaccount/providers/angellist/tests.py
@@ -23,3 +23,6 @@ class AngelListTests(OAuth2TestsMixin, TestCase):
 "email"]}
 """,
         )
+
+    def get_expected_to_str(self):
+        return "raymond.penners@example.com"

--- a/allauth/socialaccount/providers/apple/provider.py
+++ b/allauth/socialaccount/providers/apple/provider.py
@@ -9,10 +9,23 @@ from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
+class AppleAccount(ProviderAccount):
+    def to_str(self):
+        dflt = super().to_str()
+        email = self.account.extra_data.get("email")
+        name = self.account.extra_data.get("name", {})
+        if name and (name.get("firstName") or name.get("lastName")):
+            full_name = " ".join([name.get("firstName", ""), name.get("lastName", "")])
+            full_name = full_name.strip()
+            if full_name:
+                return f"{full_name} <{email or dflt}>"
+        return email or dflt
+
+
 class AppleProvider(OAuth2Provider):
     id = "apple"
     name = "Apple"
-    account_class = ProviderAccount
+    account_class = AppleAccount
     oauth2_adapter_class = AppleOAuth2Adapter
     supports_token_authentication = True
 

--- a/allauth/socialaccount/providers/apple/provider.py
+++ b/allauth/socialaccount/providers/apple/provider.py
@@ -11,15 +11,18 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class AppleAccount(ProviderAccount):
     def to_str(self):
-        dflt = super().to_str()
         email = self.account.extra_data.get("email")
-        name = self.account.extra_data.get("name", {})
-        if name and (name.get("firstName") or name.get("lastName")):
-            full_name = " ".join([name.get("firstName", ""), name.get("lastName", "")])
+        if email and not email.lower().endswith("@privaterelay.appleid.com"):
+            return email
+
+        name = self.account.extra_data.get("name") or {}
+        if name.get("firstName") or name.get("lastName"):
+            full_name = f"{name['firstName'] or ''} {name['lastName'] or ''}"
             full_name = full_name.strip()
             if full_name:
-                return f"{full_name} <{email or dflt}>"
-        return email or dflt
+                return full_name
+
+        return super().to_str()
 
 
 class AppleProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/apple/tests.py
+++ b/allauth/socialaccount/providers/apple/tests.py
@@ -170,6 +170,9 @@ class AppleTests(OAuth2TestsMixin, TestCase):
             200, KEY_SERVER_RESP_JSON, {"content-type": "application/json"}
         )
 
+    def get_expected_to_str(self):
+        return "A B <test@privaterelay.appleid.com>"
+
     def get_complete_parameters(self, auth_request_params):
         """
         Add apple specific response parameters which they include in the

--- a/allauth/socialaccount/providers/apple/tests.py
+++ b/allauth/socialaccount/providers/apple/tests.py
@@ -171,7 +171,7 @@ class AppleTests(OAuth2TestsMixin, TestCase):
         )
 
     def get_expected_to_str(self):
-        return "A B <test@privaterelay.appleid.com>"
+        return "A B"
 
     def get_complete_parameters(self, auth_request_params):
         """

--- a/allauth/socialaccount/providers/asana/provider.py
+++ b/allauth/socialaccount/providers/asana/provider.py
@@ -4,11 +4,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class AsanaAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super().to_str()
-        email = self.account.extra_data.get("email")
-        name = self.account.extra_data.get("name")
-        return email or name or dflt
+    pass
 
 
 class AsanaProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/asana/provider.py
+++ b/allauth/socialaccount/providers/asana/provider.py
@@ -4,7 +4,11 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class AsanaAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        dflt = super().to_str()
+        email = self.account.extra_data.get("email")
+        name = self.account.extra_data.get("name")
+        return email or name or dflt
 
 
 class AsanaProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/asana/tests.py
+++ b/allauth/socialaccount/providers/asana/tests.py
@@ -15,3 +15,6 @@ class AsanaTests(OAuth2TestsMixin, TestCase):
 {"id": 3133777, "name": "Personal Projects"}], "email": "test@example.com",
 "name": "Test Name", "id": 43748387}}""",
         )
+
+    def get_expected_to_str(self):
+        return "test@example.com"

--- a/allauth/socialaccount/providers/atlassian/provider.py
+++ b/allauth/socialaccount/providers/atlassian/provider.py
@@ -10,7 +10,7 @@ class AtlassianAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super().to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class AtlassianProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/atlassian/provider.py
+++ b/allauth/socialaccount/providers/atlassian/provider.py
@@ -8,10 +8,6 @@ class AtlassianAccount(ProviderAccount):
     def get_profile_url(self):
         return self.account.extra_data.get("picture")
 
-    def to_str(self):
-        dflt = super().to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class AtlassianProvider(OAuth2Provider):
     id = "atlassian"

--- a/allauth/socialaccount/providers/atlassian/tests.py
+++ b/allauth/socialaccount/providers/atlassian/tests.py
@@ -28,3 +28,6 @@ class AtlassianTests(OAuth2TestsMixin, TestCase):
             }
         }"""
         return MockedResponse(200, response_data)
+
+    def get_expected_to_str(self):
+        return "mia@example.com"

--- a/allauth/socialaccount/providers/auth0/provider.py
+++ b/allauth/socialaccount/providers/auth0/provider.py
@@ -7,13 +7,6 @@ class Auth0Account(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 
-    def to_str(self):
-        dflt = super(Auth0Account, self).to_str()
-        email = self.account.extra_data.get("email")
-        username = self.account.extra_data.get("username")
-        name = self.account.extra_data.get("name")
-        return email or username or name or dflt
-
 
 class Auth0Provider(OAuth2Provider):
     id = "auth0"

--- a/allauth/socialaccount/providers/auth0/provider.py
+++ b/allauth/socialaccount/providers/auth0/provider.py
@@ -9,7 +9,10 @@ class Auth0Account(ProviderAccount):
 
     def to_str(self):
         dflt = super(Auth0Account, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        email = self.account.extra_data.get("email")
+        username = self.account.extra_data.get("username")
+        name = self.account.extra_data.get("name")
+        return email or username or name or dflt
 
 
 class Auth0Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/auth0/tests.py
+++ b/allauth/socialaccount/providers/auth0/tests.py
@@ -20,3 +20,6 @@ class Auth0Tests(OAuth2TestsMixin, TestCase):
             }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "mr.bob@your.Auth0.server.example.com"

--- a/allauth/socialaccount/providers/authentiq/provider.py
+++ b/allauth/socialaccount/providers/authentiq/provider.py
@@ -50,12 +50,6 @@ class AuthentiqAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 
-    def to_str(self):
-        dflt = super(AuthentiqAccount, self).to_str()
-        name = self.account.extra_data.get("name")
-        email = self.account.extra_data.get("email")
-        return email or name or dflt
-
 
 class AuthentiqProvider(OAuth2Provider):
     id = "authentiq"

--- a/allauth/socialaccount/providers/authentiq/provider.py
+++ b/allauth/socialaccount/providers/authentiq/provider.py
@@ -52,7 +52,9 @@ class AuthentiqAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(AuthentiqAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        name = self.account.extra_data.get("name")
+        email = self.account.extra_data.get("email")
+        return email or name or dflt
 
 
 class AuthentiqProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/authentiq/tests.py
+++ b/allauth/socialaccount/providers/authentiq/tests.py
@@ -27,6 +27,9 @@ class AuthentiqTests(OAuth2TestsMixin, TestCase):
             ),
         )
 
+    def get_expected_to_str(self):
+        return "jane@email.invalid"
+
     @override_settings(
         SOCIALACCOUNT_QUERY_EMAIL=False,
     )

--- a/allauth/socialaccount/providers/baidu/tests.py
+++ b/allauth/socialaccount/providers/baidu/tests.py
@@ -14,3 +14,6 @@ class BaiduTests(OAuth2TestsMixin, TestCase):
 {"portrait": "78c0e9839de59bbde7859ccf43",
 "uname": "\u90dd\u56fd\u715c", "uid": "3225892368"}""",
         )
+
+    def get_expected_to_str(self):
+        return "\u90dd\u56fd\u715c"

--- a/allauth/socialaccount/providers/base/provider.py
+++ b/allauth/socialaccount/providers/base/provider.py
@@ -274,9 +274,11 @@ class ProviderAccount:
         fashion, without having to worry about it.
         """
         ed = self.account.extra_data
-        return (
-            ed.get("email")
-            or ed.get("username")
-            or ed.get("name")
-            or self.get_brand()["name"]
-        )
+        if isinstance(ed, dict):
+            if ed.get("email") and isinstance(ed["email"], str):
+                return ed["email"]
+            elif ed.get("username") and isinstance(ed["username"], str):
+                return ed["username"]
+            elif ed.get("name") and isinstance(ed["name"], str):
+                return ed["name"]
+        return self.get_brand()["name"]

--- a/allauth/socialaccount/providers/base/provider.py
+++ b/allauth/socialaccount/providers/base/provider.py
@@ -252,7 +252,18 @@ class ProviderAccount:
 
     def to_str(self):
         """
-        This did not use to work in the past due to py2 compatibility:
+        Returns string representation of this social account. This is the
+        unique identifier of the account, such as its username or its email
+        address. It should be meaningful to human beings, which means a numeric
+        ID number is rarely the appropriate representation here.
+
+        Subclasses are meant to override this method.
+
+        Users will see the string representation of their social accounts in
+        the page rendered by the allauth.socialaccount.views.connections view.
+
+        The following code did not use to work in the past due to py2
+        compatibility:
 
             class GoogleAccount(ProviderAccount):
                 def __str__(self):
@@ -262,4 +273,10 @@ class ProviderAccount:
         So we have this method `to_str` that can be overridden in a conventional
         fashion, without having to worry about it.
         """
-        return self.get_brand()["name"]
+        ed = self.account.extra_data
+        return (
+            ed.get("email")
+            or ed.get("username")
+            or ed.get("name")
+            or self.get_brand()["name"]
+        )

--- a/allauth/socialaccount/providers/base/provider.py
+++ b/allauth/socialaccount/providers/base/provider.py
@@ -144,7 +144,8 @@ class Provider:
     def extract_extra_data(self, data):
         """
         Extracts fields from `data` that will be stored in
-        `SocialAccount`'s `extra_data` JSONField.
+        `SocialAccount`'s `extra_data` JSONField, such as email address, first
+        name, last name, and phone number.
 
         :return: any JSON-serializable Python structure.
         """

--- a/allauth/socialaccount/providers/base/provider.py
+++ b/allauth/socialaccount/providers/base/provider.py
@@ -275,10 +275,23 @@ class ProviderAccount:
         """
         ed = self.account.extra_data
         if isinstance(ed, dict):
-            if ed.get("email") and isinstance(ed["email"], str):
-                return ed["email"]
-            elif ed.get("username") and isinstance(ed["username"], str):
-                return ed["username"]
-            elif ed.get("name") and isinstance(ed["name"], str):
-                return ed["name"]
+            keys = [
+                "email",
+                "default_email",
+                "username",
+                "name",
+                "full_name",
+                "fullName",
+            ]
+            for key in keys:
+                if ed.get(key) and isinstance(ed[key], str):
+                    return ed[key]
+            first_name = ed.get("first_name") or ed.get("firstName") or ""
+            last_name = ed.get("last_name") or ed.get("lastName") or ""
+            if (
+                isinstance(first_name, str)
+                and isinstance(last_name, str)
+                and (first_name or last_name)
+            ):
+                return f"{first_name} {last_name}".strip()
         return self.get_brand()["name"]

--- a/allauth/socialaccount/providers/basecamp/provider.py
+++ b/allauth/socialaccount/providers/basecamp/provider.py
@@ -11,7 +11,7 @@ class BasecampAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(BasecampAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("identity", {}).get("email_address", dflt)
 
 
 class BasecampProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/basecamp/tests.py
+++ b/allauth/socialaccount/providers/basecamp/tests.py
@@ -41,3 +41,6 @@ class BasecampTests(OAuth2TestsMixin, TestCase):
             ]
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "jason@example.com"

--- a/allauth/socialaccount/providers/battlenet/tests.py
+++ b/allauth/socialaccount/providers/battlenet/tests.py
@@ -18,6 +18,9 @@ class BattleNetTests(OAuth2TestsMixin, TestCase):
         data = {"battletag": self._battletag, "id": self._uid}
         return MockedResponse(200, json.dumps(data))
 
+    def get_expected_to_str(self):
+        return self._battletag
+
     def test_valid_response_no_battletag(self):
         data = {"id": 12345}
         response = MockedResponse(200, json.dumps(data))

--- a/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
@@ -14,7 +14,7 @@ class BitbucketOAuth2Account(ProviderAccount):
 
     def to_str(self):
         dflt = super(BitbucketOAuth2Account, self).to_str()
-        return self.account.extra_data.get("display_name", dflt)
+        return self.account.extra_data.get("username", dflt)
 
 
 class BitbucketOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/provider.py
@@ -12,10 +12,6 @@ class BitbucketOAuth2Account(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("links", {}).get("avatar", {}).get("href")
 
-    def to_str(self):
-        dflt = super(BitbucketOAuth2Account, self).to_str()
-        return self.account.extra_data.get("username", dflt)
-
 
 class BitbucketOAuth2Provider(OAuth2Provider):
     id = "bitbucket_oauth2"

--- a/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
@@ -89,13 +89,16 @@ class BitbucketOAuth2Tests(OAuth2TestsMixin, TestCase):
             MockedResponse(200, self.email_response_data),
         ]
 
+    def get_expected_to_str(self):
+        return "tutorials"
+
     def test_provider_account(self):
         self.login(self.get_mocked_response())
         socialaccount = SocialAccount.objects.get(uid="tutorials")
         self.assertEqual(socialaccount.user.username, "tutorials")
         self.assertEqual(socialaccount.user.email, "tutorials@bitbucket.org")
         account = socialaccount.get_provider_account()
-        self.assertEqual(account.to_str(), "tutorials account")
+        self.assertEqual(account.to_str(), "tutorials")
         self.assertEqual(account.get_profile_url(), "https://bitbucket.org/tutorials")
         self.assertEqual(
             account.get_avatar_url(),

--- a/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/tests.py
@@ -90,7 +90,7 @@ class BitbucketOAuth2Tests(OAuth2TestsMixin, TestCase):
         ]
 
     def get_expected_to_str(self):
-        return "tutorials"
+        return "tutorials@bitbucket.org"
 
     def test_provider_account(self):
         self.login(self.get_mocked_response())
@@ -98,7 +98,7 @@ class BitbucketOAuth2Tests(OAuth2TestsMixin, TestCase):
         self.assertEqual(socialaccount.user.username, "tutorials")
         self.assertEqual(socialaccount.user.email, "tutorials@bitbucket.org")
         account = socialaccount.get_provider_account()
-        self.assertEqual(account.to_str(), "tutorials")
+        self.assertEqual(account.to_str(), "tutorials@bitbucket.org")
         self.assertEqual(account.get_profile_url(), "https://bitbucket.org/tutorials")
         self.assertEqual(
             account.get_avatar_url(),

--- a/allauth/socialaccount/providers/bitly/provider.py
+++ b/allauth/socialaccount/providers/bitly/provider.py
@@ -12,10 +12,7 @@ class BitlyAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(BitlyAccount, self).to_str()
-        return "%s (%s)" % (
-            self.account.extra_data.get("full_name", ""),
-            dflt,
-        )
+        return self.account.extra_data.get("login") or dflt
 
 
 class BitlyProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/bitly/tests.py
+++ b/allauth/socialaccount/providers/bitly/tests.py
@@ -28,3 +28,6 @@ class BitlyTests(OAuth2TestsMixin, TestCase):
             "status_txt": "OK"
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "bitlyapioauthdemo"

--- a/allauth/socialaccount/providers/box/provider.py
+++ b/allauth/socialaccount/providers/box/provider.py
@@ -4,7 +4,8 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class BoxOAuth2Account(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("login") or super().to_str()
 
 
 class BoxOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/box/tests.py
+++ b/allauth/socialaccount/providers/box/tests.py
@@ -31,3 +31,6 @@ class BoxOAuth2Tests(OAuth2TestsMixin, TestCase):
         }""",
             )
         ]
+
+    def get_expected_to_str(self):
+        return "balls@example.com"

--- a/allauth/socialaccount/providers/cilogon/provider.py
+++ b/allauth/socialaccount/providers/cilogon/provider.py
@@ -13,9 +13,7 @@ class Scope:
 
 
 class CILogonAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super(CILogonAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
+    pass
 
 
 class CILogonProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/cilogon/provider.py
+++ b/allauth/socialaccount/providers/cilogon/provider.py
@@ -15,7 +15,7 @@ class Scope:
 class CILogonAccount(ProviderAccount):
     def to_str(self):
         dflt = super(CILogonAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class CILogonProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/cilogon/tests.py
+++ b/allauth/socialaccount/providers/cilogon/tests.py
@@ -20,3 +20,6 @@ class CILogonTests(OAuth2TestsMixin, TestCase):
             "sub": "http://cilogon.org/serverA/users/1234567"
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "johndoe@example.edu"

--- a/allauth/socialaccount/providers/clever/provider.py
+++ b/allauth/socialaccount/providers/clever/provider.py
@@ -11,10 +11,8 @@ class CleverAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(CleverAccount, self).to_str()
-        return "%s (%s)" % (
-            self.account.extra_data.get("name", ""),
-            dflt,
-        )
+        email = self.account.extra_data.get("data", {}).get("email")
+        return email or dflt
 
 
 class CleverProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/clever/tests.py
+++ b/allauth/socialaccount/providers/clever/tests.py
@@ -48,3 +48,6 @@ class CleverOAuth2Tests(OAuth2TestsMixin, TestCase):
                 }""",
             ),
         ]
+
+    def get_expected_to_str(self):
+        return "Clever"

--- a/allauth/socialaccount/providers/coinbase/provider.py
+++ b/allauth/socialaccount/providers/coinbase/provider.py
@@ -10,9 +10,10 @@ class CoinbaseAccount(ProviderAccount):
         return None
 
     def to_str(self):
-        return self.account.extra_data.get(
-            "name", super(CoinbaseAccount, self).to_str()
-        )
+        dflt = super().to_str()
+        email = self.account.extra_data.get("email")
+        name = self.account.extra_data.get("name")
+        return email or name or dflt
 
 
 class CoinbaseProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/coinbase/provider.py
+++ b/allauth/socialaccount/providers/coinbase/provider.py
@@ -9,12 +9,6 @@ class CoinbaseAccount(ProviderAccount):
     def get_avatar_url(self):
         return None
 
-    def to_str(self):
-        dflt = super().to_str()
-        email = self.account.extra_data.get("email")
-        name = self.account.extra_data.get("name")
-        return email or name or dflt
-
 
 class CoinbaseProvider(OAuth2Provider):
     id = "coinbase"

--- a/allauth/socialaccount/providers/coinbase/tests.py
+++ b/allauth/socialaccount/providers/coinbase/tests.py
@@ -23,3 +23,6 @@ class CoinbaseTests(OAuth2TestsMixin, TestCase):
           "resource_path": "/v2/user"
             }""",
         )
+
+    def get_expected_to_str(self):
+        return "user1@example.com"

--- a/allauth/socialaccount/providers/dataporten/provider.py
+++ b/allauth/socialaccount/providers/dataporten/provider.py
@@ -15,14 +15,6 @@ class DataportenAccount(ProviderAccount):
         base_url = "https://api.dataporten.no/userinfo/v1/user/media/"
         return base_url + self.account.extra_data["profilephoto"]
 
-    def to_str(self):
-        """
-        Returns string representation of a social account. This is the unique
-        identifier of the account, such as its email address.
-        """
-        dflt = super(DataportenAccount, self).to_str()
-        return self.account.extra_data.get("email") or dflt
-
 
 class DataportenProvider(OAuth2Provider):
     id = "dataporten"

--- a/allauth/socialaccount/providers/dataporten/provider.py
+++ b/allauth/socialaccount/providers/dataporten/provider.py
@@ -17,14 +17,11 @@ class DataportenAccount(ProviderAccount):
 
     def to_str(self):
         """
-        Returns string representation of a social account. Includes the name
-        of the user.
+        Returns string representation of a social account. This is the unique
+        identifier of the account, such as its email address.
         """
         dflt = super(DataportenAccount, self).to_str()
-        return "%s (%s)" % (
-            self.account.extra_data.get("name", ""),
-            dflt,
-        )
+        return self.account.extra_data.get("email") or dflt
 
 
 class DataportenProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/dataporten/tests.py
+++ b/allauth/socialaccount/providers/dataporten/tests.py
@@ -48,6 +48,9 @@ class DataportenTest(OAuth2TestsMixin, TestCase):
             headers={"content-type": "application/json"},
         )
 
+    def get_expected_to_str(self):
+        return "andreas.solberg@uninett.no"
+
     def test_extract_uid(self):
         uid = self.provider.extract_uid(self.mock_data)
         self.assertEqual(uid, self.mock_data["userid"])

--- a/allauth/socialaccount/providers/daum/provider.py
+++ b/allauth/socialaccount/providers/daum/provider.py
@@ -8,7 +8,7 @@ class DaumAccount(ProviderAccount):
         return self.account.extra_data.get("bigImagePath")
 
     def to_str(self):
-        return self.account.extra_data.get("nickname", self.account.uid)
+        return self.account.extra_data.get("userid", self.account.uid)
 
 
 class DaumProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/daum/tests.py
+++ b/allauth/socialaccount/providers/daum/tests.py
@@ -21,3 +21,6 @@ class DaumTests(OAuth2TestsMixin, TestCase):
         body["message"] = "OK"
         body["result"] = result
         return MockedResponse(200, json.dumps(body))
+
+    def get_expected_to_str(self):
+        return "38DTh"

--- a/allauth/socialaccount/providers/digitalocean/provider.py
+++ b/allauth/socialaccount/providers/digitalocean/provider.py
@@ -6,7 +6,9 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class DigitalOceanAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        dflt = super().to_str()
+        return self.account.extra_data.get("account", {}).get("email") or dflt
 
 
 class DigitalOceanProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/digitalocean/tests.py
+++ b/allauth/socialaccount/providers/digitalocean/tests.py
@@ -39,3 +39,6 @@ class DigitalOceanTests(OAuth2TestsMixin, TestCase):
             "uuid":"b6fr89dbf6d9156cace5f3c78dc9851d957381ef"
           }
         }"""
+
+    def get_expected_to_str(self):
+        return "sammy@example.com"

--- a/allauth/socialaccount/providers/dingtalk/tests.py
+++ b/allauth/socialaccount/providers/dingtalk/tests.py
@@ -24,3 +24,6 @@ class DingTalkTests(OAuth2TestsMixin, TestCase):
     "expireIn": "3600",
     "refreshToken": "testrf"
 }"""
+
+    def get_expected_to_str(self):
+        return "aiden"

--- a/allauth/socialaccount/providers/discord/tests.py
+++ b/allauth/socialaccount/providers/discord/tests.py
@@ -25,6 +25,9 @@ class DiscordTests(OAuth2TestsMixin, TestCase):
         }""",
         )
 
+    def get_expected_to_str(self):
+        return "Nelly"
+
     def test_display_name(self, multiple_login=False):
         email = "user@example.com"
         user = get_user_model()(is_active=True)
@@ -65,6 +68,9 @@ class OldDiscordTests(DiscordTests, TestCase):
             "email": "nelly@example.com"
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "Nelly#1337"
 
     def test_display_name(self, multiple_login=False):
         email = "user@example.com"

--- a/allauth/socialaccount/providers/disqus/provider.py
+++ b/allauth/socialaccount/providers/disqus/provider.py
@@ -14,7 +14,9 @@ class DisqusAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(DisqusAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        email = self.account.extra_data.get("email")
+        name = self.account.extra_data.get("name")
+        return email or name or dflt
 
 
 class DisqusProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/disqus/provider.py
+++ b/allauth/socialaccount/providers/disqus/provider.py
@@ -12,12 +12,6 @@ class DisqusAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar", {}).get("permalink")
 
-    def to_str(self):
-        dflt = super(DisqusAccount, self).to_str()
-        email = self.account.extra_data.get("email")
-        name = self.account.extra_data.get("name")
-        return email or name or dflt
-
 
 class DisqusProvider(OAuth2Provider):
     id = "disqus"

--- a/allauth/socialaccount/providers/disqus/tests.py
+++ b/allauth/socialaccount/providers/disqus/tests.py
@@ -35,6 +35,9 @@ class DisqusTests(OAuth2TestsMixin, TestCase):
             % (name, email),
         )
 
+    def get_expected_to_str(self):
+        return "raymond.penners@example.com"
+
     def test_account_connect(self):
         email = "user@example.com"
         user = User.objects.create(username="user", is_active=True, email=email)

--- a/allauth/socialaccount/providers/douban/provider.py
+++ b/allauth/socialaccount/providers/douban/provider.py
@@ -12,7 +12,7 @@ class DoubanAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(DoubanAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("uid", dflt)
 
 
 class DoubanProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/douban/tests.py
+++ b/allauth/socialaccount/providers/douban/tests.py
@@ -25,3 +25,6 @@ class DoubanTests(OAuth2TestsMixin, TestCase):
              "large_avatar": "http://img3.douban.com/icon/up3659811-3.jpg"}
 """,
         )
+
+    def get_expected_to_str(self):
+        return "qguo"

--- a/allauth/socialaccount/providers/doximity/provider.py
+++ b/allauth/socialaccount/providers/doximity/provider.py
@@ -14,7 +14,7 @@ class DoximityAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(DoximityAccount, self).to_str()
-        return self.account.extra_data.get("full_name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class DoximityProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/doximity/provider.py
+++ b/allauth/socialaccount/providers/doximity/provider.py
@@ -12,10 +12,6 @@ class DoximityAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("profile_photo")
 
-    def to_str(self):
-        dflt = super(DoximityAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class DoximityProvider(OAuth2Provider):
     id = "doximity"

--- a/allauth/socialaccount/providers/doximity/tests.py
+++ b/allauth/socialaccount/providers/doximity/tests.py
@@ -63,3 +63,6 @@ class DoximityTests(OAuth2TestsMixin, TestCase):
         }
 """,
         )
+
+    def get_expected_to_str(self):
+        return "abelalmd@example.com"

--- a/allauth/socialaccount/providers/draugiem/provider.py
+++ b/allauth/socialaccount/providers/draugiem/provider.py
@@ -25,7 +25,7 @@ class DraugiemAccount(ProviderAccount):
     def to_str(self):
         default = super(DraugiemAccount, self).to_str()
         name = self.account.extra_data.get("name")
-        surname = self.account.extra_data.get("surnname")
+        surname = self.account.extra_data.get("surname")
 
         if name and surname:
             return "%s %s" % (name, surname)

--- a/allauth/socialaccount/providers/draugiem/tests.py
+++ b/allauth/socialaccount/providers/draugiem/tests.py
@@ -144,4 +144,4 @@ class DraugiemTests(TestCase):
                 pacc.get_avatar_url()
                 == "http://cdn.memegenerator.net/instances/500x/23395689.jpg"
             )
-            assert pacc.to_str() == "Draugiem"
+            assert pacc.to_str() == "Anakin Skywalker"

--- a/allauth/socialaccount/providers/drip/provider.py
+++ b/allauth/socialaccount/providers/drip/provider.py
@@ -5,8 +5,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class DripAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("email") or super().to_str()
+    pass
 
 
 class DripProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/drip/provider.py
+++ b/allauth/socialaccount/providers/drip/provider.py
@@ -5,7 +5,8 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class DripAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("email") or super().to_str()
 
 
 class DripProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/drip/tests.py
+++ b/allauth/socialaccount/providers/drip/tests.py
@@ -18,3 +18,6 @@ class DripTests(OAuth2TestsMixin, TestCase):
             }]
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "john@acme.com"

--- a/allauth/socialaccount/providers/dropbox/provider.py
+++ b/allauth/socialaccount/providers/dropbox/provider.py
@@ -5,8 +5,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class DropboxOAuth2Account(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("email") or super().to_str()
+    pass
 
 
 class DropboxOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/dropbox/provider.py
+++ b/allauth/socialaccount/providers/dropbox/provider.py
@@ -5,7 +5,8 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class DropboxOAuth2Account(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("email") or super().to_str()
 
 
 class DropboxOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/dropbox/tests.py
+++ b/allauth/socialaccount/providers/dropbox/tests.py
@@ -34,3 +34,6 @@ class DropboxOAuth2Tests(OAuth2TestsMixin, TestCase):
             "referral_link": "https://db.tt/ASDfAsDf",
         }
         return MockedResponse(200, json.dumps(payload))
+
+    def get_expected_to_str(self):
+        return "allauth@example.com"

--- a/allauth/socialaccount/providers/dummy/provider.py
+++ b/allauth/socialaccount/providers/dummy/provider.py
@@ -15,8 +15,9 @@ class DummyAccount(ProviderAccount):
         dflt = super().to_str()
         first_name = self.account.extra_data.get("first_name") or ""
         last_name = self.account.extra_data.get("last_name") or ""
-        name = " ".join([first_name, last_name]).strip() or dflt
-        return name
+        name = " ".join([first_name, last_name]).strip()
+        email = self.account.extra_data.get("email")
+        return email or name or dflt
 
 
 class DummyProvider(Provider):

--- a/allauth/socialaccount/providers/dummy/tests.py
+++ b/allauth/socialaccount/providers/dummy/tests.py
@@ -2,6 +2,8 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
+from allauth.socialaccount.models import SocialAccount
+
 
 def test_login(client, db):
     resp = client.post(reverse("dummy_login"))
@@ -14,3 +16,6 @@ def test_login(client, db):
     assert resp.status_code == 302
     assert resp["location"] == settings.LOGIN_REDIRECT_URL
     get_user_model().objects.filter(email="a@b.com").exists()
+    socialaccount = SocialAccount.objects.get(uid="123")
+    account = socialaccount.get_provider_account()
+    assert account.to_str() == "a@b.com"

--- a/allauth/socialaccount/providers/dwolla/provider.py
+++ b/allauth/socialaccount/providers/dwolla/provider.py
@@ -6,9 +6,8 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class DwollaAccount(ProviderAccount):
-    """Dwolla Account"""
-
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("name") or super().to_str()
 
 
 class DwollaProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/dwolla/provider.py
+++ b/allauth/socialaccount/providers/dwolla/provider.py
@@ -6,8 +6,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class DwollaAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("name") or super().to_str()
+    pass
 
 
 class DwollaProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/dwolla/tests.py
+++ b/allauth/socialaccount/providers/dwolla/tests.py
@@ -29,3 +29,6 @@ class DwollaTests(OAuth2TestsMixin, TestCase):
             %s }"""
             % rt
         )
+
+    def get_expected_to_str(self):
+        return "John Doe"

--- a/allauth/socialaccount/providers/edmodo/provider.py
+++ b/allauth/socialaccount/providers/edmodo/provider.py
@@ -31,15 +31,13 @@ class EdmodoProvider(OAuth2Provider):
         )
 
     def extract_extra_data(self, data):
-        return dict(
-            avatar_url=data.get("avatars").get("large"),
-            email=data.get("email"),
-            first_name=data.get("first_name"),
-            last_name=data.get("last_name"),
-            profile_url=data.get("url"),
-            user_type=data.get("type"),
-            username=data.get("username"),
-        )
+        ret = dict(data)
+        # NOTE: For backwards compatibility
+        ret["user_type"] = data.get("type")
+        ret["profile_url"] = data.get("url")
+        ret["avatar_url"] = data.get("avatars", {}).get("large")
+        # (end NOTE)
+        return ret
 
 
 provider_classes = [EdmodoProvider]

--- a/allauth/socialaccount/providers/edmodo/provider.py
+++ b/allauth/socialaccount/providers/edmodo/provider.py
@@ -10,6 +10,9 @@ class EdmodoAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar_url")
 
+    def to_str(self):
+        return self.account.extra_data.get("username") or super().to_str()
+
 
 class EdmodoProvider(OAuth2Provider):
     id = "edmodo"

--- a/allauth/socialaccount/providers/edmodo/provider.py
+++ b/allauth/socialaccount/providers/edmodo/provider.py
@@ -32,9 +32,13 @@ class EdmodoProvider(OAuth2Provider):
 
     def extract_extra_data(self, data):
         return dict(
-            user_type=data.get("type"),
-            profile_url=data.get("url"),
             avatar_url=data.get("avatars").get("large"),
+            email=data.get("email"),
+            first_name=data.get("first_name"),
+            last_name=data.get("last_name"),
+            profile_url=data.get("url"),
+            user_type=data.get("type"),
+            username=data.get("username"),
         )
 
 

--- a/allauth/socialaccount/providers/edmodo/provider.py
+++ b/allauth/socialaccount/providers/edmodo/provider.py
@@ -10,9 +10,6 @@ class EdmodoAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar_url")
 
-    def to_str(self):
-        return self.account.extra_data.get("username") or super().to_str()
-
 
 class EdmodoProvider(OAuth2Provider):
     id = "edmodo"

--- a/allauth/socialaccount/providers/edmodo/tests.py
+++ b/allauth/socialaccount/providers/edmodo/tests.py
@@ -42,3 +42,6 @@ class EdmodoTests(OAuth2TestsMixin, TestCase):
 }
 """,
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "getacclaim-teacher1"

--- a/allauth/socialaccount/providers/edmodo/tests.py
+++ b/allauth/socialaccount/providers/edmodo/tests.py
@@ -44,4 +44,4 @@ class EdmodoTests(OAuth2TestsMixin, TestCase):
         )  # noqa
 
     def get_expected_to_str(self):
-        return "getacclaim-teacher1"
+        return "test@example.com"

--- a/allauth/socialaccount/providers/edx/provider.py
+++ b/allauth/socialaccount/providers/edx/provider.py
@@ -8,6 +8,9 @@ class EdxAccount(ProviderAccount):
         if self.account.extra_data["profile_image"]["has_image"]:
             return self.account.extra_data["image_url_full"]
 
+    def to_str(self):
+        return self.account.extra_data.get("username") or super().to_str()
+
 
 class EdxProvider(OAuth2Provider):
     id = "edx"

--- a/allauth/socialaccount/providers/edx/provider.py
+++ b/allauth/socialaccount/providers/edx/provider.py
@@ -8,9 +8,6 @@ class EdxAccount(ProviderAccount):
         if self.account.extra_data["profile_image"]["has_image"]:
             return self.account.extra_data["image_url_full"]
 
-    def to_str(self):
-        return self.account.extra_data.get("username") or super().to_str()
-
 
 class EdxProvider(OAuth2Provider):
     id = "edx"

--- a/allauth/socialaccount/providers/edx/tests.py
+++ b/allauth/socialaccount/providers/edx/tests.py
@@ -44,3 +44,6 @@ class EdxTests(OAuth2TestsMixin, TestCase):
 "account_privacy":"private"
 }""",
         )
+
+    def get_expected_to_str(self):
+        return "krzysztof"

--- a/allauth/socialaccount/providers/edx/tests.py
+++ b/allauth/socialaccount/providers/edx/tests.py
@@ -46,4 +46,4 @@ class EdxTests(OAuth2TestsMixin, TestCase):
         )
 
     def get_expected_to_str(self):
-        return "krzysztof"
+        return "krzysztof.hoffmann@opi.org.pl"

--- a/allauth/socialaccount/providers/eventbrite/provider.py
+++ b/allauth/socialaccount/providers/eventbrite/provider.py
@@ -15,6 +15,12 @@ class EventbriteAccount(ProviderAccount):
         """Return avatar url."""
         return self.account.extra_data["image_id"]
 
+    def to_str(self):
+        for email in self.account.extra_data.get("emails", []):
+            if email.get("verified") and email.get("email"):
+                return email["email"]
+        return super().to_str()
+
 
 class EventbriteProvider(OAuth2Provider):
     """OAuth2Provider subclass for Eventbrite."""

--- a/allauth/socialaccount/providers/eventbrite/tests.py
+++ b/allauth/socialaccount/providers/eventbrite/tests.py
@@ -27,3 +27,6 @@ class EventbriteTests(OAuth2TestsMixin, TestCase):
             "image_id": "99999999"
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "test@example.com"

--- a/allauth/socialaccount/providers/eveonline/tests.py
+++ b/allauth/socialaccount/providers/eveonline/tests.py
@@ -20,3 +20,6 @@ class EveOnlineTests(OAuth2TestsMixin, TestCase):
             "CharacterOwnerHash": "XM4D...FoY="
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "CCP illurkall"

--- a/allauth/socialaccount/providers/evernote/provider.py
+++ b/allauth/socialaccount/providers/evernote/provider.py
@@ -10,6 +10,9 @@ class EvernoteAccount(ProviderAccount):
     def get_avatar_url(self):
         return None
 
+    def to_str(self):
+        return self.account.extra_data.get("edam_userId") or super().to_str()
+
 
 class EvernoteProvider(OAuthProvider):
     id = "evernote"

--- a/allauth/socialaccount/providers/evernote/tests.py
+++ b/allauth/socialaccount/providers/evernote/tests.py
@@ -10,6 +10,9 @@ class EvernoteTests(OAuthTestsMixin, TestCase):
     def get_mocked_response(self):
         return []
 
+    def get_expected_to_str(self):
+        return "591969"
+
     def get_access_token_response(self):
         return MockedResponse(
             200,

--- a/allauth/socialaccount/providers/exist/provider.py
+++ b/allauth/socialaccount/providers/exist/provider.py
@@ -11,8 +11,8 @@ class ExistAccount(ProviderAccount):
         return self.account.extra_data.get("avatar")
 
     def to_str(self):
-        name = super().to_str()
-        return self.account.extra_data.get("name", name)
+        dflt = super().to_str()
+        return self.account.extra_data.get("username", dflt)
 
 
 class ExistProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/exist/provider.py
+++ b/allauth/socialaccount/providers/exist/provider.py
@@ -10,10 +10,6 @@ class ExistAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar")
 
-    def to_str(self):
-        dflt = super().to_str()
-        return self.account.extra_data.get("username", dflt)
-
 
 class ExistProvider(OAuth2Provider):
     id = "exist"

--- a/allauth/socialaccount/providers/exist/tests.py
+++ b/allauth/socialaccount/providers/exist/tests.py
@@ -31,3 +31,6 @@ class ExistTests(OAuth2TestsMixin, TestCase):
             }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "josh"

--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -52,7 +52,7 @@ class FacebookAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(FacebookAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class FacebookProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/facebook/provider.py
+++ b/allauth/socialaccount/providers/facebook/provider.py
@@ -50,10 +50,6 @@ class FacebookAccount(ProviderAccount):
             % uid
         )  # noqa
 
-    def to_str(self):
-        dflt = super(FacebookAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class FacebookProvider(OAuth2Provider):
     id = PROVIDER_ID

--- a/allauth/socialaccount/providers/facebook/tests.py
+++ b/allauth/socialaccount/providers/facebook/tests.py
@@ -53,6 +53,9 @@ class FacebookTests(OAuth2TestsMixin, TestCase):
             data = self.facebook_data
         return MockedResponse(200, data)
 
+    def get_expected_to_str(self):
+        return "raymond.penners@example.com"
+
     def test_username_conflict(self):
         User = get_user_model()
         User.objects.create(username="raymond.penners")

--- a/allauth/socialaccount/providers/feedly/provider.py
+++ b/allauth/socialaccount/providers/feedly/provider.py
@@ -8,13 +8,8 @@ class FeedlyAccount(ProviderAccount):
         return self.account.extra_data.get("picture")
 
     def to_str(self):
-        name = "{0} {1}".format(
-            self.account.extra_data.get("givenName", ""),
-            self.account.extra_data.get("familyName", ""),
-        )
-        if name.strip() != "":
-            return name
-        return super(FeedlyAccount, self).to_str()
+        dflt = super().to_str()
+        return self.account.extra_data.get("email", dflt)
 
 
 class FeedlyProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/feedly/provider.py
+++ b/allauth/socialaccount/providers/feedly/provider.py
@@ -7,10 +7,6 @@ class FeedlyAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 
-    def to_str(self):
-        dflt = super().to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class FeedlyProvider(OAuth2Provider):
     id = "feedly"

--- a/allauth/socialaccount/providers/feedly/tests.py
+++ b/allauth/socialaccount/providers/feedly/tests.py
@@ -26,3 +26,6 @@ class FeedlyTests(OAuth2TestsMixin, TestCase):
   "wave": "2013.7"
 }""",
         )
+
+    def get_expected_to_str(self):
+        return "jim.smith@example.com"

--- a/allauth/socialaccount/providers/feishu/provider.py
+++ b/allauth/socialaccount/providers/feishu/provider.py
@@ -7,9 +7,6 @@ class FeishuAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar_big")
 
-    def to_str(self):
-        return self.account.extra_data.get("name", super(FeishuAccount, self).to_str())
-
 
 class FeishuProvider(OAuth2Provider):
     id = "feishu"

--- a/allauth/socialaccount/providers/feishu/tests.py
+++ b/allauth/socialaccount/providers/feishu/tests.py
@@ -40,5 +40,8 @@ class FeishuTests(OAuth2TestsMixin, TestCase):
             ),
         ]
 
+    def get_expected_to_str(self):
+        return "zhangsan"
+
     def get_login_response_json(self, with_refresh_token=True):
         return """{"app_access_token":"testac"}"""

--- a/allauth/socialaccount/providers/figma/provider.py
+++ b/allauth/socialaccount/providers/figma/provider.py
@@ -6,9 +6,6 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class FigmaAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("email", "")
-
     def get_avatar_url(self):
         return self.account.extra_data.get("img_url", "")
 

--- a/allauth/socialaccount/providers/figma/provider.py
+++ b/allauth/socialaccount/providers/figma/provider.py
@@ -7,7 +7,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class FigmaAccount(ProviderAccount):
     def to_str(self):
-        return self.account.extra_data.get("handle", "")
+        return self.account.extra_data.get("email", "")
 
     def get_avatar_url(self):
         return self.account.extra_data.get("img_url", "")

--- a/allauth/socialaccount/providers/figma/tests.py
+++ b/allauth/socialaccount/providers/figma/tests.py
@@ -19,3 +19,6 @@ class FigmaTests(OAuth2TestsMixin, TestCase):
                 }
             """,
         )
+
+    def get_expected_to_str(self):
+        return "johndoe@example.com"

--- a/allauth/socialaccount/providers/fivehundredpx/provider.py
+++ b/allauth/socialaccount/providers/fivehundredpx/provider.py
@@ -14,8 +14,7 @@ class FiveHundredPxAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(FiveHundredPxAccount, self).to_str()
-        name = self.account.extra_data.get("fullname", dflt)
-        return name
+        return self.account.extra_data.get("username", dflt)
 
 
 class FiveHundredPxProvider(OAuthProvider):

--- a/allauth/socialaccount/providers/fivehundredpx/provider.py
+++ b/allauth/socialaccount/providers/fivehundredpx/provider.py
@@ -12,10 +12,6 @@ class FiveHundredPxAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("userpic_url")
 
-    def to_str(self):
-        dflt = super(FiveHundredPxAccount, self).to_str()
-        return self.account.extra_data.get("username", dflt)
-
 
 class FiveHundredPxProvider(OAuthProvider):
     id = "500px"

--- a/allauth/socialaccount/providers/fivehundredpx/tests.py
+++ b/allauth/socialaccount/providers/fivehundredpx/tests.py
@@ -78,3 +78,6 @@ class FiveHundredPxTests(OAuthTestsMixin, TestCase):
         }""",
             )
         ]  # noqa
+
+    def get_expected_to_str(self):
+        return "testuser"

--- a/allauth/socialaccount/providers/fivehundredpx/tests.py
+++ b/allauth/socialaccount/providers/fivehundredpx/tests.py
@@ -80,4 +80,4 @@ class FiveHundredPxTests(OAuthTestsMixin, TestCase):
         ]  # noqa
 
     def get_expected_to_str(self):
-        return "testuser"
+        return "test@example.com"

--- a/allauth/socialaccount/providers/flickr/provider.py
+++ b/allauth/socialaccount/providers/flickr/provider.py
@@ -13,15 +13,6 @@ class FlickrAccount(ProviderAccount):
     def to_str(self):
         dflt = super(FlickrAccount, self).to_str()
 
-        # Try to use name if it exists. If there is no name, the Flickr API
-        # returns an empty string.
-        name = (
-            self.account.extra_data.get("person").get("realname").get("_content", None)
-        )
-        if name:
-            return name
-
-        # Default to username if name does not exist.
         return (
             self.account.extra_data.get("person").get("username").get("_content", dflt)
         )

--- a/allauth/socialaccount/providers/flickr/tests.py
+++ b/allauth/socialaccount/providers/flickr/tests.py
@@ -43,6 +43,9 @@ class FlickrTests(OAuthTestsMixin, TestCase):
             ),
         ]  # noqa
 
+    def get_expected_to_str(self):
+        return "pennersr"
+
     def test_login(self):
         account = super(FlickrTests, self).test_login()
         f_account = account.get_provider_account()
@@ -52,7 +55,7 @@ class FlickrTests(OAuthTestsMixin, TestCase):
             f_account.get_profile_url(),
             "http://www.flickr.com/people/12345678@N00/",
         )
-        self.assertEqual(f_account.to_str(), "raymond penners")
+        self.assertEqual(f_account.to_str(), "pennersr")
 
 
 class FlickrWithoutRealNameTests(OAuthTestsMixin, TestCase):
@@ -95,6 +98,9 @@ class FlickrWithoutRealNameTests(OAuthTestsMixin, TestCase):
 """,
             ),
         ]  # noqa
+
+    def get_expected_to_str(self):
+        return "pennersr"
 
     def test_login(self):
         account = super(FlickrWithoutRealNameTests, self).test_login()

--- a/allauth/socialaccount/providers/foursquare/provider.py
+++ b/allauth/socialaccount/providers/foursquare/provider.py
@@ -14,7 +14,7 @@ class FoursquareAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(FoursquareAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("contact", {}).get("email", dflt)
 
 
 class FoursquareProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/foursquare/tests.py
+++ b/allauth/socialaccount/providers/foursquare/tests.py
@@ -66,3 +66,6 @@ class FoursquareTests(OAuth2TestsMixin, TestCase):
                                  }
 """,
         )
+
+    def get_expected_to_str(self):
+        return "romdimtsouroplis@example.com"

--- a/allauth/socialaccount/providers/frontier/provider.py
+++ b/allauth/socialaccount/providers/frontier/provider.py
@@ -23,11 +23,7 @@ class FrontierAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(FrontierAccount, self).to_str()
-        full_name = "%s %s" % (
-            self.account.extra_data.get("firstname", dflt),
-            self.account.extra_data.get("lastname", dflt),
-        )
-        return full_name
+        return self.account.extra_data.get("email", dflt)
 
 
 class FrontierProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/frontier/provider.py
+++ b/allauth/socialaccount/providers/frontier/provider.py
@@ -21,10 +21,6 @@ class FrontierAccount(ProviderAccount):
             urlencode({"d": "mp"}),
         )
 
-    def to_str(self):
-        dflt = super(FrontierAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class FrontierProvider(OAuth2Provider):
     id = "frontier"

--- a/allauth/socialaccount/providers/frontier/tests.py
+++ b/allauth/socialaccount/providers/frontier/tests.py
@@ -21,3 +21,6 @@ class FrontierTests(OAuth2TestsMixin, TestCase):
             "platform": "frontier"
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "johndoe@example.com"

--- a/allauth/socialaccount/providers/fxa/provider.py
+++ b/allauth/socialaccount/providers/fxa/provider.py
@@ -7,8 +7,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class FirefoxAccountsAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("email") or super().to_str()
+    pass
 
 
 class FirefoxAccountsProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/fxa/provider.py
+++ b/allauth/socialaccount/providers/fxa/provider.py
@@ -8,7 +8,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 class FirefoxAccountsAccount(ProviderAccount):
     def to_str(self):
-        return self.account.uid
+        return self.account.extra_data.get("email") or super().to_str()
 
 
 class FirefoxAccountsProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/fxa/tests.py
+++ b/allauth/socialaccount/providers/fxa/tests.py
@@ -16,3 +16,6 @@ class FirefoxAccountsTests(OAuth2TestsMixin, TestCase):
             "email":"user@example.com"
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "user@example.com"

--- a/allauth/socialaccount/providers/gitea/tests.py
+++ b/allauth/socialaccount/providers/gitea/tests.py
@@ -36,6 +36,9 @@ class GiteaTests(OAuth2TestsMixin, TestCase):
             }""",
         )
 
+    def get_expected_to_str(self):
+        return "giteauser"
+
     def test_account_name_null(self):
         """String conversion when Gitea responds with empty username"""
         data = """{

--- a/allauth/socialaccount/providers/github/provider.py
+++ b/allauth/socialaccount/providers/github/provider.py
@@ -17,8 +17,8 @@ class GitHubAccount(ProviderAccount):
         return next(
             value
             for value in (
-                self.account.extra_data.get("name", None),
                 self.account.extra_data.get("login", None),
+                self.account.extra_data.get("name", None),
                 dflt,
             )
             if value is not None

--- a/allauth/socialaccount/providers/github/tests.py
+++ b/allauth/socialaccount/providers/github/tests.py
@@ -58,6 +58,9 @@ class GitHubTests(OAuth2TestsMixin, TestCase):
             ),
         ]
 
+    def get_expected_to_str(self):
+        return "pennersr"
+
     def test_account_name_null(self):
         """String conversion when GitHub responds with empty name"""
         mocks = [

--- a/allauth/socialaccount/providers/gitlab/provider.py
+++ b/allauth/socialaccount/providers/gitlab/provider.py
@@ -12,7 +12,7 @@ class GitLabAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(GitLabAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("username", dflt)
 
 
 class GitLabProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/gitlab/tests.py
+++ b/allauth/socialaccount/providers/gitlab/tests.py
@@ -50,6 +50,9 @@ class GitLabTests(OAuth2TestsMixin, TestCase):
         """,
         )
 
+    def get_expected_to_str(self):
+        return "mr.bob"
+
     def test_valid_response(self):
         data = {"id": 12345}
         response = MockedResponse(200, json.dumps(data))

--- a/allauth/socialaccount/providers/globus/provider.py
+++ b/allauth/socialaccount/providers/globus/provider.py
@@ -16,7 +16,7 @@ class GlobusAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(GlobusAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class GlobusProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/globus/provider.py
+++ b/allauth/socialaccount/providers/globus/provider.py
@@ -14,10 +14,6 @@ class GlobusAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar_url", "dflt")
 
-    def to_str(self):
-        dflt = super(GlobusAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class GlobusProvider(OAuth2Provider):
     id = "globus"

--- a/allauth/socialaccount/providers/globus/tests.py
+++ b/allauth/socialaccount/providers/globus/tests.py
@@ -25,3 +25,6 @@ class GlobusTests(OAuth2TestsMixin, TestCase):
         }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "morty@ugz.edu"

--- a/allauth/socialaccount/providers/google/provider.py
+++ b/allauth/socialaccount/providers/google/provider.py
@@ -52,7 +52,7 @@ class GoogleAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(GoogleAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class GoogleProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/google/provider.py
+++ b/allauth/socialaccount/providers/google/provider.py
@@ -50,10 +50,6 @@ class GoogleAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 
-    def to_str(self):
-        dflt = super(GoogleAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class GoogleProvider(OAuth2Provider):
     id = "google"

--- a/allauth/socialaccount/providers/google/tests.py
+++ b/allauth/socialaccount/providers/google/tests.py
@@ -53,6 +53,9 @@ class GoogleTests(OAuth2TestsMixin, TestCase):
         self.email = "raymond.penners@example.com"
         self.identity_overwrites = {}
 
+    def get_expected_to_str(self):
+        return "raymond.penners@example.com"
+
     def get_google_id_token_payload(self):
         now = datetime.utcnow()
         client_id = "app123id"  # Matches `setup_app`

--- a/allauth/socialaccount/providers/gumroad/provider.py
+++ b/allauth/socialaccount/providers/gumroad/provider.py
@@ -7,10 +7,6 @@ class GumroadAccount(ProviderAccount):
     def get_profile_url(self):
         return self.account.extra_data.get("url")
 
-    def to_str(self):
-        dflt = super(GumroadAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class GumroadProvider(OAuth2Provider):
     id = "gumroad"

--- a/allauth/socialaccount/providers/gumroad/provider.py
+++ b/allauth/socialaccount/providers/gumroad/provider.py
@@ -9,7 +9,7 @@ class GumroadAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(GumroadAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class GumroadProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/gumroad/tests.py
+++ b/allauth/socialaccount/providers/gumroad/tests.py
@@ -21,3 +21,6 @@ class GumroadTests(OAuth2TestsMixin, TestCase):
                 }
             }""",
         )
+
+    def get_expected_to_str(self):
+        return "johnsmith@gumroad.com"

--- a/allauth/socialaccount/providers/hubic/provider.py
+++ b/allauth/socialaccount/providers/hubic/provider.py
@@ -4,7 +4,8 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class HubicAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("email") or super().to_str()
 
 
 class HubicProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/hubic/provider.py
+++ b/allauth/socialaccount/providers/hubic/provider.py
@@ -4,8 +4,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class HubicAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("email") or super().to_str()
+    pass
 
 
 class HubicProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/hubic/tests.py
+++ b/allauth/socialaccount/providers/hubic/tests.py
@@ -24,6 +24,9 @@ class HubicTests(OAuth2TestsMixin, TestCase):
 """,
         )
 
+    def get_expected_to_str(self):
+        return "user@example.com"
+
     def get_login_response_json(self, with_refresh_token=True):
         return '{\
     "access_token": "testac",\

--- a/allauth/socialaccount/providers/hubspot/provider.py
+++ b/allauth/socialaccount/providers/hubspot/provider.py
@@ -5,7 +5,8 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class HubspotAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("user") or super().to_str()
 
 
 class HubspotProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/hubspot/tests.py
+++ b/allauth/socialaccount/providers/hubspot/tests.py
@@ -25,3 +25,6 @@ class HubspotTests(OAuth2TestsMixin, TestCase):
                     "token_type": "access"
                 }""",
         )
+
+    def get_expected_to_str(self):
+        return "m@acme.com"

--- a/allauth/socialaccount/providers/instagram/provider.py
+++ b/allauth/socialaccount/providers/instagram/provider.py
@@ -11,10 +11,6 @@ class InstagramAccount(ProviderAccount):
     def get_profile_url(self):
         return self.PROFILE_URL + self.account.extra_data.get("username")
 
-    def to_str(self):
-        dflt = super(InstagramAccount, self).to_str()
-        return self.account.extra_data.get("username", dflt)
-
 
 class InstagramProvider(OAuth2Provider):
     id = "instagram"

--- a/allauth/socialaccount/providers/instagram/tests.py
+++ b/allauth/socialaccount/providers/instagram/tests.py
@@ -26,3 +26,6 @@ class InstagramTests(OAuth2TestsMixin, TestCase):
             "id": "11428116"
         }""",
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "georgewhewell"

--- a/allauth/socialaccount/providers/jupyterhub/provider.py
+++ b/allauth/socialaccount/providers/jupyterhub/provider.py
@@ -6,9 +6,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class JupyterHubAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super(JupyterHubAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+    pass
 
 
 class JupyterHubProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/jupyterhub/tests.py
+++ b/allauth/socialaccount/providers/jupyterhub/tests.py
@@ -23,3 +23,6 @@ class JupyterHubTests(OAuth2TestsMixin, TestCase):
         "servers": null}
         """,
         )
+
+    def get_expected_to_str(self):
+        return "abc"

--- a/allauth/socialaccount/providers/kakao/provider.py
+++ b/allauth/socialaccount/providers/kakao/provider.py
@@ -20,7 +20,11 @@ class KakaoAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(KakaoAccount, self).to_str()
-        return self.profile.get("nickname", self.properties.get("nickname", dflt))
+        account_data = self.account.extra_data.get("kakao_account", {})
+        if account_data.get("email") and account_data.get("is_email_verified"):
+            return account_data["email"]
+        nickname = self.profile.get("nickname", self.properties.get("nickname"))
+        return nickname or dflt
 
 
 class KakaoProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/kakao/tests.py
+++ b/allauth/socialaccount/providers/kakao/tests.py
@@ -51,6 +51,9 @@ class KakaoTests(OAuth2TestsMixin, TestCase):
         }
     """
 
+    def get_expected_to_str(self):
+        return "sample@sample.com"
+
     def get_mocked_response(self, data=None):
         if data is None:
             data = self.kakao_data

--- a/allauth/socialaccount/providers/lemonldap/provider.py
+++ b/allauth/socialaccount/providers/lemonldap/provider.py
@@ -9,10 +9,6 @@ class LemonLDAPAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 
-    def to_str(self):
-        dflt = super(LemonLDAPAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class LemonLDAPProvider(OAuth2Provider):
     id = "lemonldap"

--- a/allauth/socialaccount/providers/lemonldap/provider.py
+++ b/allauth/socialaccount/providers/lemonldap/provider.py
@@ -11,7 +11,7 @@ class LemonLDAPAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(LemonLDAPAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class LemonLDAPProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/lemonldap/tests.py
+++ b/allauth/socialaccount/providers/lemonldap/tests.py
@@ -20,3 +20,6 @@ class LemonLDAPTests(OAuth2TestsMixin, TestCase):
             }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "dwho@example.com"

--- a/allauth/socialaccount/providers/lichess/provider.py
+++ b/allauth/socialaccount/providers/lichess/provider.py
@@ -12,10 +12,6 @@ class LichessAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar")
 
-    def to_str(self):
-        dflt = super().to_str()
-        return self.account.extra_data.get("username", dflt)
-
 
 class LichessProvider(OAuth2Provider):
     id = "lichess"

--- a/allauth/socialaccount/providers/lichess/tests.py
+++ b/allauth/socialaccount/providers/lichess/tests.py
@@ -83,3 +83,6 @@ class LichessTests(OAuth2TestsMixin, TestCase):
             ),
             MockedResponse(200, """{"email":"george@example.com"}"""),
         ]
+
+    def get_expected_to_str(self):
+        return "george"

--- a/allauth/socialaccount/providers/lichess/tests.py
+++ b/allauth/socialaccount/providers/lichess/tests.py
@@ -85,4 +85,4 @@ class LichessTests(OAuth2TestsMixin, TestCase):
         ]
 
     def get_expected_to_str(self):
-        return "george"
+        return "george@example.com"

--- a/allauth/socialaccount/providers/line/provider.py
+++ b/allauth/socialaccount/providers/line/provider.py
@@ -10,7 +10,9 @@ class LineAccount(ProviderAccount):
         )
 
     def to_str(self):
-        return self.account.extra_data.get("displayName", self.account.uid)
+        email = self.account.extra_data.get("email")
+        display_name = self.account.extra_data.get("displayName")
+        return email or display_name or self.account.uid
 
 
 class LineProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/line/tests.py
+++ b/allauth/socialaccount/providers/line/tests.py
@@ -18,3 +18,6 @@ class LineTests(OAuth2TestsMixin, TestCase):
 "http://dl.profile.line-cdn.net/0m055ab14d725138288331268c45ac5286a35482fb794a"
 }""",
         )
+
+    def get_expected_to_str(self):
+        return "\uc774\uc0c1\ud601"

--- a/allauth/socialaccount/providers/linkedin_oauth2/provider.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/provider.py
@@ -46,6 +46,8 @@ def _extract_email(data):
 class LinkedInOAuth2Account(ProviderAccount):
     def to_str(self):
         ret = super(LinkedInOAuth2Account, self).to_str()
+        if self.account.extra_data.get("emailAddress"):
+            return self.account.extra_data["emailAddress"]
         first_name = _extract_name_field(self.account.extra_data, "firstName")
         last_name = _extract_name_field(self.account.extra_data, "lastName")
         if first_name or last_name:

--- a/allauth/socialaccount/providers/linkedin_oauth2/tests.py
+++ b/allauth/socialaccount/providers/linkedin_oauth2/tests.py
@@ -52,6 +52,9 @@ class LinkedInOAuth2Tests(OAuth2TestsMixin, TestCase):
             ),
         ]
 
+    def get_expected_to_str(self):
+        return "Raymond Penners"
+
     def test_data_to_str(self):
         data = {
             "emailAddress": "john@doe.org",
@@ -66,7 +69,7 @@ class LinkedInOAuth2Tests(OAuth2TestsMixin, TestCase):
             "publicProfileUrl": "https://www.linkedin.com/in/johndoe",
         }
         acc = SocialAccount(extra_data=data, provider="linkedin_oauth2")
-        self.assertEqual(acc.get_provider_account().to_str(), "John Doe")
+        self.assertEqual(acc.get_provider_account().to_str(), "john@doe.org")
 
     def test_get_avatar_url_no_picture_setting(self):
         extra_data = """

--- a/allauth/socialaccount/providers/mailchimp/provider.py
+++ b/allauth/socialaccount/providers/mailchimp/provider.py
@@ -18,6 +18,11 @@ class MailChimpAccount(ProviderAccount):
         """Return avatar url."""
         return self.account.extra_data["login"]["avatar"]
 
+    def to_str(self):
+        dflt = super().to_str()
+        login_data = self.account.extra_data.get("login", {})
+        return login_data.get("login_email") or login_data.get("email") or dflt
+
 
 class MailChimpProvider(OAuth2Provider):
     """OAuth2Provider subclass for MailChimp v3."""

--- a/allauth/socialaccount/providers/mailchimp/tests.py
+++ b/allauth/socialaccount/providers/mailchimp/tests.py
@@ -31,3 +31,6 @@ class MailChimpTests(OAuth2TestsMixin, TestCase):
             "api_endpoint": "https://usX.api.mailchimp.com"
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "test@example.com"

--- a/allauth/socialaccount/providers/mailru/provider.py
+++ b/allauth/socialaccount/providers/mailru/provider.py
@@ -21,7 +21,7 @@ class MailRuAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(MailRuAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class MailRuProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/mailru/provider.py
+++ b/allauth/socialaccount/providers/mailru/provider.py
@@ -19,10 +19,6 @@ class MailRuAccount(ProviderAccount):
         else:
             return ret
 
-    def to_str(self):
-        dflt = super(MailRuAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class MailRuProvider(OAuth2Provider):
     id = "mailru"

--- a/allauth/socialaccount/providers/mailru/tests.py
+++ b/allauth/socialaccount/providers/mailru/tests.py
@@ -19,3 +19,6 @@ class MailRuTests(OAuth2TestsMixin, TestCase):
         # to get the test suite going but did not verify to check the
         # exact response being returned.
         return '{"access_token": "testac", "uid": "weibo", "refresh_token": "testrf", "x_mailru_vid": "1"}'  # noqa
+
+    def get_expected_to_str(self):
+        return "emaslov@mail.ru"

--- a/allauth/socialaccount/providers/mediawiki/provider.py
+++ b/allauth/socialaccount/providers/mediawiki/provider.py
@@ -23,10 +23,6 @@ class MediaWikiAccount(ProviderAccount):
             return None
         return userpage.format(username=username.replace(" ", "_"))
 
-    def to_str(self):
-        dflt = super(MediaWikiAccount, self).to_str()
-        return self.account.extra_data.get("username", dflt)
-
 
 class MediaWikiProvider(OAuth2Provider):
     id = "mediawiki"

--- a/allauth/socialaccount/providers/mediawiki/provider.py
+++ b/allauth/socialaccount/providers/mediawiki/provider.py
@@ -45,6 +45,8 @@ class MediaWikiProvider(OAuth2Provider):
 
     def extract_extra_data(self, data):
         return dict(
+            email=self._get_email(data),
+            realname=data.get("realname"),
             username=data.get("username"),
         )
 

--- a/allauth/socialaccount/providers/mediawiki/tests.py
+++ b/allauth/socialaccount/providers/mediawiki/tests.py
@@ -29,3 +29,6 @@ class MediaWikiTests(OAuth2TestsMixin, TestCase):
                 }
             """,
         )
+
+    def get_expected_to_str(self):
+        return "John Doe"

--- a/allauth/socialaccount/providers/mediawiki/tests.py
+++ b/allauth/socialaccount/providers/mediawiki/tests.py
@@ -31,4 +31,4 @@ class MediaWikiTests(OAuth2TestsMixin, TestCase):
         )
 
     def get_expected_to_str(self):
-        return "John Doe"
+        return "johndoe@example.com"

--- a/allauth/socialaccount/providers/meetup/provider.py
+++ b/allauth/socialaccount/providers/meetup/provider.py
@@ -4,7 +4,12 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class MeetupAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        email = self.account.extra_data.get("email")
+        name = self.account.extra_data.get("name") or self.account.extra_data.get(
+            "photo", {}
+        ).get("name")
+        return email or name or super().to_str()
 
 
 class MeetupProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/meetup/tests.py
+++ b/allauth/socialaccount/providers/meetup/tests.py
@@ -9,6 +9,7 @@ class MeetupTests(OAuth2TestsMixin, TestCase):
 
     def get_mocked_response(self):
         return MockedResponse(
+            # TODO: most keys are nested under "photo", verify that this is correct
             200,
             """
         {"id": 1, "lang": "en_US", "city": "Bhubaneswar",
@@ -34,3 +35,6 @@ class MeetupTests(OAuth2TestsMixin, TestCase):
         "hometown": "Kolkata", "lat": 20.270000457763672,
         "visited": 1488829924000, "self": {"common": {}}}}""",
         )
+
+    def get_expected_to_str(self):
+        return "Abhishek Jaiswal"

--- a/allauth/socialaccount/providers/microsoft/provider.py
+++ b/allauth/socialaccount/providers/microsoft/provider.py
@@ -11,7 +11,7 @@ class MicrosoftGraphAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(MicrosoftGraphAccount, self).to_str()
-        return self.account.extra_data.get("displayName", dflt)
+        return self.account.extra_data.get("mail", dflt)
 
 
 class MicrosoftGraphProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/microsoft/tests.py
+++ b/allauth/socialaccount/providers/microsoft/tests.py
@@ -31,6 +31,9 @@ class MicrosoftGraphTests(OAuth2TestsMixin, TestCase):
         """  # noqa
         return MockedResponse(200, response_data)
 
+    def get_expected_to_str(self):
+        return "annew@CIE493742.onmicrosoft.com"
+
     def test_invalid_data(self):
         response = MockedResponse(200, json.dumps({}))
         with self.assertRaises(OAuth2Error):

--- a/allauth/socialaccount/providers/miro/provider.py
+++ b/allauth/socialaccount/providers/miro/provider.py
@@ -5,7 +5,8 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class MiroAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("email") or super().to_str()
 
 
 class MiroProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/miro/provider.py
+++ b/allauth/socialaccount/providers/miro/provider.py
@@ -5,8 +5,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class MiroAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("email") or super().to_str()
+    pass
 
 
 class MiroProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/miro/tests.py
+++ b/allauth/socialaccount/providers/miro/tests.py
@@ -24,3 +24,6 @@ class MiroTests(OAuth2TestsMixin, TestCase):
                 }
             }""",
         )
+
+    def get_expected_to_str(self):
+        return "oborin.p@gmail.com"

--- a/allauth/socialaccount/providers/naver/provider.py
+++ b/allauth/socialaccount/providers/naver/provider.py
@@ -8,9 +8,6 @@ class NaverAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("profile_image")
 
-    def to_str(self):
-        return self.account.extra_data.get("email", self.account.uid)
-
 
 class NaverProvider(OAuth2Provider):
     id = "naver"

--- a/allauth/socialaccount/providers/naver/provider.py
+++ b/allauth/socialaccount/providers/naver/provider.py
@@ -9,7 +9,7 @@ class NaverAccount(ProviderAccount):
         return self.account.extra_data.get("profile_image")
 
     def to_str(self):
-        return self.account.extra_data.get("nickname", self.account.uid)
+        return self.account.extra_data.get("email", self.account.uid)
 
 
 class NaverProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/naver/tests.py
+++ b/allauth/socialaccount/providers/naver/tests.py
@@ -30,3 +30,6 @@ class NaverTests(OAuth2TestsMixin, TestCase):
 }
 """,
         )
+
+    def get_expected_to_str(self):
+        return "shlee940322@example.com"

--- a/allauth/socialaccount/providers/netiq/provider.py
+++ b/allauth/socialaccount/providers/netiq/provider.py
@@ -4,9 +4,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class NetIQAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super(NetIQAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
+    pass
 
 
 class NetIQProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/netiq/provider.py
+++ b/allauth/socialaccount/providers/netiq/provider.py
@@ -6,7 +6,7 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 class NetIQAccount(ProviderAccount):
     def to_str(self):
         dflt = super(NetIQAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class NetIQProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/netiq/tests.py
+++ b/allauth/socialaccount/providers/netiq/tests.py
@@ -22,3 +22,6 @@ class NetIQTests(OAuth2TestsMixin, TestCase):
             }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "mocktest@your.netiq.server.example.com"

--- a/allauth/socialaccount/providers/nextcloud/provider.py
+++ b/allauth/socialaccount/providers/nextcloud/provider.py
@@ -6,7 +6,8 @@ from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
 
 
 class NextCloudAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("id") or super().to_str()
 
 
 class NextCloudProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/nextcloud/tests.py
+++ b/allauth/socialaccount/providers/nextcloud/tests.py
@@ -64,3 +64,6 @@ class NextCloudTests(OAuth2TestsMixin, TestCase):
 </ocs>
 """,
         )
+
+    def get_expected_to_str(self):
+        return "batman"

--- a/allauth/socialaccount/providers/notion/tests.py
+++ b/allauth/socialaccount/providers/notion/tests.py
@@ -19,6 +19,7 @@ class NotionTests(OAuth2TestsMixin, TestCase):
             """
             {
                 "workspace_id": "workspace-abc",
+                "workspace_name": "My Workspace",
                 "owner": {
                     "user": {
                         "id": "test123",
@@ -30,6 +31,9 @@ class NotionTests(OAuth2TestsMixin, TestCase):
             }
             """,
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "John Doe (My Workspace)"
 
     def get_login_response_json(self, with_refresh_token=False):
         """

--- a/allauth/socialaccount/providers/odnoklassniki/provider.py
+++ b/allauth/socialaccount/providers/odnoklassniki/provider.py
@@ -25,7 +25,9 @@ class OdnoklassnikiAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(OdnoklassnikiAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        email = self.account.extra_data.get("email")
+        name = self.account.extra_data.get("name")
+        return email or name or dflt
 
 
 class OdnoklassnikiProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/odnoklassniki/provider.py
+++ b/allauth/socialaccount/providers/odnoklassniki/provider.py
@@ -23,12 +23,6 @@ class OdnoklassnikiAccount(ProviderAccount):
         else:
             return ret
 
-    def to_str(self):
-        dflt = super(OdnoklassnikiAccount, self).to_str()
-        email = self.account.extra_data.get("email")
-        name = self.account.extra_data.get("name")
-        return email or name or dflt
-
 
 class OdnoklassnikiProvider(OAuth2Provider):
     id = "odnoklassniki"

--- a/allauth/socialaccount/providers/odnoklassniki/tests.py
+++ b/allauth/socialaccount/providers/odnoklassniki/tests.py
@@ -20,5 +20,8 @@ class OdnoklassnikiTests(OAuth2TestsMixin, TestCase):
 """,
         )
 
+    def get_expected_to_str(self):
+        return "Ivan Petrov"
+
     def get_login_response_json(self, with_refresh_token=True):
         return '{"access_token": "testac"}'  # noqa

--- a/allauth/socialaccount/providers/okta/provider.py
+++ b/allauth/socialaccount/providers/okta/provider.py
@@ -5,9 +5,7 @@ from allauth.socialaccount.providers.okta.views import OktaOAuth2Adapter
 
 
 class OktaAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super(OktaAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
+    pass
 
 
 class OktaProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/okta/provider.py
+++ b/allauth/socialaccount/providers/okta/provider.py
@@ -7,7 +7,7 @@ from allauth.socialaccount.providers.okta.views import OktaOAuth2Adapter
 class OktaAccount(ProviderAccount):
     def to_str(self):
         dflt = super(OktaAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class OktaProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/okta/tests.py
+++ b/allauth/socialaccount/providers/okta/tests.py
@@ -26,3 +26,6 @@ class OktaTests(OAuth2TestsMixin, TestCase):
             }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "jsmith@example.com"

--- a/allauth/socialaccount/providers/openid/tests.py
+++ b/allauth/socialaccount/providers/openid/tests.py
@@ -61,6 +61,11 @@ class OpenIDTests(TestCase):
                         fetch_redirect_response=False,
                     )
                     get_user_model().objects.get(first_name="raymond")
+                    social_account = SocialAccount.objects.get(
+                        uid=complete_response.identity_url
+                    )
+                    account = social_account.get_provider_account()
+                    self.assertEqual(account.to_str(), complete_response.identity_url)
 
     @override_settings(
         SOCIALACCOUNT_PROVIDERS={

--- a/allauth/socialaccount/providers/openid_connect/provider.py
+++ b/allauth/socialaccount/providers/openid_connect/provider.py
@@ -12,7 +12,9 @@ from allauth.socialaccount.providers.openid_connect.views import (
 class OpenIDConnectProviderAccount(ProviderAccount):
     def to_str(self):
         dflt = super(OpenIDConnectProviderAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        user_id = self.account.extra_data.get("user_id")
+        name = self.account.extra_data.get("name")
+        return user_id or name or dflt
 
 
 class OpenIDConnectProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/openstreetmap/provider.py
+++ b/allauth/socialaccount/providers/openstreetmap/provider.py
@@ -16,10 +16,11 @@ class OpenStreetMapAccount(ProviderAccount):
         return self.account.extra_data.get("avatar")
 
     def get_username(self):
+        # TODO: this actually returns the display name, not the unique username
         return self.account.extra_data["display_name"]
 
     def to_str(self):
-        return self.get_username()
+        return self.account.extra_data.get("display_name") or super().to_str()
 
 
 class OpenStreetMapProvider(OAuthProvider):

--- a/allauth/socialaccount/providers/openstreetmap/tests.py
+++ b/allauth/socialaccount/providers/openstreetmap/tests.py
@@ -30,6 +30,9 @@ class OpenStreetMapTests(OAuthTestsMixin, TestCase):
             )
         ]  # noqa
 
+    def get_expected_to_str(self):
+        return "Steve"
+
     def test_login(self):
         account = super(OpenStreetMapTests, self).test_login()
         osm_account = account.get_provider_account()
@@ -42,3 +45,4 @@ class OpenStreetMapTests(OAuthTestsMixin, TestCase):
             osm_account.get_profile_url(),
             "https://www.openstreetmap.org/user/Steve",
         )
+        self.assertEqual(osm_account.to_str(), "Steve")

--- a/allauth/socialaccount/providers/orcid/tests.py
+++ b/allauth/socialaccount/providers/orcid/tests.py
@@ -370,6 +370,9 @@ class OrcidTests(OAuth2TestsMixin, TestCase):
         """,
         )
 
+    def get_expected_to_str(self):
+        return "0000-0001-6796-198X"
+
     def get_login_response_json(self, with_refresh_token=True):
         # TODO: This is not an actual response. I added this in order
         # to get the test suite going but did not verify to check the

--- a/allauth/socialaccount/providers/patreon/provider.py
+++ b/allauth/socialaccount/providers/patreon/provider.py
@@ -13,6 +13,10 @@ class PatreonAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("attributes").get("thumb_url")
 
+    def to_str(self):
+        email = self.account.extra_data.get("attributes", {}).get("email")
+        return email or super().to_str()
+
 
 class PatreonProvider(OAuth2Provider):
     id = PROVIDER_ID

--- a/allauth/socialaccount/providers/patreon/tests.py
+++ b/allauth/socialaccount/providers/patreon/tests.py
@@ -57,3 +57,6 @@ class PatreonTests(OAuth2TestsMixin, TestCase):
         }
         }""",
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "john@example.com"

--- a/allauth/socialaccount/providers/paypal/provider.py
+++ b/allauth/socialaccount/providers/paypal/provider.py
@@ -7,9 +7,6 @@ class PaypalAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 
-    def to_str(self):
-        return self.account.extra_data.get("email", super(PaypalAccount, self).to_str())
-
 
 class PaypalProvider(OAuth2Provider):
     id = "paypal"

--- a/allauth/socialaccount/providers/paypal/provider.py
+++ b/allauth/socialaccount/providers/paypal/provider.py
@@ -8,7 +8,7 @@ class PaypalAccount(ProviderAccount):
         return self.account.extra_data.get("picture")
 
     def to_str(self):
-        return self.account.extra_data.get("name", super(PaypalAccount, self).to_str())
+        return self.account.extra_data.get("email", super(PaypalAccount, self).to_str())
 
 
 class PaypalProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/paypal/tests.py
+++ b/allauth/socialaccount/providers/paypal/tests.py
@@ -21,3 +21,6 @@ class PaypalTests(OAuth2TestsMixin, TestCase):
         }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "janedoe@example.com"

--- a/allauth/socialaccount/providers/pinterest/provider.py
+++ b/allauth/socialaccount/providers/pinterest/provider.py
@@ -26,7 +26,7 @@ class PinterestAccount(ProviderAccount):
         first_name = self.account.extra_data.get("first_name")
         last_name = self.account.extra_data.get("last_name")
         if first_name or last_name:
-            return " ".join(x for x in [first_name, last_name] if x)
+            return f"{first_name or ''} {last_name or ''}".strip()
         return super().to_str()
 
 

--- a/allauth/socialaccount/providers/pinterest/provider.py
+++ b/allauth/socialaccount/providers/pinterest/provider.py
@@ -20,8 +20,14 @@ class PinterestAccount(ProviderAccount):
         return self.account.extra_data.get("profile_image")
 
     def to_str(self):
-        dflt = super(PinterestAccount, self).to_str()
-        return self.account.extra_data.get("username", dflt)
+        username = self.account.extra_data.get("username")
+        if username:
+            return username
+        first_name = self.account.extra_data.get("first_name")
+        last_name = self.account.extra_data.get("last_name")
+        if first_name or last_name:
+            return " ".join(x for x in [first_name, last_name] if x)
+        return super().to_str()
 
 
 class PinterestProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/pinterest/tests.py
+++ b/allauth/socialaccount/providers/pinterest/tests.py
@@ -24,6 +24,9 @@ class PinterestTests(OAuth2TestsMixin, TestCase):
             """,
         )
 
+    def get_expected_to_str(self):
+        return "Jane Doe"
+
     @override_settings(
         SOCIALACCOUNT_AUTO_SIGNUP=False,
         SOCIALACCOUNT_PROVIDERS={

--- a/allauth/socialaccount/providers/pocket/provider.py
+++ b/allauth/socialaccount/providers/pocket/provider.py
@@ -7,7 +7,7 @@ from allauth.socialaccount.providers.pocket.views import PocketOAuthAdapter
 class PocketAccount(ProviderAccount):
     def to_str(self):
         dflt = super(PocketAccount, self).to_str()
-        return self.account.extra_data.get("Display_Name", dflt)
+        return self.account.extra_data.get("username", dflt)
 
 
 class PocketProvider(OAuthProvider):

--- a/allauth/socialaccount/providers/pocket/provider.py
+++ b/allauth/socialaccount/providers/pocket/provider.py
@@ -5,9 +5,7 @@ from allauth.socialaccount.providers.pocket.views import PocketOAuthAdapter
 
 
 class PocketAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super(PocketAccount, self).to_str()
-        return self.account.extra_data.get("username", dflt)
+    pass
 
 
 class PocketProvider(OAuthProvider):

--- a/allauth/socialaccount/providers/pocket/tests.py
+++ b/allauth/socialaccount/providers/pocket/tests.py
@@ -14,6 +14,9 @@ class PocketOAuthTests(OAuthTestsMixin, TestCase):
     def get_mocked_response(self):
         return []
 
+    def get_expected_to_str(self):
+        return "name@example.com"
+
     def get_access_token_response(self):
         return MockedResponse(
             200,

--- a/allauth/socialaccount/providers/questrade/tests.py
+++ b/allauth/socialaccount/providers/questrade/tests.py
@@ -12,3 +12,6 @@ class QuestradeTests(OAuth2TestsMixin, TestCase):
             200,
             """{"userId":400,"accounts":[]}""",
         )
+
+    def get_expected_to_str(self):
+        return "Questrade"

--- a/allauth/socialaccount/providers/quickbooks/provider.py
+++ b/allauth/socialaccount/providers/quickbooks/provider.py
@@ -11,17 +11,14 @@ from allauth.socialaccount.providers.quickbooks.views import (
 
 class QuickBooksAccount(ProviderAccount):
     def to_str(self):
-        dflt = super(QuickBooksAccount, self).to_str()
         email = self.account.extra_data.get("email")
-        email_verified = self.account.extra_data.get("emailVerified")
-        if email and email_verified:
+        if email:
             return email
-        name = self.account.extra_data.get("name", dflt)
-        first_name = self.account.extra_data.get("givenName", None)
-        last_name = self.account.extra_data.get("familyName", None)
-        if first_name and last_name:
-            name = first_name + " " + last_name
-        return name
+        first_name = self.account.extra_data.get("givenName")
+        last_name = self.account.extra_data.get("familyName")
+        if first_name or last_name:
+            return f"{first_name} {last_name}".strip()
+        return super().to_str()
 
 
 class QuickBooksOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/quickbooks/provider.py
+++ b/allauth/socialaccount/providers/quickbooks/provider.py
@@ -12,6 +12,10 @@ from allauth.socialaccount.providers.quickbooks.views import (
 class QuickBooksAccount(ProviderAccount):
     def to_str(self):
         dflt = super(QuickBooksAccount, self).to_str()
+        email = self.account.extra_data.get("email")
+        email_verified = self.account.extra_data.get("emailVerified")
+        if email and email_verified:
+            return email
         name = self.account.extra_data.get("name", dflt)
         first_name = self.account.extra_data.get("givenName", None)
         last_name = self.account.extra_data.get("familyName", None)

--- a/allauth/socialaccount/providers/quickbooks/tests.py
+++ b/allauth/socialaccount/providers/quickbooks/tests.py
@@ -20,3 +20,6 @@ class QuickBooksOAuth2Tests(OAuth2TestsMixin, TestCase):
         "email": "darren@blocklight.io"}
 """,
         )
+
+    def get_expected_to_str(self):
+        return "darren@blocklight.io"

--- a/allauth/socialaccount/providers/reddit/provider.py
+++ b/allauth/socialaccount/providers/reddit/provider.py
@@ -4,10 +4,7 @@ from allauth.socialaccount.providers.reddit.views import RedditAdapter
 
 
 class RedditAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super(RedditAccount, self).to_str()
-        name = self.account.extra_data.get("name", dflt)
-        return name
+    pass
 
 
 class RedditProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/reddit/tests.py
+++ b/allauth/socialaccount/providers/reddit/tests.py
@@ -15,3 +15,6 @@ class RedditTests(OAuth2TestsMixin, TestCase):
         "name": "wayward710"}""",
             )
         ]
+
+    def get_expected_to_str(self):
+        return "wayward710"

--- a/allauth/socialaccount/providers/robinhood/provider.py
+++ b/allauth/socialaccount/providers/robinhood/provider.py
@@ -9,11 +9,6 @@ class RobinhoodAccount(ProviderAccount):
     def get_avatar_url(self):
         return None
 
-    def to_str(self):
-        return self.account.extra_data.get(
-            "username", super(RobinhoodAccount, self).to_str()
-        )
-
 
 class RobinhoodProvider(OAuth2Provider):
     id = "robinhood"

--- a/allauth/socialaccount/providers/robinhood/tests.py
+++ b/allauth/socialaccount/providers/robinhood/tests.py
@@ -17,3 +17,6 @@ class RobinhoodTests(OAuth2TestsMixin, TestCase):
 }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "test_username"

--- a/allauth/socialaccount/providers/salesforce/provider.py
+++ b/allauth/socialaccount/providers/salesforce/provider.py
@@ -14,10 +14,6 @@ class SalesforceAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("picture")
 
-    def to_str(self):
-        dflt = super(SalesforceAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class SalesforceProvider(OAuth2Provider):
     id = "salesforce"

--- a/allauth/socialaccount/providers/salesforce/provider.py
+++ b/allauth/socialaccount/providers/salesforce/provider.py
@@ -16,7 +16,7 @@ class SalesforceAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(SalesforceAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class SalesforceProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/salesforce/tests.py
+++ b/allauth/socialaccount/providers/salesforce/tests.py
@@ -31,6 +31,9 @@ class SalesforceTests(OAuth2TestsMixin, TestCase):
         )
         return MockedResponse(200, userinfo)
 
+    def get_expected_to_str(self):
+        return "raymond.penners@gmail.com"
+
 
 USERINFO_RESPONSE = """
 {{

--- a/allauth/socialaccount/providers/saml/provider.py
+++ b/allauth/socialaccount/providers/saml/provider.py
@@ -6,8 +6,7 @@ from allauth.socialaccount.providers.base import Provider, ProviderAccount
 
 
 class SAMLAccount(ProviderAccount):
-    def to_str(self):
-        return super().to_str()
+    pass
 
 
 class SAMLProvider(Provider):

--- a/allauth/socialaccount/providers/sharefile/provider.py
+++ b/allauth/socialaccount/providers/sharefile/provider.py
@@ -8,7 +8,7 @@ from allauth.socialaccount.providers.sharefile.views import (
 class ShareFileAccount(ProviderAccount):
     def to_str(self):
         dflt = super(ShareFileAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("Email", dflt)
 
 
 class ShareFileProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/sharefile/tests.py
+++ b/allauth/socialaccount/providers/sharefile/tests.py
@@ -23,3 +23,6 @@ class ShareFileTests(OAuth2TestsMixin, TestCase):
   }
 }         """,
         )
+
+    def get_expected_to_str(self):
+        return "user.one@domain.com"

--- a/allauth/socialaccount/providers/shopify/provider.py
+++ b/allauth/socialaccount/providers/shopify/provider.py
@@ -6,7 +6,8 @@ from allauth.socialaccount.providers.shopify.views import ShopifyOAuth2Adapter
 
 
 class ShopifyAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("shop", {}).get("email") or super().to_str()
 
 
 class ShopifyProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/shopify/tests.py
+++ b/allauth/socialaccount/providers/shopify/tests.py
@@ -62,6 +62,9 @@ class ShopifyTests(OAuth2TestsMixin, TestCase):
         """,
         )
 
+    def get_expected_to_str(self):
+        return "email@example.com"
+
 
 @override_settings(SOCIALACCOUNT_PROVIDERS={"shopify": {"IS_EMBEDDED": True}})
 class ShopifyEmbeddedTests(ShopifyTests):

--- a/allauth/socialaccount/providers/slack/provider.py
+++ b/allauth/socialaccount/providers/slack/provider.py
@@ -8,11 +8,14 @@ class SlackAccount(ProviderAccount):
         return self.account.extra_data.get("user").get("image_192", None)
 
     def to_str(self):
-        dflt = super(SlackAccount, self).to_str()
-        return "%s (%s)" % (
-            self.account.extra_data.get("name", ""),
-            dflt,
-        )
+        user = self.account.extra_data.get("user", {})
+        team = self.account.extra_data.get("team", {})
+        username = user.get("email") or user.get("name") or user.get("id")
+        teamname = team.get("name") or team.get("id") or ""
+        if teamname:
+            return "%s (%s)" % (username or super().to_str(), teamname)
+        else:
+            return username or super().to_str()
 
 
 class SlackProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/slack/tests.py
+++ b/allauth/socialaccount/providers/slack/tests.py
@@ -19,3 +19,6 @@ class SlackOAuth2Tests(OAuth2TestsMixin, TestCase):
           "user_id": "U12345"
         }""",
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "T0G9PQBBK (My Team)"

--- a/allauth/socialaccount/providers/snapchat/provider.py
+++ b/allauth/socialaccount/providers/snapchat/provider.py
@@ -12,10 +12,7 @@ from allauth.socialaccount.providers.snapchat.views import (
 class SnapchatAccount(ProviderAccount):
     def to_str(self):
         dflt = super(SnapchatAccount, self).to_str()
-        return "%s (%s)" % (
-            self.account.extra_data.get("data").get("me").get("displayName", ""),
-            dflt,
-        )
+        return self.account.extra_data.get("data").get("me").get("displayName") or dflt
 
 
 class SnapchatProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/snapchat/tests.py
+++ b/allauth/socialaccount/providers/snapchat/tests.py
@@ -24,3 +24,6 @@ class SnapchatOAuth2Tests(OAuth2TestsMixin, TestCase):
                   "errors":[]
             }""",
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "Karun Shrestha"

--- a/allauth/socialaccount/providers/soundcloud/provider.py
+++ b/allauth/socialaccount/providers/soundcloud/provider.py
@@ -16,7 +16,7 @@ class SoundCloudAccount(ProviderAccount):
         dflt = super(SoundCloudAccount, self).to_str()
         full_name = self.account.extra_data.get("full_name")
         username = self.account.extra_data.get("username")
-        return full_name or username or dflt
+        return username or full_name or dflt
 
 
 class SoundCloudProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/soundcloud/provider.py
+++ b/allauth/socialaccount/providers/soundcloud/provider.py
@@ -12,12 +12,6 @@ class SoundCloudAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar_url")
 
-    def to_str(self):
-        dflt = super(SoundCloudAccount, self).to_str()
-        full_name = self.account.extra_data.get("full_name")
-        username = self.account.extra_data.get("username")
-        return username or full_name or dflt
-
 
 class SoundCloudProvider(OAuth2Provider):
     id = "soundcloud"

--- a/allauth/socialaccount/providers/soundcloud/tests.py
+++ b/allauth/socialaccount/providers/soundcloud/tests.py
@@ -40,3 +40,6 @@ class SoundCloudTests(OAuth2TestsMixin, TestCase):
             "plan": "Free"
         }""",
         )
+
+    def get_expected_to_str(self):
+        return "user187631676"

--- a/allauth/socialaccount/providers/spotify/provider.py
+++ b/allauth/socialaccount/providers/spotify/provider.py
@@ -16,7 +16,7 @@ class SpotifyAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(SpotifyAccount, self).to_str()
-        return self.account.extra_data.get("display_name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class SpotifyOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/spotify/provider.py
+++ b/allauth/socialaccount/providers/spotify/provider.py
@@ -14,10 +14,6 @@ class SpotifyAccount(ProviderAccount):
         except IndexError:
             return None
 
-    def to_str(self):
-        dflt = super(SpotifyAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class SpotifyOAuth2Provider(OAuth2Provider):
     id = "spotify"

--- a/allauth/socialaccount/providers/spotify/tests.py
+++ b/allauth/socialaccount/providers/spotify/tests.py
@@ -37,3 +37,6 @@ class SpotifyOAuth2Tests(OAuth2TestsMixin, TestCase):
           "uri": "spotify:user:wizzler"
         }""",
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "email@example.com"

--- a/allauth/socialaccount/providers/stackexchange/provider.py
+++ b/allauth/socialaccount/providers/stackexchange/provider.py
@@ -14,7 +14,7 @@ class StackExchangeAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(StackExchangeAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("display_name", dflt)
 
 
 class StackExchangeProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/stackexchange/tests.py
+++ b/allauth/socialaccount/providers/stackexchange/tests.py
@@ -43,3 +43,6 @@ class StackExchangeTests(OAuth2TestsMixin, TestCase):
            "quota_remaining": 9999
         }""",
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "pennersr"

--- a/allauth/socialaccount/providers/stocktwits/provider.py
+++ b/allauth/socialaccount/providers/stocktwits/provider.py
@@ -11,7 +11,7 @@ class StocktwitsAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(StocktwitsAccount, self).to_str()
-        return self.account.extra_data.get("user", {}).get("name", dflt)
+        return self.account.extra_data.get("user", {}).get("username", dflt)
 
 
 class StocktwitsProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/stocktwits/tests.py
+++ b/allauth/socialaccount/providers/stocktwits/tests.py
@@ -29,3 +29,6 @@ class StocktwitsTests(OAuth2TestsMixin, TestCase):
 }
 """,
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "zerobeta"

--- a/allauth/socialaccount/providers/strava/provider.py
+++ b/allauth/socialaccount/providers/strava/provider.py
@@ -16,10 +16,6 @@ class StravaAccount(ProviderAccount):
             return avatar
         return None
 
-    def to_str(self):
-        name = super(StravaAccount, self).to_str()
-        return self.account.extra_data.get("email", name)
-
 
 class StravaProvider(OAuth2Provider):
     id = "strava"

--- a/allauth/socialaccount/providers/strava/provider.py
+++ b/allauth/socialaccount/providers/strava/provider.py
@@ -18,7 +18,7 @@ class StravaAccount(ProviderAccount):
 
     def to_str(self):
         name = super(StravaAccount, self).to_str()
-        return self.account.extra_data.get("name", name)
+        return self.account.extra_data.get("email", name)
 
 
 class StravaProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/strava/tests.py
+++ b/allauth/socialaccount/providers/strava/tests.py
@@ -36,6 +36,9 @@ class StravaTests(OAuth2TestsMixin, TestCase):
             }""",
         )  # noqa
 
+    def get_expected_to_str(self):
+        return "bill@example.com"
+
     def get_mocked_response_avatar_invalid_id(self):
         """Profile including realistic avatar URL
         user ID set to 0 to test edge case where id would be missing"""

--- a/allauth/socialaccount/providers/stripe/provider.py
+++ b/allauth/socialaccount/providers/stripe/provider.py
@@ -6,7 +6,12 @@ from allauth.socialaccount.providers.stripe.views import StripeOAuth2Adapter
 class StripeAccount(ProviderAccount):
     def to_str(self):
         default = super(StripeAccount, self).to_str()
-        return self.account.extra_data.get("business_name", default)
+        email = self.account.extra_data.get("email")
+        business = self.account.extra_data.get("business_name")
+        if business:
+            return "%s (%s)" % (email or default, business)
+        else:
+            return email or default
 
 
 class StripeProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/stripe/tests.py
+++ b/allauth/socialaccount/providers/stripe/tests.py
@@ -36,6 +36,9 @@ class StripeTests(OAuth2TestsMixin, TestCase):
         }""",
         )
 
+    def get_expected_to_str(self):
+        return "test@example.com"
+
     def get_login_response_json(self, with_refresh_token=True):
         rt = ""
         if with_refresh_token:

--- a/allauth/socialaccount/providers/telegram/provider.py
+++ b/allauth/socialaccount/providers/telegram/provider.py
@@ -6,8 +6,7 @@ from allauth.socialaccount.providers.base import Provider, ProviderAccount
 
 
 class TelegramAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("username") or super().to_str()
+    pass
 
 
 class TelegramProvider(Provider):

--- a/allauth/socialaccount/providers/telegram/provider.py
+++ b/allauth/socialaccount/providers/telegram/provider.py
@@ -6,7 +6,8 @@ from allauth.socialaccount.providers.base import Provider, ProviderAccount
 
 
 class TelegramAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("username") or super().to_str()
 
 
 class TelegramProvider(Provider):

--- a/allauth/socialaccount/providers/tiktok/provider.py
+++ b/allauth/socialaccount/providers/tiktok/provider.py
@@ -17,10 +17,6 @@ class TikTokAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar_url")
 
-    def to_str(self):
-        username = self.get_username()
-        return username or super().to_str()
-
 
 class TikTokProvider(OAuth2Provider):
     id = "tiktok"

--- a/allauth/socialaccount/providers/tiktok/tests.py
+++ b/allauth/socialaccount/providers/tiktok/tests.py
@@ -24,3 +24,6 @@ class TikTokTests(OAuth2TestsMixin, TestCase):
         }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "username123"

--- a/allauth/socialaccount/providers/trainingpeaks/provider.py
+++ b/allauth/socialaccount/providers/trainingpeaks/provider.py
@@ -13,14 +13,8 @@ class TrainingPeaksAccount(ProviderAccount):
         return None
 
     def to_str(self):
-        name = (
-            self.account.extra_data.get("FirstName")
-            + " "
-            + self.account.extra_data.get("LastName")
-        )
-        if name != " ":
-            return name
-        return super(TrainingPeaksAccount, self).to_str()
+        dflt = super().to_str()
+        return self.account.extra_data.get("Email", dflt)
 
 
 class TrainingPeaksProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/trainingpeaks/tests.py
+++ b/allauth/socialaccount/providers/trainingpeaks/tests.py
@@ -31,6 +31,9 @@ class TrainingPeaksTests(OAuth2TestsMixin, TestCase):
             }""",
         )  # noqa
 
+    def get_expected_to_str(self):
+        return "user@example.com"
+
     def get_login_response_json(self, with_refresh_token=True):
         rtoken = ""
         if with_refresh_token:

--- a/allauth/socialaccount/providers/trello/provider.py
+++ b/allauth/socialaccount/providers/trello/provider.py
@@ -10,9 +10,6 @@ class TrelloAccount(ProviderAccount):
     def get_avatar_url(self):
         return None
 
-    def to_str(self):
-        return self.account.extra_data.get("username") or super().to_str()
-
 
 class TrelloProvider(OAuthProvider):
     id = "trello"

--- a/allauth/socialaccount/providers/trello/provider.py
+++ b/allauth/socialaccount/providers/trello/provider.py
@@ -10,6 +10,9 @@ class TrelloAccount(ProviderAccount):
     def get_avatar_url(self):
         return None
 
+    def to_str(self):
+        return self.account.extra_data.get("username") or super().to_str()
+
 
 class TrelloProvider(OAuthProvider):
     id = "trello"

--- a/allauth/socialaccount/providers/trello/tests.py
+++ b/allauth/socialaccount/providers/trello/tests.py
@@ -16,3 +16,6 @@ class TrelloTests(OAuthTestsMixin, TestCase):
         """,
             ),
         ]  # noqa
+
+    def get_expected_to_str(self):
+        return "pennersr"

--- a/allauth/socialaccount/providers/trello/tests.py
+++ b/allauth/socialaccount/providers/trello/tests.py
@@ -18,4 +18,4 @@ class TrelloTests(OAuthTestsMixin, TestCase):
         ]  # noqa
 
     def get_expected_to_str(self):
-        return "pennersr"
+        return "raymond.penners@example.com"

--- a/allauth/socialaccount/providers/tumblr/provider.py
+++ b/allauth/socialaccount/providers/tumblr/provider.py
@@ -7,11 +7,6 @@ class TumblrAccount(ProviderAccount):
     def get_profile_url_(self):
         return "http://%s.tumblr.com/" % self.account.extra_data.get("name")
 
-    def to_str(self):
-        dflt = super(TumblrAccount, self).to_str()
-        name = self.account.extra_data.get("name", dflt)
-        return name
-
 
 class TumblrProvider(OAuthProvider):
     id = "tumblr"

--- a/allauth/socialaccount/providers/tumblr/tests.py
+++ b/allauth/socialaccount/providers/tumblr/tests.py
@@ -42,3 +42,6 @@ class TumblrTests(OAuthTestsMixin, TestCase):
 """,
             )
         ]
+
+    def get_expected_to_str(self):
+        return "derekg"

--- a/allauth/socialaccount/providers/twentythreeandme/provider.py
+++ b/allauth/socialaccount/providers/twentythreeandme/provider.py
@@ -6,7 +6,8 @@ from allauth.socialaccount.providers.twentythreeandme.views import (
 
 
 class TwentyThreeAndMeAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("email") or super().to_str()
 
 
 class TwentyThreeAndMeProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/twentythreeandme/provider.py
+++ b/allauth/socialaccount/providers/twentythreeandme/provider.py
@@ -6,8 +6,7 @@ from allauth.socialaccount.providers.twentythreeandme.views import (
 
 
 class TwentyThreeAndMeAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("email") or super().to_str()
+    pass
 
 
 class TwentyThreeAndMeProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/twentythreeandme/tests.py
+++ b/allauth/socialaccount/providers/twentythreeandme/tests.py
@@ -20,6 +20,9 @@ class TwentyThreeAndMeTests(OAuth2TestsMixin, TestCase):
         """,
         )
 
+    def get_expected_to_str(self):
+        return "23andMe"
+
     def get_login_response_json(self, with_refresh_token=True):
         return """
         {

--- a/allauth/socialaccount/providers/twitch/tests.py
+++ b/allauth/socialaccount/providers/twitch/tests.py
@@ -34,6 +34,9 @@ class TwitchTests(OAuth2TestsMixin, TestCase):
         """,
         )  # noqa
 
+    def get_expected_to_str(self):
+        return "dallas"
+
     def test_response_over_400_raises_OAuth2Error(self):
         resp_mock = MockedResponse(400, '{"error": "Invalid token"}')
         expected_error = "Twitch API Error: Invalid token ()"

--- a/allauth/socialaccount/providers/twitter/provider.py
+++ b/allauth/socialaccount/providers/twitter/provider.py
@@ -5,6 +5,7 @@ from allauth.socialaccount.providers.twitter.views import TwitterOAuthAdapter
 
 class TwitterAccount(ProviderAccount):
     def get_screen_name(self):
+        """The screen name is the username of the Twitter account."""
         return self.account.extra_data.get("screen_name")
 
     def get_profile_url(self):

--- a/allauth/socialaccount/providers/twitter/tests.py
+++ b/allauth/socialaccount/providers/twitter/tests.py
@@ -27,6 +27,9 @@ class TwitterTests(OAuthTestsMixin, TestCase):
             )
         ]  # noqa
 
+    def get_expected_to_str(self):
+        return "pennersr"
+
     def test_login(self):
         account = super(TwitterTests, self).test_login()
         tw_account = account.get_provider_account()
@@ -36,3 +39,4 @@ class TwitterTests(OAuthTestsMixin, TestCase):
             "http://pbs.twimg.com/profile_images/793142149/r.png",
         )
         self.assertEqual(tw_account.get_profile_url(), "http://twitter.com/pennersr")
+        self.assertEqual(tw_account.to_str(), "pennersr")

--- a/allauth/socialaccount/providers/twitter_oauth2/provider.py
+++ b/allauth/socialaccount/providers/twitter_oauth2/provider.py
@@ -18,10 +18,6 @@ class TwitterOAuth2Account(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("profile_image_url")
 
-    def to_str(self):
-        username = self.get_username()
-        return username or super(TwitterOAuth2Account, self).to_str()
-
 
 class TwitterOAuth2Provider(OAuth2Provider):
     id = "twitter_oauth2"

--- a/allauth/socialaccount/providers/twitter_oauth2/tests.py
+++ b/allauth/socialaccount/providers/twitter_oauth2/tests.py
@@ -22,3 +22,6 @@ class TwitterOAuth2Tests(OAuth2TestsMixin, TestCase):
             }
             """,
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "realllkk520"

--- a/allauth/socialaccount/providers/untappd/provider.py
+++ b/allauth/socialaccount/providers/untappd/provider.py
@@ -15,7 +15,10 @@ class UntappdAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(UntappdAccount, self).to_str()
-        return self.account.extra_data.get("user_name", dflt)
+        return (
+            self.account.extra_data.get("response", {}).get("user", {}).get("user_name")
+            or dflt
+        )
 
 
 class UntappdProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/untappd/tests.py
+++ b/allauth/socialaccount/providers/untappd/tests.py
@@ -97,3 +97,6 @@ class UntappdTests(OAuth2TestsMixin, TestCase):
 }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "groovecoder"

--- a/allauth/socialaccount/providers/vimeo/provider.py
+++ b/allauth/socialaccount/providers/vimeo/provider.py
@@ -4,8 +4,7 @@ from allauth.socialaccount.providers.vimeo.views import VimeoOAuthAdapter
 
 
 class VimeoAccount(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("username") or super().to_str()
+    pass
 
 
 class VimeoProvider(OAuthProvider):

--- a/allauth/socialaccount/providers/vimeo/provider.py
+++ b/allauth/socialaccount/providers/vimeo/provider.py
@@ -4,7 +4,8 @@ from allauth.socialaccount.providers.vimeo.views import VimeoOAuthAdapter
 
 
 class VimeoAccount(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("username") or super().to_str()
 
 
 class VimeoProvider(OAuthProvider):

--- a/allauth/socialaccount/providers/vimeo/tests.py
+++ b/allauth/socialaccount/providers/vimeo/tests.py
@@ -37,3 +37,6 @@ class VimeoTests(OAuthTestsMixin, TestCase):
 """,
             )
         ]
+
+    def get_expected_to_str(self):
+        return "user17574504"

--- a/allauth/socialaccount/providers/vimeo_oauth2/provider.py
+++ b/allauth/socialaccount/providers/vimeo_oauth2/provider.py
@@ -10,8 +10,7 @@ from allauth.socialaccount.providers.vimeo_oauth2.views import (
 
 
 class VimeoOAuth2Account(ProviderAccount):
-    def to_str(self):
-        return self.account.extra_data.get("name") or super().to_str()
+    pass
 
 
 class VimeoOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/vimeo_oauth2/provider.py
+++ b/allauth/socialaccount/providers/vimeo_oauth2/provider.py
@@ -10,7 +10,8 @@ from allauth.socialaccount.providers.vimeo_oauth2.views import (
 
 
 class VimeoOAuth2Account(ProviderAccount):
-    pass
+    def to_str(self):
+        return self.account.extra_data.get("name") or super().to_str()
 
 
 class VimeoOAuth2Provider(OAuth2Provider):

--- a/allauth/socialaccount/providers/vimeo_oauth2/tests.py
+++ b/allauth/socialaccount/providers/vimeo_oauth2/tests.py
@@ -30,3 +30,6 @@ class VimeoOAuth2Tests(OAuth2TestsMixin, TestCase):
             "account": "pro"
         }""",
         )  # noqa
+
+    def get_expected_to_str(self):
+        return "AllAuth"

--- a/allauth/socialaccount/providers/vk/provider.py
+++ b/allauth/socialaccount/providers/vk/provider.py
@@ -19,13 +19,6 @@ class VKAccount(ProviderAccount):
         else:
             return ret
 
-    def to_str(self):
-        email = self.account.extra_data.get("email")
-        first_name = self.account.extra_data.get("first_name", "")
-        last_name = self.account.extra_data.get("last_name", "")
-        name = " ".join([first_name, last_name]).strip()
-        return email or name or super(VKAccount, self).to_str()
-
 
 class VKProvider(OAuth2Provider):
     id = "vk"

--- a/allauth/socialaccount/providers/vk/provider.py
+++ b/allauth/socialaccount/providers/vk/provider.py
@@ -20,10 +20,11 @@ class VKAccount(ProviderAccount):
             return ret
 
     def to_str(self):
+        email = self.account.extra_data.get("email")
         first_name = self.account.extra_data.get("first_name", "")
         last_name = self.account.extra_data.get("last_name", "")
         name = " ".join([first_name, last_name]).strip()
-        return name or super(VKAccount, self).to_str()
+        return email or name or super(VKAccount, self).to_str()
 
 
 class VKProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/vk/tests.py
+++ b/allauth/socialaccount/providers/vk/tests.py
@@ -25,5 +25,8 @@ class VKTests(OAuth2TestsMixin, TestCase):
 """,
         )
 
+    def get_expected_to_str(self):
+        return "Raymond Penners"
+
     def get_login_response_json(self, with_refresh_token=True):
         return '{"user_id": 219004864, "access_token":"testac"}'

--- a/allauth/socialaccount/providers/wahoo/provider.py
+++ b/allauth/socialaccount/providers/wahoo/provider.py
@@ -9,6 +9,9 @@ class WahooAccount(ProviderAccount):
     def get_profile_url(self):
         return "https://api.wahooligan.com/v1/user"
 
+    def to_str(self):
+        return self.account.extra_data.get("email") or super().to_str()
+
 
 class WahooProvider(OAuth2Provider):
     id = "wahoo"

--- a/allauth/socialaccount/providers/wahoo/provider.py
+++ b/allauth/socialaccount/providers/wahoo/provider.py
@@ -9,9 +9,6 @@ class WahooAccount(ProviderAccount):
     def get_profile_url(self):
         return "https://api.wahooligan.com/v1/user"
 
-    def to_str(self):
-        return self.account.extra_data.get("email") or super().to_str()
-
 
 class WahooProvider(OAuth2Provider):
     id = "wahoo"

--- a/allauth/socialaccount/providers/wahoo/tests.py
+++ b/allauth/socialaccount/providers/wahoo/tests.py
@@ -25,3 +25,6 @@ class WahooTests(OAuth2TestsMixin, TestCase):
             }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "sample@test-domain.com"

--- a/allauth/socialaccount/providers/weibo/provider.py
+++ b/allauth/socialaccount/providers/weibo/provider.py
@@ -14,10 +14,6 @@ class WeiboAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("avatar_large")
 
-    def to_str(self):
-        dflt = super(WeiboAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
-
 
 class WeiboProvider(OAuth2Provider):
     id = "weibo"

--- a/allauth/socialaccount/providers/weibo/tests.py
+++ b/allauth/socialaccount/providers/weibo/tests.py
@@ -28,3 +28,6 @@ class WeiboTests(OAuth2TestsMixin, TestCase):
 
 """,
         )
+
+    def get_expected_to_str(self):
+        return "pennersr"

--- a/allauth/socialaccount/providers/weixin/tests.py
+++ b/allauth/socialaccount/providers/weixin/tests.py
@@ -29,3 +29,10 @@ class WeixinTests(OAuth2TestsMixin, TestCase):
  "sex": 1,
  "unionid": "ohHrhwKnD9TOunEW0eKTS45vS5Qo"}""",
         )  # noqa
+
+    def get_expected_to_str(self):
+        # For some reason, WeixinOAuth2Adapter.complete_login runs this line:
+        # extra_data["nickname"] = nickname.encode("raw_unicode_escape").decode(
+        #     "utf-8"
+        # )
+        return "\\u67d0\\u67d0\\u67d0"

--- a/allauth/socialaccount/providers/windowslive/provider.py
+++ b/allauth/socialaccount/providers/windowslive/provider.py
@@ -7,6 +7,9 @@ from allauth.socialaccount.providers.windowslive.views import (
 
 class WindowsLiveAccount(ProviderAccount):
     def to_str(self):
+        email = self.account.extra_data.get("emails", {}).get("preferred")
+        if email:
+            return email
         name = "{0} {1}".format(
             self.account.extra_data.get("first_name", ""),
             self.account.extra_data.get("last_name", ""),

--- a/allauth/socialaccount/providers/windowslive/provider.py
+++ b/allauth/socialaccount/providers/windowslive/provider.py
@@ -10,12 +10,6 @@ class WindowsLiveAccount(ProviderAccount):
         email = self.account.extra_data.get("emails", {}).get("preferred")
         if email:
             return email
-        name = "{0} {1}".format(
-            self.account.extra_data.get("first_name", ""),
-            self.account.extra_data.get("last_name", ""),
-        )
-        if name.strip() != "":
-            return name
         return super(WindowsLiveAccount, self).to_str()
 
 

--- a/allauth/socialaccount/providers/windowslive/tests.py
+++ b/allauth/socialaccount/providers/windowslive/tests.py
@@ -29,3 +29,6 @@ class WindowsLiveTests(OAuth2TestsMixin, TestCase):
         }
         """,
         )
+
+    def get_expected_to_str(self):
+        return "jsmith@example.com"

--- a/allauth/socialaccount/providers/xing/provider.py
+++ b/allauth/socialaccount/providers/xing/provider.py
@@ -12,10 +12,7 @@ class XingAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(XingAccount, self).to_str()
-        first_name = self.account.extra_data.get("first_name", "")
-        last_name = self.account.extra_data.get("last_name", "")
-        name = " ".join([first_name, last_name]).strip()
-        return name or dflt
+        return self.account.extra_data.get("active_email") or dflt
 
 
 class XingProvider(OAuthProvider):

--- a/allauth/socialaccount/providers/xing/tests.py
+++ b/allauth/socialaccount/providers/xing/tests.py
@@ -40,3 +40,6 @@ class XingTests(OAuthTestsMixin, TestCase):
 """,
             )
         ]
+
+    def get_expected_to_str(self):
+        return "raymond.penners@example.com"

--- a/allauth/socialaccount/providers/yahoo/provider.py
+++ b/allauth/socialaccount/providers/yahoo/provider.py
@@ -6,13 +6,8 @@ from allauth.socialaccount.providers.yahoo.views import YahooOAuth2Adapter
 
 class YahooAccount(ProviderAccount):
     def to_str(self):
-        name = "{0} {1}".format(
-            self.account.extra_data.get("given_name", ""),
-            self.account.extra_data.get("family_name", ""),
-        )
-        if name.strip() != "":
-            return name
-        return super(YahooAccount, self).to_str()
+        dflt = super(YahooAccount, self).to_str()
+        return self.account.extra_data.get("email", dflt)
 
 
 class YahooProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/yahoo/provider.py
+++ b/allauth/socialaccount/providers/yahoo/provider.py
@@ -5,9 +5,7 @@ from allauth.socialaccount.providers.yahoo.views import YahooOAuth2Adapter
 
 
 class YahooAccount(ProviderAccount):
-    def to_str(self):
-        dflt = super(YahooAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
+    pass
 
 
 class YahooProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/yahoo/tests.py
+++ b/allauth/socialaccount/providers/yahoo/tests.py
@@ -21,3 +21,6 @@ class YahooTests(OAuth2TestsMixin, TestCase):
         }
         """  # noqa
         return MockedResponse(200, response_data)
+
+    def get_expected_to_str(self):
+        return "janedoe@example.com"

--- a/allauth/socialaccount/providers/yandex/provider.py
+++ b/allauth/socialaccount/providers/yandex/provider.py
@@ -7,6 +7,9 @@ from allauth.socialaccount.providers.yandex.views import YandexOAuth2Adapter
 
 class YandexAccout(ProviderAccount):
     def to_str(self):
+        default_email = self.account.extra_data.get("default_email")
+        if default_email:
+            return default_email
         first_name = self.account.extra_data.get("first_name", "")
         last_name = self.account.extra_data.get("last_name", "")
         name = " ".join([first_name, last_name]).strip()

--- a/allauth/socialaccount/providers/yandex/provider.py
+++ b/allauth/socialaccount/providers/yandex/provider.py
@@ -6,14 +6,7 @@ from allauth.socialaccount.providers.yandex.views import YandexOAuth2Adapter
 
 
 class YandexAccout(ProviderAccount):
-    def to_str(self):
-        default_email = self.account.extra_data.get("default_email")
-        if default_email:
-            return default_email
-        first_name = self.account.extra_data.get("first_name", "")
-        last_name = self.account.extra_data.get("last_name", "")
-        name = " ".join([first_name, last_name]).strip()
-        return name or super(YandexAccout, self).to_str()
+    pass
 
 
 class YandexProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/yandex/tests.py
+++ b/allauth/socialaccount/providers/yandex/tests.py
@@ -29,6 +29,9 @@ class YandexTests(OAuth2TestsMixin, TestCase):
             data = self.yandex_data
         return MockedResponse(200, data)
 
+    def get_expected_to_str(self):
+        return "test@yandex.ru"
+
     def get_login_response_json(self, with_refresh_token=True):
         return """
             {

--- a/allauth/socialaccount/providers/ynab/tests.py
+++ b/allauth/socialaccount/providers/ynab/tests.py
@@ -33,6 +33,9 @@ class YNABTests(OAuth2TestsMixin, TestCase):
         """,
         )
 
+    def get_expected_to_str(self):
+        return "YNAB"
+
     def test_ynab_compelete_login_401(self):
         from allauth.socialaccount.providers.ynab.views import (
             YNABOAuth2Adapter,

--- a/allauth/socialaccount/providers/zoho/provider.py
+++ b/allauth/socialaccount/providers/zoho/provider.py
@@ -7,7 +7,7 @@ from allauth.socialaccount.providers.zoho.views import ZohoOAuth2Adapter
 class ZohoAccount(ProviderAccount):
     def to_str(self):
         dflt = super(ZohoAccount, self).to_str()
-        return self.account.extra_data.get("Display_Name", dflt)
+        return self.account.extra_data.get("Email", dflt)
 
 
 class ZohoProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/zoho/tests.py
+++ b/allauth/socialaccount/providers/zoho/tests.py
@@ -15,3 +15,6 @@ class ZohoTests(OAuth2TestsMixin, TestCase):
 "Last_Name":"Doe","Display_Name":"JDoee","ZUID":1234567}
 """,
         )
+
+    def get_expected_to_str(self):
+        return "jdoe@example.com"

--- a/allauth/socialaccount/providers/zoom/provider.py
+++ b/allauth/socialaccount/providers/zoom/provider.py
@@ -11,10 +11,6 @@ class ZoomAccount(ProviderAccount):
     def get_avatar_url(self):
         return self.account.extra_data.get("pic_url")
 
-    def to_str(self):
-        dflt = super(ZoomAccount, self).to_str()
-        return self.account.extra_data.get("email", dflt)
-
 
 class ZoomProvider(OAuth2Provider):
     id = "zoom"

--- a/allauth/socialaccount/providers/zoom/provider.py
+++ b/allauth/socialaccount/providers/zoom/provider.py
@@ -13,7 +13,7 @@ class ZoomAccount(ProviderAccount):
 
     def to_str(self):
         dflt = super(ZoomAccount, self).to_str()
-        return self.account.extra_data.get("name", dflt)
+        return self.account.extra_data.get("email", dflt)
 
 
 class ZoomProvider(OAuth2Provider):

--- a/allauth/socialaccount/providers/zoom/tests.py
+++ b/allauth/socialaccount/providers/zoom/tests.py
@@ -43,3 +43,6 @@ class ZoomTests(OAuth2TestsMixin, TestCase):
 }
 """,
         )
+
+    def get_expected_to_str(self):
+        return "jane.dev@email.com"

--- a/allauth/socialaccount/tests/__init__.py
+++ b/allauth/socialaccount/tests/__init__.py
@@ -49,6 +49,9 @@ class OAuthTestsMixin:
     def get_mocked_response(self):
         pass
 
+    def get_expected_to_str(self):
+        raise NotImplementedError
+
     def setUp(self):
         super(OAuthTestsMixin, self).setUp()
         self.app = setup_app(self.provider_id)
@@ -74,13 +77,13 @@ class OAuthTestsMixin:
         user = resp.context["user"]
         self.assertFalse(user.has_usable_password())
         account = SocialAccount.objects.get(user=user, provider=self.provider.id)
+        provider_account = account.get_provider_account()
+        self.assertEqual(provider_account.to_str(), self.get_expected_to_str())
         # The following lines don't actually test that much, but at least
         # we make sure that the code is hit.
-        provider_account = account.get_provider_account()
         provider_account.get_avatar_url()
         provider_account.get_profile_url()
         provider_account.get_brand()
-        provider_account.to_str()
         return account
 
     @override_settings(
@@ -149,6 +152,9 @@ class OAuth2TestsMixin:
 
     def get_mocked_response(self):
         pass
+
+    def get_expected_to_str(self):
+        raise NotImplementedError
 
     def get_access_token(self) -> str:
         return "testac"
@@ -283,13 +289,13 @@ class OAuth2TestsMixin:
         sa = SocialAccount.objects.filter(
             user=user, provider=self.provider.app.provider_id or self.provider.id
         ).get()
+        provider_account = sa.get_provider_account()
+        self.assertEqual(provider_account.to_str(), self.get_expected_to_str())
         # The following lines don't actually test that much, but at least
         # we make sure that the code is hit.
-        provider_account = sa.get_provider_account()
         provider_account.get_avatar_url()
         provider_account.get_profile_url()
         provider_account.get_brand()
-        provider_account.to_str()
         # get token
         if self.app:
             t = sa.socialtoken_set.get()
@@ -410,6 +416,9 @@ class OpenIDConnectTests(OAuth2TestsMixin):
 
     def mocked_response(self, *responses):
         return mocked_response(*responses, callback=self._mocked_responses)
+
+    def get_expected_to_str(self):
+        return "Ness"
 
     def setup_provider(self):
         self.app = setup_app(self.provider_id)


### PR DESCRIPTION
This fixes this issue: https://github.com/pennersr/django-allauth/issues/3906

I added tests, so that the result of `to_str` is always tested.