### PR TITLE
refactor(templates): Inject "default" slots with their implicit syntax

### DIFF
--- a/allauth/templates/allauth/elements/button_group.html
+++ b/allauth/templates/allauth/elements/button_group.html
@@ -1,5 +1,5 @@
 {% load allauth %}
 <div>
-    {% slot default %}
+    {% slot %}
     {% endslot %}
 </div>

--- a/allauth/templates/allauth/elements/h1.html
+++ b/allauth/templates/allauth/elements/h1.html
@@ -1,1 +1,1 @@
-{% comment %} djlint:off {% endcomment %}{% load allauth %}<h1>{% slot default %}{% endslot %}</h1>
+{% comment %} djlint:off {% endcomment %}{% load allauth %}<h1>{% slot %}{% endslot %}</h1>

--- a/allauth/templates/allauth/elements/h2.html
+++ b/allauth/templates/allauth/elements/h2.html
@@ -1,1 +1,1 @@
-{% comment %} djlint:off {% endcomment %}{% load allauth %}<h2>{% slot default %}{% endslot %}</h2>
+{% comment %} djlint:off {% endcomment %}{% load allauth %}<h2>{% slot %}{% endslot %}</h2>

--- a/allauth/templates/allauth/elements/p.html
+++ b/allauth/templates/allauth/elements/p.html
@@ -1,1 +1,1 @@
-{% comment %} djlint:off {% endcomment %}{% load allauth %}<p>{% slot default %}{% endslot %}</p>
+{% comment %} djlint:off {% endcomment %}{% load allauth %}<p>{% slot %}{% endslot %}</p>

--- a/allauth/templates/allauth/elements/provider_list.html
+++ b/allauth/templates/allauth/elements/provider_list.html
@@ -1,5 +1,5 @@
 {% load allauth %}
 <ul>
-    {% slot default %}
+    {% slot %}
     {% endslot %}
 </ul>

--- a/docs/common/templates.rst
+++ b/docs/common/templates.rst
@@ -113,7 +113,7 @@ element `templatetag`::
 Under the hood, this `templatetag` renders the ``allauth/elements/h1.html``
 template, which out of the box contains this::
 
-    {% load allauth %}<h1>{% slot default %}{% endslot %}</h1>
+    {% load allauth %}<h1>{% slot %}{% endslot %}</h1>
 
 If you want to change the styling of all headings across all pages, you can do
 so by overriding that ``allauth/elements/h1.html`` template, as follows::
@@ -121,13 +121,37 @@ so by overriding that ``allauth/elements/h1.html`` template, as follows::
     {% load allauth %}
     <div class="myproject-h1 aa-{{ origin|slugify }}"
          style="font-size: {% if "foo" in attrs.tags %}3{% else %}5{% endif %}rem">
-        {% slot default %}{% endslot %}
+        {% slot %}{% endslot %}
     </div>
 
 Of course, the above is a bit of a contrived example. In each of the element
 templates the ``{{ origin }}`` context variable is available, which is equal to
 the base template name where the element is used (e.g. ``account/login`` for
 elements used from within the ``account/login.html`` template).
+
+Slots may also be named. In that case, the ``element`` will be invoked like::
+
+    {% load allauth %}
+    {% element form method="post" action=action_url %}
+        {% slot body %}
+            ...
+        {% endslot %}
+        {% slot actions %}
+            ...
+        {% endslot %}
+    {% endelement %}
+
+When overriding an element with named slots, they may be injected in any order.
+For example, with ``allauth/elements/form.html``::
+
+    {% load allauth %}
+    <form method="{{ attrs.method }}" action="{{ attrs.action }}">
+        {% slot body %}
+        {% endslot %}
+        <hr>
+        {% slot actions %}
+        {% endslot %}
+    </form>
 
 The following elements are available -- override them as you see fit for your
 project:

--- a/examples/regular-django/example/templates/allauth/elements/button_group.html
+++ b/examples/regular-django/example/templates/allauth/elements/button_group.html
@@ -1,5 +1,5 @@
 {% load allauth %}
 <div class="btn-group-vertical w-100" role="group">
-    {% slot default %}
+    {% slot %}
     {% endslot %}
 </div>

--- a/examples/regular-django/example/templates/allauth/elements/h1.html
+++ b/examples/regular-django/example/templates/allauth/elements/h1.html
@@ -1,5 +1,5 @@
 {% load allauth %}
 <h1 class="mt-4">
-    {% slot default %}
+    {% slot %}
     {% endslot %}
 </h1>

--- a/examples/regular-django/example/templates/allauth/elements/h1__entrance.html
+++ b/examples/regular-django/example/templates/allauth/elements/h1__entrance.html
@@ -1,5 +1,5 @@
 {% load allauth %}
 <h1 class="fw-bold fs-2">
-    {% slot default %}
+    {% slot %}
     {% endslot %}
 </h1>

--- a/examples/regular-django/example/templates/allauth/elements/h2__entrance.html
+++ b/examples/regular-django/example/templates/allauth/elements/h2__entrance.html
@@ -1,5 +1,5 @@
 {% load allauth %}
 <h2 class="fw-bold fs-5">
-    {% slot default %}
+    {% slot %}
     {% endslot %}
 </h2>

--- a/examples/regular-django/example/templates/allauth/elements/provider_list.html
+++ b/examples/regular-django/example/templates/allauth/elements/provider_list.html
@@ -1,5 +1,5 @@
 {% load allauth %}
 <div class="list-group">
-    {% slot default %}
+    {% slot %}
     {% endslot %}
 </div>


### PR DESCRIPTION
This better matches the way they're invoked (with no explicit name), making them simpler to understand.

This also adds documentation about both default and named slots.