### PR TITLE
tests: Upgrade coverage to 7.6.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,7 @@ setenv =
     prjregular: DJANGO_SETTINGS_MODULE = tests.regular.settings
     prjheadless_only: DJANGO_SETTINGS_MODULE = tests.headless_only.settings
 deps =
-    # 6.x drops py35/36 support
-    coverage==5.5
+    coverage==7.6.1
     Pillow>=9.0
     pytest>=7.4
     pytest-asyncio == 0.23.8


### PR DESCRIPTION
Fixes these warnings seen during tests on Python 3.12:

```
/.../coverage/pytracer.py:223: DeprecationWarning: currentThread() is deprecated, use current_thread() instead
  self.thread = self.threading.currentThread()
  
...

/.../coverage/parser.py:382: DeprecationWarning: co_lnotab is deprecated, use co_lines instead.
  if not hasattr(self.code, attr):
```

The last one is repeated many times.

Coverage 7.6.1 is compatible with Python 3.8-3.12, so perfect for the range tested here.

# Submitting Pull Requests

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [x] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [x] If your changes are significant, please update `ChangeLog.rst`.
 - [x] If your change is substantial, feel free to add yourself to `AUTHORS`.
