### PR TITLE
Render checkboxes and radio buttons before label

### DIFF
--- a/allauth/templates/allauth/elements/field.html
+++ b/allauth/templates/allauth/elements/field.html
@@ -1,11 +1,11 @@
 {% load allauth %}
 {{ attrs.errors }}
 <p>
-    <label for="{{ attrs.id }}">
-        {% slot label %}
-        {% endslot %}
-    </label>
     {% if attrs.type == "textarea" %}
+        <label for="{{ attrs.id }}">
+            {% slot label %}
+            {% endslot %}
+        </label>
         <textarea {% if attrs.required %}required{% endif %}
                   {% if attrs.rows %}rows="{{ attrs.rows }}"{% endif %}
                   {% if attrs.disabled %}disabled{% endif %}
@@ -15,6 +15,12 @@
                   {% if attrs.id %}id="{{ attrs.id }}"{% endif %}
                   {% if attrs.placeholder %}placeholder="{{ attrs.placeholder }}"{% endif %}>{% slot value %}{% endslot %}</textarea>
     {% else %}
+        {% if attrs.type != "checkbox" and attrs.type != "radio" %}
+            <label for="{{ attrs.id }}">
+                {% slot label %}
+                {% endslot %}
+            </label>
+        {% endif %}
         <input {% if attrs.required %}required{% endif %}
                {% if attrs.disabled %}disabled{% endif %}
                {% if attrs.readonly %}readonly{% endif %}
@@ -25,6 +31,12 @@
                {% if attrs.autocomplete %}autocomplete="{{ attrs.autocomplete }}"{% endif %}
                value="{{ attrs.value|default_if_none:'' }}"
                type="{{ attrs.type }}">
+        {% if attrs.type == "checkbox" or attrs.type == "radio" %}
+            <label for="{{ attrs.id }}">
+                {% slot label %}
+                {% endslot %}
+            </label>
+        {% endif %}
     {% endif %}
     {% if slots.help_text %}
         <span>


### PR DESCRIPTION
The `<label>` element should be placed before its corresponding <input> in most cases. However, in the case of a checkbox input or a radio input, the <label> element should be placed after it.

To illustrate:

Bad:

    I agree to terms and conditions ☑

Good:

    ☑ I agree to terms and conditions

django-allauth ships with the two templates that will be affected positively by this change:

allauth/templates/account/email.html
allauth/templates/socialaccount/connections.html