### PR TITLE
fix: remove the type attribute from <script> tags

### DIFF
--- a/allauth/socialaccount/providers/facebook/templates/facebook/fbconnect.html
+++ b/allauth/socialaccount/providers/facebook/templates/facebook/fbconnect.html
@@ -1,4 +1,4 @@
 {% load static %}
 <div id="fb-root"></div>
 {{ fb_data|json_script:"allauth-facebook-settings" }}
-<script type="text/javascript" src="{% static 'facebook/js/fbconnect.js' %}"></script>
+<script src="{% static 'facebook/js/fbconnect.js' %}"></script>

--- a/allauth/socialaccount/providers/telegram/templates/telegram/callback.html
+++ b/allauth/socialaccount/providers/telegram/templates/telegram/callback.html
@@ -1,6 +1,6 @@
 {% load static %}
 <html>
     <body>
-        <script type="text/javascript" src="{% static 'telegram/js/telegram.js' %}"></script>
+        <script src="{% static 'telegram/js/telegram.js' %}"></script>
     </body>
 </html>

--- a/allauth/templates/account/email.html
+++ b/allauth/templates/account/email.html
@@ -74,7 +74,7 @@
     {% endif %}
 {% endblock content %}
 {% block extra_body %}
-    <script type="text/javascript">
+    <script>
 (function() {
   var message = "{% trans 'Do you really want to remove the selected email address?' %}";
   var actions = document.getElementsByName('action_remove');

--- a/allauth/templates/mfa/authenticate.html
+++ b/allauth/templates/mfa/authenticate.html
@@ -51,7 +51,7 @@
         {% endelement %}
         {{ js_data|json_script:"js_data" }}
         {% include "mfa/webauthn/snippets/scripts.html" %}
-        <script type="text/javascript">
+        <script>
         allauth.webauthn.forms.authenticateForm({
         ids: {
         authenticate: "mfa_webauthn_authenticate",

--- a/allauth/templates/mfa/webauthn/reauthenticate.html
+++ b/allauth/templates/mfa/webauthn/reauthenticate.html
@@ -18,7 +18,7 @@
     {% endelement %}
     {{ js_data|json_script:"js_data" }}
     {% include "mfa/webauthn/snippets/scripts.html" %}
-    <script type="text/javascript">
+    <script>
         allauth.webauthn.forms.authenticateForm({
         ids: {
         authenticate: "mfa_webauthn_reauthenticate",

--- a/allauth/templates/mfa/webauthn/snippets/login_script.html
+++ b/allauth/templates/mfa/webauthn/snippets/login_script.html
@@ -4,7 +4,7 @@
     {{ redirect_field }}
     <input type="hidden" name="credential" id="mfa_credential">
 </form>
-<script type="text/javascript">
+<script>
     allauth.webauthn.forms.loginForm({
         ids: {
             login: "passkey_login",

--- a/allauth/templates/mfa/webauthn/snippets/scripts.html
+++ b/allauth/templates/mfa/webauthn/snippets/scripts.html
@@ -1,4 +1,4 @@
 {% load i18n static %}
 <noscript>{% translate "This functionality requires JavaScript." %}"</noscript>
-<script type="text/javascript" src="{% static 'mfa/js/webauthn-json.js' %}"></script>
-<script type="text/javascript" src="{% static 'mfa/js/webauthn.js' %}"></script>
+<script src="{% static 'mfa/js/webauthn-json.js' %}"></script>
+<script src="{% static 'mfa/js/webauthn.js' %}"></script>


### PR DESCRIPTION
# Submitting Pull Requests

The “type” attribute is unnecessary for JavaScript resources. The default type for <script> tags is JavaScript, so you don’t need to include the type for JS resources.


## General

 - [X] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [X] All Python code must formatted using Black, and clean from pep8 and isort issues.
 - [X] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [X] If your changes are significant, please update `ChangeLog.rst`.
 - [X] If your change is substantial, feel free to add yourself to `AUTHORS`.
