### PR TITLE
feat: Add template block for HTML tag customization

### DIFF
--- a/allauth/templates/allauth/layouts/base.html
+++ b/allauth/templates/allauth/layouts/base.html
@@ -1,6 +1,8 @@
 {% load i18n %}
 <!DOCTYPE html>
-<html>
+{% block html %}
+    <html>
+    {% endblock html %}
     <head>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/tests/apps/test_templates.py
+++ b/tests/apps/test_templates.py
@@ -1,0 +1,111 @@
+from django.template import Context, Template
+from django.template.loader import render_to_string
+from django.test import TestCase
+
+
+class TemplateBlockTests(TestCase):
+    """Test cases for template block functionality, particularly the HTML block."""
+
+    def test_html_block_default(self):
+        """Test that the default HTML block renders <html> without modifications."""
+        # Create a simple template that extends base.html without overriding the html block
+        template_string = """
+        {% extends "allauth/layouts/base.html" %}
+        {% block content %}Test Content{% endblock %}
+        """
+
+        # Render the template
+        template = Template(template_string)
+        rendered = template.render(Context({}))
+
+        # Verify the default <html> tag is present
+        self.assertIn("<html>", rendered)
+        self.assertNotIn("data-theme", rendered)
+
+    def test_html_block_override(self):
+        """Test that the HTML block can be overridden with custom attributes."""
+        # Create a template that overrides the html block
+        template_string = """
+        {% extends "allauth/layouts/base.html" %}
+        {% block html %}<html data-theme="dark" lang="en">{% endblock %}
+        {% block content %}Test Content{% endblock %}
+        """
+
+        # Render the template
+        template = Template(template_string)
+        rendered = template.render(Context({}))
+
+        # Verify custom attributes are present
+        self.assertIn('<html data-theme="dark" lang="en">', rendered)
+        self.assertIn("Test Content", rendered)
+
+    def test_html_block_with_data_theme(self):
+        """Test the specific use case of adding a data-theme attribute."""
+        # Create a template with data-theme attribute
+        template_string = """
+        {% extends "allauth/layouts/base.html" %}
+        {% block html %}<html data-theme="custom-theme">{% endblock %}
+        {% block content %}Themed Content{% endblock %}
+        """
+
+        # Render the template
+        template = Template(template_string)
+        rendered = template.render(Context({}))
+
+        # Verify data-theme attribute is present
+        self.assertIn('data-theme="custom-theme"', rendered)
+        self.assertIn("Themed Content", rendered)
+
+    def test_html_block_multiple_attributes(self):
+        """Test the HTML block with multiple custom attributes."""
+        # Create a template with multiple attributes
+        template_string = """
+        {% extends "allauth/layouts/base.html" %}
+        {% block html %}<html data-theme="light" lang="fr" dir="ltr" class="no-js">{% endblock %}
+        {% block content %}Multi-attribute Content{% endblock %}
+        """
+
+        # Render the template
+        template = Template(template_string)
+        rendered = template.render(Context({}))
+
+        # Verify all attributes are present
+        self.assertIn('data-theme="light"', rendered)
+        self.assertIn('lang="fr"', rendered)
+        self.assertIn('dir="ltr"', rendered)
+        self.assertIn('class="no-js"', rendered)
+        self.assertIn("Multi-attribute Content", rendered)
+
+    def test_html_block_backward_compatibility(self):
+        """Test that templates not using the HTML block continue to work."""
+        # Test a simple template that doesn't override the html block
+        template_string = """
+        {% extends "allauth/layouts/base.html" %}
+        {% block head_title %}Test Title{% endblock %}
+        {% block content %}Legacy Content{% endblock %}
+        """
+
+        # Render the template
+        template = Template(template_string)
+        rendered = template.render(Context({}))
+
+        # Verify basic structure is intact
+        self.assertIn("<html>", rendered)
+        self.assertIn("Test Title", rendered)
+        self.assertIn("Legacy Content", rendered)
+        # Ensure no unexpected attributes were added
+        self.assertNotIn("data-", rendered)
+
+    def test_base_template_renders_correctly(self):
+        """Test that the base template renders correctly with the HTML block."""
+        # Directly render the base template
+        rendered = render_to_string("allauth/layouts/base.html", {})
+
+        # Verify the HTML structure is correct
+        self.assertIn("<!DOCTYPE html>", rendered)
+        self.assertIn("<html>", rendered)
+        self.assertIn("</html>", rendered)
+        self.assertIn("<head>", rendered)
+        self.assertIn("</head>", rendered)
+        self.assertIn("<body>", rendered)
+        self.assertIn("</body>", rendered)


### PR DESCRIPTION
## Summary
This PR adds Django template block support for the `<html>` tag in the base template, allowing users to customize HTML tag attributes while maintaining backward compatibility.

## Motivation
Currently, the `<html>` tag in `allauth/templates/allauth/layouts/base.html` is hardcoded, making it impossible to add custom attributes (such as `data-theme` for theming support) without overriding the entire template.

This idea was inspired by @rilhutch18 who identified this limitation and suggested this improvement.

## Changes
- Wrapped the `<html>` tag with `{% block html %}...{% endblock html %}`
- Default behavior remains unchanged - the block contains `<html>` by default
- Users can now override this block in their templates to add custom attributes
- Template follows djlint formatting standards with proper indentation
- Added comprehensive test coverage in `tests/apps/test_templates.py`

## Example Usage
Users can now customize the HTML tag in their templates:
```django
{% extends "allauth/layouts/base.html" %}

{% block html %}
<html data-theme="dark" lang="en">
{% endblock html %}
```

## Testing
- Added comprehensive test suite in `tests/apps/test_templates.py` with 6 test cases
- Tests cover:
  - Default behavior (backward compatibility)
  - Custom attribute override (data-theme, lang, etc.)
  - Multiple attributes support
  - Template inheritance chain
  - Base template structure integrity
- Tests follow existing patterns using Django's Template class
- All linting checks pass (black, isort, flake8, bandit, djlint)
- Run tests with: `pytest tests/apps/test_templates.py`

## Backward Compatibility
This change is fully backward compatible. Existing implementations will continue to work without any modifications, as the default block content remains `<html>`.

## Credits
Thanks to @rilhutch18 for inspiring this enhancement!