### PR TITLE
fix: Always fetch emails when QUERY_EMAILS is set

### DIFF
--- a/allauth/socialaccount/providers/bitbucket_oauth2/views.py
+++ b/allauth/socialaccount/providers/bitbucket_oauth2/views.py
@@ -21,11 +21,12 @@ class BitbucketOAuth2Adapter(OAuth2Adapter):
             .get(self.profile_url, params={"access_token": token.token})
         )
         extra_data = resp.json()
-        if app_settings.QUERY_EMAIL and not extra_data.get("email"):
-            extra_data["email"] = self.get_email(token)
+        if app_settings.QUERY_EMAIL:
+            if email := self.get_email(token):
+                extra_data["email"] = email
         return self.get_provider().sociallogin_from_response(request, extra_data)
 
-    def get_email(self, token):
+    def get_email(self, token) -> str:
         """Fetches email address from email API endpoint"""
         resp = (
             get_adapter()

--- a/allauth/socialaccount/providers/github/views.py
+++ b/allauth/socialaccount/providers/github/views.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from allauth.socialaccount import app_settings
 from allauth.socialaccount.adapter import get_adapter
 from allauth.socialaccount.providers.oauth2.views import (
@@ -30,13 +32,12 @@ class GitHubOAuth2Adapter(OAuth2Adapter):
         )
         resp.raise_for_status()
         extra_data = resp.json()
-        if app_settings.QUERY_EMAIL and not extra_data.get("email"):
-            emails = self.get_emails(headers)
-            if emails:
+        if app_settings.QUERY_EMAIL:
+            if emails := self.get_emails(headers):
                 extra_data["emails"] = emails
         return self.get_provider().sociallogin_from_response(request, extra_data)
 
-    def get_emails(self, headers):
+    def get_emails(self, headers) -> Optional[list]:
         resp = (
             get_adapter().get_requests_session().get(self.emails_url, headers=headers)
         )


### PR DESCRIPTION
I encountered this situation by having the following context.


First, I have this social account configuration:

```python
SOCIALACCOUNT_LOGIN_ON_GET = True
SOCIALACCOUNT_EMAIL_AUTHENTICATION = True
SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True

SOCIALACCOUNT_PROVIDERS = {
    "google": {
        "APP": {
            "client_id": getenv("GOOGLE_OAUTH_CLIENT_ID"),
            "secret": getenv("GOOGLE_OAUTH_CLIENT_SECRET"),
        }
    },
    "github": {
        "APP": {
            "client_id": getenv("GITHUB_OAUTH_CLIENT_ID"),
            "secret": getenv("GITHUB_OAUTH_CLIENT_SECRET"),
        }
    },
}
```
Next, I took these steps:

1. Register a new user w/ email and password, `foo@bar.com`.
2. I configured a GH OAuth application and provider.
3. I hit the `github_login` view to initiate the process of linking my GitHub user w/ email address `foo@bar.com` to my local user account.
4. Instead of the existing user having the GH socialaccount data merged/associated w/ it, allauth was trying to register a fresh user with the same email address, which triggered the "account already exists" email flow.

I inspected the data I was getting back from GH, and because the [fetched profile](https://github.com/mecampbellsoup/django-allauth/blob/aa89da5ce199e71b0ee3fe3a2e44007de1d55ea6/allauth/socialaccount/providers/github/views.py#L29) had an `"email"` key in it, the `self.get_emails()` call is never made. Since I don't have a provider setting on the `"github"` provider configuration above, allauth seems to begin new user registration process instead of e.g. querying the DB for the given email address to see if it exists yet or not.

This PR should be completely backwards compatible w/ current behavior, but in some cases it will result in an extra API call to fetch the user's email addresses. I will leave a comment w/ an alternative option in the diff.

Related to https://github.com/pennersr/django-allauth/issues/3745.
