### PR TITLE
Add feature to delete unverified accounts during signup

### DIFF
--- a/allauth/headless/account/views.py
+++ b/allauth/headless/account/views.py
@@ -105,6 +105,11 @@ class SignupView(APIView):
             return ConflictResponse(request)
         if not get_account_adapter().is_open_for_signup(request):
             return ForbiddenResponse(request)
+        
+        unverified_users = User.objects.filter(email=self.input.cleaned_data["email"], is_verified=False)
+        if settings.DELETE_UNVERIFIED_ACCOUNTS_ON_SIGNUP and unverified_users.exists():
+            unverified_users.delete()
+            
         user, resp = self.input.try_save(request)
         if not resp:
             try:


### PR DESCRIPTION
Implemented a feature that deletes unverified accounts during the signup process if a new setting DELETE_UNVERIFIED_ACCOUNTS_ON_SIGNUP in settings.py is set to True. This helps ensure that users can continue the registration process without conflicts. Updated the SignupView class in views.py to include this logic.