### PR TITLE
fix: Add first_name and last_name to openid_connect provider

### DIFF
--- a/allauth/socialaccount/providers/openid_connect/provider.py
+++ b/allauth/socialaccount/providers/openid_connect/provider.py
@@ -64,9 +64,10 @@ class OpenIDConnectProvider(OAuth2Provider):
         return dict(
             email=data.get("email"),
             username=data.get("preferred_username"),
-            name=data.get("name"),
             user_id=data.get("user_id"),
             picture=data.get("picture"),
+            last_name=data["family_name"],
+            first_name=data["given_name"],
         )
 
     def extract_email_addresses(self, data):


### PR DESCRIPTION
This replaces name with first_name and last_name. Which is used more often.

https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims