### PR TITLE
Default webauthn templates require django.contrib.humanize

### DIFF
--- a/docs/mfa/webauthn.rst
+++ b/docs/mfa/webauthn.rst
@@ -14,3 +14,9 @@ WebAuthn support is disabled by default. To enable it, add these settings::
     # regard localhost as a secure origin, which is problematic during
     # local development and testing.
     MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = True
+
+    # Add "humanize" contrib app if using default templates
+    INSTALLED_APPS = [
+        ...
+        "django.contrib.humanize",
+    ]


### PR DESCRIPTION
When using the default MFA templates, the humanize contrib module is required:

https://github.com/pennersr/django-allauth/blob/57154de32994f907718810e72d7063daa09af1af/allauth/templates/mfa/webauthn/authenticator_list.html#L5
