### PR TITLE
Fix: Convert Unix timestamp to milliseconds in Sessions component

### DIFF
--- a/examples/react-spa/frontend/src/usersessions/Sessions.js
+++ b/examples/react-spa/frontend/src/usersessions/Sessions.js
@@ -54,7 +54,7 @@ export default function Sessions () {
           {sessions.map((session, i) => {
             return (
               <tr key={i}>
-                <td>{new Date(session.created_at).toLocaleString()}</td>
+                <td>{new Date(session.created_at * 1000).toLocaleString()}</td>
                 <td>{session.ip}</td>
                 <td>{session.user_agent}</td>
                 {config.data.usersessions.track_activity ? <td>{session.last_seen_at}</td> : null}


### PR DESCRIPTION
# Fix Unix timestamp conversion in Sessions component

## Changes
- Updated the `Sessions.js` file to convert Unix timestamp to milliseconds before creating a Date object.

## Reason
The `created_at` timestamp was being interpreted as milliseconds instead of seconds, resulting in incorrect date display. This fix ensures the correct date is shown for each session.